### PR TITLE
fix(driver): resolve rhx from local node_modules instead of npx cache

### DIFF
--- a/blackbox/.test/assets/route-escape-hatch/1.design.guard
+++ b/blackbox/.test/assets/route-escape-hatch/1.design.guard
@@ -5,4 +5,4 @@ reviews:
   - bash $route/.test/perma-fail-review.sh
 
 judges:
-  - npx rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0
+  - rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0

--- a/blackbox/.test/assets/route-guard-cwd/1.vision.guard
+++ b/blackbox/.test/assets/route-guard-cwd/1.vision.guard
@@ -5,4 +5,4 @@ reviews:
   - bash -c 'if [ -f "$route/1.vision.md" ]; then echo "blockers: 0"; echo "artifact present at $route"; else echo "blockers: 1"; echo "artifact absent at $route"; fi'
 
 judges:
-  - npx rhx route.stone.judge --mechanism approved? --stone $stone --route $route
+  - rhx route.stone.judge --mechanism approved? --stone $stone --route $route

--- a/blackbox/.test/assets/route-journey/1.vision.guard
+++ b/blackbox/.test/assets/route-journey/1.vision.guard
@@ -4,4 +4,4 @@ artifacts:
 reviews: []
 
 judges:
-  - npx rhx route.stone.judge --mechanism approved? --stone $stone --route $route
+  - rhx route.stone.judge --mechanism approved? --stone $stone --route $route

--- a/blackbox/.test/assets/route-journey/3.blueprint.guard
+++ b/blackbox/.test/assets/route-journey/3.blueprint.guard
@@ -12,5 +12,5 @@ reviews:
     - bash $route/.test/mock-review.sh
 
 judges:
-  - npx rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 2
-  - npx rhx route.stone.judge --mechanism approved? --stone $stone --route $route
+  - rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 2
+  - rhx route.stone.judge --mechanism approved? --stone $stone --route $route

--- a/blackbox/.test/assets/route-journey/5.execute.guard
+++ b/blackbox/.test/assets/route-journey/5.execute.guard
@@ -5,4 +5,4 @@ reviews:
   - bash $route/.test/mock-review.sh
 
 judges:
-  - npx rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
+  - rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1

--- a/blackbox/.test/assets/route-review-blocks/1.plan.guard
+++ b/blackbox/.test/assets/route-review-blocks/1.plan.guard
@@ -5,5 +5,5 @@ reviews:
   - bash $route/.test/mock-review.sh
 
 judges:
-  - npx rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0
-  - npx rhx route.stone.judge --mechanism approved? --stone $stone --route $route
+  - rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0
+  - rhx route.stone.judge --mechanism approved? --stone $stone --route $route

