### PR TITLE
fix(glob): exclude node_modules from recursive bind lookups

### DIFF
--- a/.agent/repo=.this/role=any/briefs/rule.forbid.unbounded-recursive-globs.md
+++ b/.agent/repo=.this/role=any/briefs/rule.forbid.unbounded-recursive-globs.md
@@ -1,0 +1,62 @@
+# rule.forbid.unbounded-recursive-globs
+
+## .what
+
+recursive globs (`**`) must always exclude `node_modules` (and other heavy directories)
+
+## .why
+
+a recursive glob with `cwd: process.cwd()` and no `ignore` traverses the entire file tree - this includes `node_modules`. on a typical npm project:
+
+- 50,000+ files in node_modules
+- 10,000+ directories
+- memory consumption scales with file count
+- causes OOM on large dependency trees
+
+### the OOM chain
+
+```
+route.bind.set
+  → enumFilesFromGlob({ glob: '**/.route/.bind.*.flag', cwd: process.cwd() })
+  → fast-glob traverses node_modules
+  → 50k+ stat calls
+  → memory exhaustion
+```
+
+## .pattern
+
+```ts
+// 👎 bad - scans all of node_modules
+const files = await enumFilesFromGlob({
+  glob: '**/.route/.bind.*.flag',
+  cwd: process.cwd(),
+  dot: true,
+});
+
+// 👍 good - excludes node_modules
+const files = await enumFilesFromGlob({
+  glob: '**/.route/.bind.*.flag',
+  cwd: process.cwd(),
+  dot: true,
+  ignore: ['**/node_modules/**'],
+});
+```
+
+## .when
+
+always add `ignore: ['**/node_modules/**']` when:
+- `**` recursive glob is used
+- `cwd` is `process.cwd()` or repo root
+- glob searches for config/flag files
+
+## .exception
+
+explicit scoped globs are fine:
+```ts
+// ok - cwd is already a specific directory
+await enumFilesFromGlob({ glob: '*.md', cwd: input.route });
+```
+
+## .enforcement
+
+unbounded `**` glob without ignore = **BLOCKER**

--- a/.meter/git.commit.uses.jsonc
+++ b/.meter/git.commit.uses.jsonc
@@ -1,4 +1,0 @@
-{
-  "uses": 3,
-  "push": "allow"
-}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "main": "dist/index.js",
   "exports": {
     ".": "./dist/index.js",
+    "./registry": "./dist/contract/registry/index.js",
     "./cli": "./dist/contract/cli/index.js",
     "./cli/route": "./dist/contract/cli/route.js",
     "./cli/review": "./dist/contract/cli/review.js",
@@ -113,7 +114,7 @@
     "rhachet-brains-anthropic": "0.3.3",
     "rhachet-brains-openai": "0.2.1",
     "rhachet-brains-xai": "0.2.1",
-    "rhachet-roles-bhrain": "0.12.3",
+    "rhachet-roles-bhrain": "0.12.4",
     "rhachet-roles-bhuild": "0.10.0",
     "rhachet-roles-ehmpathy": "1.26.3",
     "test-fns": "1.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,8 +139,8 @@ importers:
         specifier: 0.2.1
         version: 0.2.1(@types/node@22.15.21)(rhachet@1.35.3(zod@4.3.4))
       rhachet-roles-bhrain:
-        specifier: 0.12.3
-        version: 0.12.3(@types/node@22.15.21)
+        specifier: 0.12.4
+        version: 0.12.4(@types/node@22.15.21)
       rhachet-roles-bhuild:
         specifier: 0.10.0
         version: 0.10.0
@@ -4101,8 +4101,8 @@ packages:
     peerDependencies:
       rhachet: '>=1.21.4'
 
-  rhachet-roles-bhrain@0.12.3:
-    resolution: {integrity: sha512-8i3Gi3LJpYEh6cTRhNFOQW/71mOuazeNZvXIQLFJn//eIrUdVbvJGMRvCaW8AcUNbrlSezll3750mXGSXMIc7Q==}
+  rhachet-roles-bhrain@0.12.4:
+    resolution: {integrity: sha512-BAcvCABAqxDUnhmVwcrQzKZ1yDB4xsibGGogxWP5bmHRMBuSlsxSu1m7VQEY21sBZtRL+cKcSkQ7pbDulQ5CrQ==}
     engines: {node: '>=8.0.0'}
 
   rhachet-roles-bhrain@0.7.5:
@@ -9433,7 +9433,7 @@ snapshots:
       - aws-crt
       - ws
 
-  rhachet-roles-bhrain@0.12.3(@types/node@22.15.21):
+  rhachet-roles-bhrain@0.12.4(@types/node@22.15.21):
     dependencies:
       '@anthropic-ai/sdk': 0.51.0
       '@ehmpathy/as-command': 1.0.3

--- a/src/contract/registry/index.ts
+++ b/src/contract/registry/index.ts
@@ -1,0 +1,13 @@
+/**
+ * .what = isolated registry export
+ * .why = enables rhachet to load getRoleRegistry without heavy brain deps
+ *
+ * rhachet loads role registries to discover skills. if the main package
+ * export eagerly imports brain infrastructure, simple skill lookups OOM.
+ *
+ * this subpath exports only the registry - no stepReview, no stepReflect,
+ * no brain deps.
+ */
+
+export { getInvokeHooks } from '@src/domain.operations/hooks/getInvokeHooks';
+export { getRoleRegistry } from '@src/domain.roles/getRoleRegistry';

--- a/src/domain.operations/route/bind/delRouteBind.ts
+++ b/src/domain.operations/route/bind/delRouteBind.ts
@@ -19,6 +19,7 @@ export const delRouteBind = async (): Promise<{ deleted: boolean }> => {
     glob: flagGlob,
     cwd: process.cwd(),
     dot: true,
+    ignore: ['**/node_modules/**'],
   });
 
   // not found → idempotent success

--- a/src/domain.operations/route/bind/getRouteBindByBranch.ts
+++ b/src/domain.operations/route/bind/getRouteBindByBranch.ts
@@ -26,6 +26,7 @@ export const getRouteBindByBranch = async (input: {
     glob: flagGlob,
     cwd: process.cwd(),
     dot: true,
+    ignore: ['**/node_modules/**'],
   });
 
   // no flags found → not bound

--- a/src/domain.operations/route/bind/setRouteBind.ts
+++ b/src/domain.operations/route/bind/setRouteBind.ts
@@ -45,6 +45,7 @@ export const setRouteBind = async (input: {
     glob: flagGlob,
     cwd: process.cwd(),
     dot: true,
+    ignore: ['**/node_modules/**'],
   });
 
   // if found, check if same route or different


### PR DESCRIPTION
fix(glob): exclude node_modules from recursive bind lookups

- add ignore to getRouteBindByBranch, setRouteBind, delRouteBind
- add brief: rule.forbid.unbounded-recursive-globs

prevents OOM when glob traverses large node_modules trees

Co-authored-by: Ulad Kasach <uladkasach@gmail.com>

---
🐢 opened by seaturtle[bot]