### PR TITLE
feat(sdk): expose route operations via /sdk/route subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": "./dist/index.js",
     "./registry": "./dist/contract/registry/index.js",
+    "./sdk/route": "./dist/contract/sdk/route.js",
     "./cli": "./dist/contract/cli/index.js",
     "./cli/route": "./dist/contract/cli/route.js",
     "./cli/review": "./dist/contract/cli/review.js",

--- a/src/contract/sdk/route.ts
+++ b/src/contract/sdk/route.ts
@@ -1,0 +1,23 @@
+/**
+ * .what = sdk exports for route operations
+ * .why = enables other role repos to compose route ops programmatically
+ */
+
+// types for context injection
+export type { ContextCliEmit } from '@src/domain.objects/Driver/ContextCliEmit';
+export type { GuardProgressEvent } from '@src/domain.objects/Driver/GuardProgressEvent';
+export type { RouteStone } from '@src/domain.objects/Driver/RouteStone';
+export { delRouteBind } from '@src/domain.operations/route/bind/delRouteBind';
+export { getRouteBind } from '@src/domain.operations/route/bind/getRouteBind';
+export { getRouteBindByBranch } from '@src/domain.operations/route/bind/getRouteBindByBranch';
+// bind operations
+export { setRouteBind } from '@src/domain.operations/route/bind/setRouteBind';
+// step operations
+export { stepRouteDrive } from '@src/domain.operations/route/stepRouteDrive';
+export { stepRouteStoneDel } from '@src/domain.operations/route/stepRouteStoneDel';
+export { stepRouteStoneGet } from '@src/domain.operations/route/stepRouteStoneGet';
+export { stepRouteStoneSet } from '@src/domain.operations/route/stepRouteStoneSet';
+// stone operations
+export { getAllStones } from '@src/domain.operations/route/stones/getAllStones';
+export { setStoneAsApproved } from '@src/domain.operations/route/stones/setStoneAsApproved';
+export { setStoneAsPassed } from '@src/domain.operations/route/stones/setStoneAsPassed';


### PR DESCRIPTION
feat(sdk): expose route operations via /sdk/route subpath

- add bind operations: setRouteBind, getRouteBind, getRouteBindByBranch, delRouteBind
- add step operations: stepRouteDrive, stepRouteStoneGet, stepRouteStoneSet, stepRouteStoneDel
- add stone operations: getAllStones, setStoneAsPassed, setStoneAsApproved
- export types: ContextCliEmit, GuardProgressEvent, RouteStone
- enables other role repos to compose route ops programmatically

Co-authored-by: Ulad Kasach <uladkasach@gmail.com>

---
🐢 opened by seaturtle[bot]