--- a/blackbox/__snapshots__/driver.route.escape-hatch.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.escape-hatch.acceptance.test.ts.snap
@@ -16,7 +16,7 @@ exports[`driver.route.escape-hatch.acceptance given: [escape-hatch] stone with p
       │       ├─ review: .route/1.design.guard.review.i1.9a1abf10a35fb1f3aebd56a1685a92c738b5f171df478c06b2985c2ed0f0be31.r1.md
       │       └─ 1 blocker 🔴
       └─ judges
-          └─ j1: npx rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0
+          └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0
               ├─ finished [TIME] ✗
               ├─ judge: .route/1.design.guard.judge.i1p1.9a1abf10a35fb1f3aebd56a1685a92c738b5f171df478c06b2985c2ed0f0be31.8639492cd5da2b98ce0d9613cc721cb00dcbdfaa1529db66634571459ef17e37.j1.md
               └─ reason: nitpicks exceed threshold (1 > 0)

--- a/blackbox/__snapshots__/driver.route.guard-cwd.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.guard-cwd.acceptance.test.ts.snap
@@ -15,7 +15,7 @@ exports[`driver.route.guard-cwd.acceptance given: [case1] guard with $route in j
       │       ├─ finished [TIME] ✓
       │       └─ review: .route/1.vision.guard.review.i1.b8e920970d841849e881399c4e5aa3f3a65139d95e252dfe2d9da99b9d1a487c.r1.md
       └─ judges
-          └─ j1: npx rhx route.stone.judge --mechanism approved? --stone $stone --route $route
+          └─ j1: rhx route.stone.judge --mechanism approved? --stone $stone --route $route
               ├─ finished [TIME] ✗
               ├─ judge: .route/1.vision.guard.judge.i1p1.b8e920970d841849e881399c4e5aa3f3a65139d95e252dfe2d9da99b9d1a487c.d9cf933e977d13a739b011b4636454c33679c0c20b27c7cab0fdd0b953a7f118.j1.md
               └─ reason: wait for human approval
@@ -35,7 +35,7 @@ exports[`driver.route.guard-cwd.acceptance given: [case1] guard with $route in j
       │   └─ r1: bash -c 'if [ -f "$route/1.vision.md" ]; then echo "blockers: 0"; echo "artifact present at $route"; else echo "blockers: 1"; echo "artifact absent at $route"; fi'
       │       └─ · cached
       └─ judges
-          └─ j1: npx rhx route.stone.judge --mechanism approved? --stone $stone --route $route
+          └─ j1: rhx route.stone.judge --mechanism approved? --stone $stone --route $route
               ├─ finished [TIME] ✓
               └─ judge: .route/1.vision.guard.judge.i2p1.b8e920970d841849e881399c4e5aa3f3a65139d95e252dfe2d9da99b9d1a487c.25217f380d8a30101c1f247abab9bcefc427ba1253ddc4bf79d3fee6d730250c.j1.md
 "
@@ -56,7 +56,7 @@ exports[`driver.route.guard-cwd.acceptance given: [case2] guard with $route work
       │       ├─ finished [TIME] ✓
       │       └─ review: .route/1.vision.guard.review.i1.3db2db995e943d5489545acc1deb4e5e7fa92632ebf3a76ccb5a04c7493bbd63.r1.md
       └─ judges
-          └─ j1: npx rhx route.stone.judge --mechanism approved? --stone $stone --route $route
+          └─ j1: rhx route.stone.judge --mechanism approved? --stone $stone --route $route
               ├─ finished [TIME] ✗
               ├─ judge: .route/1.vision.guard.judge.i1p1.3db2db995e943d5489545acc1deb4e5e7fa92632ebf3a76ccb5a04c7493bbd63.c8593a0926e33e6c69809f063f164e743f781aa8438fd37d4d60a3205f1892da.j1.md
               └─ reason: wait for human approval
@@ -76,7 +76,7 @@ exports[`driver.route.guard-cwd.acceptance given: [case2] guard with $route work
       │   └─ r1: bash -c 'if [ -f "$route/1.vision.md" ]; then echo "blockers: 0"; echo "artifact present at $route"; else echo "blockers: 1"; echo "artifact absent at $route"; fi'
       │       └─ · cached
       └─ judges
-          └─ j1: npx rhx route.stone.judge --mechanism approved? --stone $stone --route $route
+          └─ j1: rhx route.stone.judge --mechanism approved? --stone $stone --route $route
               ├─ finished [TIME] ✓
               └─ judge: .route/1.vision.guard.judge.i2p1.3db2db995e943d5489545acc1deb4e5e7fa92632ebf3a76ccb5a04c7493bbd63.a5499447b8e1f50ddfb0d2fe719ea85b0a022f5fa411b1b0762b93f20c7f8d1c.j1.md
 "

--- a/blackbox/__snapshots__/driver.route.journey.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.journey.acceptance.test.ts.snap
@@ -20,7 +20,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
       ├─ artifacts
       │   └─ 1.vision.md
       └─ judges
-          └─ j1: npx rhx route.stone.judge --mechanism approved? --stone $stone --route $route
+          └─ j1: rhx route.stone.judge --mechanism approved? --stone $stone --route $route
               ├─ finished [TIME] ✗
               ├─ judge: .route/1.vision.guard.judge.i1p1.89a3b47031ddeb8c23151d71f85717bdb3adfed2e3c6224d3fe7c6d059cbf474.79af67282f021ee213087dfc0cd59b76b6fc4f2fa230045b79504ff592f988f9.j1.md
               └─ reason: wait for human approval
@@ -46,7 +46,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
       ├─ artifacts
       │   └─ 1.vision.md
       └─ judges
-          └─ j1: npx rhx route.stone.judge --mechanism approved? --stone $stone --route $route
+          └─ j1: rhx route.stone.judge --mechanism approved? --stone $stone --route $route
               ├─ finished [TIME] ✓
               └─ judge: .route/1.vision.guard.judge.i1p1.89a3b47031ddeb8c23151d71f85717bdb3adfed2e3c6224d3fe7c6d059cbf474.9344949395a1fec3b64b9504524cb70f309a6460bf804270ccc38491a2863eba.j1.md
 "
@@ -133,9 +133,9 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
       │   └─ r1: bash $route/.test/mock-review.sh
       │       └─ · cached
       └─ judges
-          ├─ j1: npx rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 2
+          ├─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 2
           │   └─ · cached
-          └─ j2: npx rhx route.stone.judge --mechanism approved? --stone $stone --route $route
+          └─ j2: rhx route.stone.judge --mechanism approved? --stone $stone --route $route
               ├─ finished [TIME] ✗
               ├─ judge: .route/3.blueprint.guard.judge.i2p2.fd29f621e589e44175adf2201fa80bf72797235b994355101b4f50e08e4ebe44.70d50298a823e186ed1641bc32518956a7362338a59b85ded9b26acfe38f816c.j2.md
               └─ reason: wait for human approval
@@ -158,10 +158,10 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
       │       ├─ review: .route/3.blueprint.guard.review.i1.fd29f621e589e44175adf2201fa80bf72797235b994355101b4f50e08e4ebe44.r1.md
       │       └─ 1 blocker 🔴
       └─ judges
-          ├─ j1: npx rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 2
+          ├─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 2
           │   ├─ finished [TIME] ✓
           │   └─ judge: .route/3.blueprint.guard.judge.i1p1.fd29f621e589e44175adf2201fa80bf72797235b994355101b4f50e08e4ebe44.70d50298a823e186ed1641bc32518956a7362338a59b85ded9b26acfe38f816c.j1.md
-          └─ j2: npx rhx route.stone.judge --mechanism approved? --stone $stone --route $route
+          └─ j2: rhx route.stone.judge --mechanism approved? --stone $stone --route $route
               ├─ finished [TIME] ✗
               ├─ judge: .route/3.blueprint.guard.judge.i1p1.fd29f621e589e44175adf2201fa80bf72797235b994355101b4f50e08e4ebe44.70d50298a823e186ed1641bc32518956a7362338a59b85ded9b26acfe38f816c.j2.md
               └─ reason: wait for human approval
@@ -181,10 +181,10 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
       │   └─ r1: bash $route/.test/mock-review.sh
       │       └─ · cached
       └─ judges
-          ├─ j1: npx rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 2
+          ├─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 2
           │   ├─ finished [TIME] ✓
           │   └─ judge: .route/3.blueprint.guard.judge.i2p1.fd29f621e589e44175adf2201fa80bf72797235b994355101b4f50e08e4ebe44.100ff96e8539bfa8572353fd104e8abb3dfc186c10f0e02d6acd5189f1b53b5b.j1.md
-          └─ j2: npx rhx route.stone.judge --mechanism approved? --stone $stone --route $route
+          └─ j2: rhx route.stone.judge --mechanism approved? --stone $stone --route $route
               ├─ finished [TIME] ✓
               └─ judge: .route/3.blueprint.guard.judge.i2p1.fd29f621e589e44175adf2201fa80bf72797235b994355101b4f50e08e4ebe44.100ff96e8539bfa8572353fd104e8abb3dfc186c10f0e02d6acd5189f1b53b5b.j2.md
 "
@@ -213,7 +213,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
       │       ├─ finished [TIME] ✓
       │       └─ review: .route/5.execute.guard.review.i1.e5c031c5923de2dd7ebc77d84ac1c222cfdb9d3143fa8c0bc27ed9d821ce74e3.r1.md
       └─ judges
-          └─ j1: npx rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
+          └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✓
               └─ judge: .route/5.execute.guard.judge.i1p1.e5c031c5923de2dd7ebc77d84ac1c222cfdb9d3143fa8c0bc27ed9d821ce74e3.a98dc386edcd8c99a3d132b7fc4a6366285cfa5e55717c43387c45b76d6c0800.j1.md
 "

--- a/blackbox/__snapshots__/driver.route.review-blocks-approval.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.review-blocks-approval.acceptance.test.ts.snap
@@ -25,11 +25,11 @@ exports[`driver.route.review-blocks-approval.acceptance given: [review-blocks] s
       │       ├─ review: .route/1.plan.guard.review.i1.0492a9fb2b499c70f4acde2cab892c6f7a39b07b00e33bbd020d47b3ede47ef0.r1.md
       │       └─ 1 blocker 🔴
       └─ judges
-          ├─ j1: npx rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0
+          ├─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0
           │   ├─ finished [TIME] ✗
           │   ├─ judge: .route/1.plan.guard.judge.i1p1.0492a9fb2b499c70f4acde2cab892c6f7a39b07b00e33bbd020d47b3ede47ef0.291f1ecb1ec16b18f789d67885fe0b855e1614ec87a50e30cb4790e28d725d4e.j1.md
           │   └─ reason: nitpicks exceed threshold (1 > 0)
-          └─ j2: npx rhx route.stone.judge --mechanism approved? --stone $stone --route $route
+          └─ j2: rhx route.stone.judge --mechanism approved? --stone $stone --route $route
               ├─ finished [TIME] ✓
               └─ judge: .route/1.plan.guard.judge.i1p1.0492a9fb2b499c70f4acde2cab892c6f7a39b07b00e33bbd020d47b3ede47ef0.291f1ecb1ec16b18f789d67885fe0b855e1614ec87a50e30cb4790e28d725d4e.j2.md
 "
@@ -49,10 +49,10 @@ exports[`driver.route.review-blocks-approval.acceptance given: [review-blocks] s
       │       ├─ finished [TIME] ✓
       │       └─ review: .route/1.plan.guard.review.i1.d8ed0868a677f608e0a3c48cc7a8c7061dcdb60a0b154c7644d723ab94c25089.r1.md
       └─ judges
-          ├─ j1: npx rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0
+          ├─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0
           │   ├─ finished [TIME] ✓
           │   └─ judge: .route/1.plan.guard.judge.i1p1.d8ed0868a677f608e0a3c48cc7a8c7061dcdb60a0b154c7644d723ab94c25089.41dcbd1c450f782b0523c18cbfaeb54d3624ad287123a4a0321e84fd800ac759.j1.md
-          └─ j2: npx rhx route.stone.judge --mechanism approved? --stone $stone --route $route
+          └─ j2: rhx route.stone.judge --mechanism approved? --stone $stone --route $route
               ├─ finished [TIME] ✓
               └─ judge: .route/1.plan.guard.judge.i1p1.d8ed0868a677f608e0a3c48cc7a8c7061dcdb60a0b154c7644d723ab94c25089.41dcbd1c450f782b0523c18cbfaeb54d3624ad287123a4a0321e84fd800ac759.j2.md
 "

--- a/src/domain.operations/route/judges/runStoneGuardJudges.ts
+++ b/src/domain.operations/route/judges/runStoneGuardJudges.ts
@@ -1,6 +1,7 @@
 import { exec } from 'child_process';
 import * as fs from 'fs/promises';
 import * as path from 'path';
+import { getGitRepoRoot } from 'rhachet-artifact-git';
 import { promisify } from 'util';
 
 import type { ContextCliEmit } from '@src/domain.objects/Driver/ContextCliEmit';
@@ -47,12 +48,20 @@ export const runOneStoneGuardJudge = async (input: {
     output: outputPath,
   });
 
-  // execute command
+  // execute command with node_modules/.bin in PATH
+  // .why = enables guards to use `rhx` or `rhachet` directly without npx
+  const repoRoot = await getGitRepoRoot({ from: input.route });
+  const nodeModulesBin = path.join(repoRoot, 'node_modules', '.bin');
+  const execEnv = {
+    ...process.env,
+    PATH: `${nodeModulesBin}${path.delimiter}${process.env.PATH ?? ''}`,
+  };
+
   let stdout = '';
   let stderr = '';
   let exitCode = 0;
   try {
-    const result = await execAsync(cmd);
+    const result = await execAsync(cmd, { env: execEnv });
     stdout = result.stdout;
     stderr = result.stderr;
   } catch (error: unknown) {

--- a/src/domain.operations/route/judges/runStoneGuardJudges.ts
+++ b/src/domain.operations/route/judges/runStoneGuardJudges.ts
@@ -50,12 +50,12 @@ export const runOneStoneGuardJudge = async (input: {
 
   // execute command with node_modules/.bin in PATH
   // .why = enables guards to use `rhx` or `rhachet` directly without npx
-  // .note = falls back to route dir when not in a git repo (e.g., integration tests)
+  // .note = falls back to cwd when not in a git repo (e.g., integration tests)
   let repoRoot: string;
   try {
     repoRoot = await getGitRepoRoot({ from: input.route });
   } catch {
-    repoRoot = input.route;
+    repoRoot = process.cwd();
   }
   const nodeModulesBin = path.join(repoRoot, 'node_modules', '.bin');
   const execEnv = {

--- a/src/domain.operations/route/judges/runStoneGuardJudges.ts
+++ b/src/domain.operations/route/judges/runStoneGuardJudges.ts
@@ -50,7 +50,13 @@ export const runOneStoneGuardJudge = async (input: {
 
   // execute command with node_modules/.bin in PATH
   // .why = enables guards to use `rhx` or `rhachet` directly without npx
-  const repoRoot = await getGitRepoRoot({ from: input.route });
+  // .note = falls back to route dir when not in a git repo (e.g., integration tests)
+  let repoRoot: string;
+  try {
+    repoRoot = await getGitRepoRoot({ from: input.route });
+  } catch {
+    repoRoot = input.route;
+  }
   const nodeModulesBin = path.join(repoRoot, 'node_modules', '.bin');
   const execEnv = {
     ...process.env,


### PR DESCRIPTION
- add node_modules/.bin to PATH when executing judge commands
- use getGitRepoRoot to find repo root from route path
- update guard fixtures to use rhx instead of npx rhx
- eliminates stale npx cache failures

Co-authored-by: Ulad Kasach <uladkasach@gmail.com>
