### PR TITLE
fix(driver): show informative judge errors and prevent false cache

### DIFF
--- a/blackbox/.test/assets/route-judge-failure/.test/mock-judge-fail.sh
+++ b/blackbox/.test/assets/route-judge-failure/.test/mock-judge-fail.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+######################################################################
+# .what = mock judge that fails without proper passed: false output
+# .why = tests that failed judges show clear errors and don't cache
+######################################################################
+set -euo pipefail
+
+# simulates a judge command that crashes/fails without
+# proper passed: true/false metadata
+
+echo "error: evaluation crashed unexpectedly"
+exit 1

--- a/blackbox/.test/assets/route-judge-failure/0.wish.md
+++ b/blackbox/.test/assets/route-judge-failure/0.wish.md
@@ -1,0 +1,3 @@
+# wish: test judge failure
+
+test that failed judges show informative errors and don't cache incorrectly.

--- a/blackbox/.test/assets/route-judge-failure/1.stone
+++ b/blackbox/.test/assets/route-judge-failure/1.stone
@@ -1,0 +1,6 @@
+# stone: implement feature
+
+implement the feature.
+
+done when:
+- feature works

--- a/blackbox/.test/assets/route-judge-failure/1.stone.guard
+++ b/blackbox/.test/assets/route-judge-failure/1.stone.guard
@@ -1,0 +1,5 @@
+artifacts:
+  - 1.stone*.md
+
+judges:
+  - .test/mock-judge-fail.sh --stone $stone --route $route

--- a/blackbox/.test/assets/route-judge-failure/package.json
+++ b/blackbox/.test/assets/route-judge-failure/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "route-judge-failure-fixture",
+  "private": true,
+  "description": "fixture for judge failure acceptance tests - enables rhachet role discovery",
+  "dependencies": {
+    "rhachet-roles-bhrain": "link:."
+  }
+}

--- a/blackbox/__snapshots__/driver.route.judge-failure.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.judge-failure.acceptance.test.ts.snap
@@ -1,0 +1,37 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`driver.route.judge-failure.acceptance given: [case1] judge command fails without proper passed: metadata when: [t0] route.stone.set --as passed is invoked then: stdout matches snapshot 1`] = `
+"🦉 so you're saying there's a chance?
+
+🗿 route.stone.set
+   ├─ stone = 1
+   ├─ passage = blocked
+   ├─ reason = command exited 1; see judge artifact for details
+   └─ guard
+      ├─ artifacts
+      │   └─ 1.stone.i1.md
+      └─ judges
+          └─ j1: .test/mock-judge-fail.sh --stone $stone --route $route
+              ├─ finished [TIME] ✗
+              ├─ judge: .route/1.guard.judge.i1p1.156a9f0f09dfcfcc9e057eb0e87a9d7640f81e1ced57d02adb60acdfc35b30ff.b45efdffcf2572bd861f4ffb64b735ddf7f468ebc39a089deb373ba2f5092af8.j1.md
+              └─ reason: command exited 1; see judge artifact for details
+"
+`;
+
+exports[`driver.route.judge-failure.acceptance given: [case1] judge command fails without proper passed: metadata when: [t1] route.stone.set --as passed is invoked again then: stdout matches snapshot 1`] = `
+"🦉 so you're saying there's a chance?
+
+🗿 route.stone.set
+   ├─ stone = 1
+   ├─ passage = blocked
+   ├─ reason = command exited 1; see judge artifact for details
+   └─ guard
+      ├─ artifacts
+      │   └─ 1.stone.i1.md
+      └─ judges
+          └─ j1: .test/mock-judge-fail.sh --stone $stone --route $route
+              ├─ finished [TIME] ✗
+              ├─ judge: .route/1.guard.judge.i1p2.156a9f0f09dfcfcc9e057eb0e87a9d7640f81e1ced57d02adb60acdfc35b30ff.b45efdffcf2572bd861f4ffb64b735ddf7f468ebc39a089deb373ba2f5092af8.j1.md
+              └─ reason: command exited 1; see judge artifact for details
+"
+`;

--- a/blackbox/driver.route.judge-failure.acceptance.test.ts
+++ b/blackbox/driver.route.judge-failure.acceptance.test.ts
@@ -1,0 +1,99 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { given, then, useThen, when, useBeforeAll } from 'test-fns';
+
+import {
+  execAsync,
+  genTempDirForRhachet,
+  invokeRouteSkill,
+  sanitizeTimeForSnapshot,
+} from './.test/invokeRouteSkill';
+
+const ASSETS_DIR = path.join(__dirname, '.test/assets/route-judge-failure');
+
+/**
+ * .what = acceptance tests for judge failure error messages and cache behavior
+ * .why = verifies failed judges show informative errors and don't cache as passed
+ */
+describe('driver.route.judge-failure.acceptance', () => {
+  given('[case1] judge command fails without proper passed: metadata', () => {
+    const scene = useBeforeAll(async () => {
+      const tempDir = genTempDirForRhachet({
+        slug: 'judge-fail-case1',
+        clone: ASSETS_DIR,
+      });
+
+      // link the driver role
+      await execAsync('npx rhachet roles link --role driver', { cwd: tempDir });
+
+      // create feature branch
+      await execAsync('git checkout -b vlad/test-judge-fail-case1', {
+        cwd: tempDir,
+      });
+
+      // bind the route
+      await invokeRouteSkill({
+        skill: 'route.bind.set',
+        args: { route: '.' },
+        cwd: tempDir,
+      });
+
+      // create artifact
+      await fs.writeFile(
+        path.join(tempDir, '1.stone.i1.md'),
+        '# Implementation\n\nFeature done.',
+      );
+
+      return { tempDir };
+    });
+
+    when('[t0] route.stone.set --as passed is invoked', () => {
+      const result = useThen('judge fails', async () =>
+        invokeRouteSkill({
+          skill: 'route.stone.set',
+          args: { stone: '1', as: 'passed' },
+          cwd: scene.tempDir,
+        }),
+      );
+
+      then('exit code is 2 (failure)', () => {
+        expect(result.code).toEqual(2);
+      });
+
+      then('stdout shows informative error (not "no reason captured")', () => {
+        expect(result.stdout).not.toContain('no reason captured');
+        // should show the actual error or exit code info
+        expect(result.stdout).toMatch(/reason:|command exited|stderr:/);
+      });
+
+      then('stdout matches snapshot', () => {
+        expect(sanitizeTimeForSnapshot(result.stdout)).toMatchSnapshot();
+      });
+    });
+
+    when('[t1] route.stone.set --as passed is invoked again', () => {
+      const result = useThen('judge still fails (not cached as passed)', async () =>
+        invokeRouteSkill({
+          skill: 'route.stone.set',
+          args: { stone: '1', as: 'passed' },
+          cwd: scene.tempDir,
+        }),
+      );
+
+      then('exit code is 2 (failure)', () => {
+        expect(result.code).toEqual(2);
+      });
+
+      then('judge is NOT cached as passed (should re-run or show failed)', () => {
+        // if it were wrongly cached as passed, it would exit 0
+        // the judge should either re-run and fail, or show cached failure
+        expect(result.stdout).toContain('judge');
+        expect(result.stdout).toContain('blocked');
+      });
+
+      then('stdout matches snapshot', () => {
+        expect(sanitizeTimeForSnapshot(result.stdout)).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/src/domain.operations/route/guard/genContextCliEmit.ts
+++ b/src/domain.operations/route/guard/genContextCliEmit.ts
@@ -105,6 +105,7 @@ export const genContextCliEmit = (input: {
           const reason =
             event.outcome.judge.reason ?? 'no reason captured (command failed)';
           detail(`    reason: ${reason}`);
+          detail(''); // blank line after failure for visual separation
         }
       }
     }

--- a/src/domain.operations/route/judges/runStoneGuardJudges.ts
+++ b/src/domain.operations/route/judges/runStoneGuardJudges.ts
@@ -102,7 +102,7 @@ export const runOneStoneGuardJudge = async (input: {
 
   // parse passed and reason from content
   const passed = parsePassed(content, exitCode);
-  const reason = parseReason(content);
+  const reason = parseReason(content, exitCode);
 
   return new RouteStoneGuardJudgeArtifact({
     stone: { path: input.stone.path },
@@ -164,8 +164,8 @@ export const runStoneGuardJudges = async (
   let maxPriorJudgeIteration = 0;
   for (const filePath of priorJudgeFiles) {
     const content = await fs.readFile(filePath, 'utf-8');
-    const passed = parsePassed(content, 0);
-    const reason = parseReason(content);
+    const passed = parsePassed(content, null);
+    const reason = parseReason(content, null);
 
     // parse index from filename: $stone.guard.judge.i$rp$j.$reviewHash.$judgeHash.j$index.md
     const indexMatch = filePath.match(/\.j(\d+)\.md$/);
@@ -282,16 +282,32 @@ const substituteVars = (
 /**
  * .what = parses passed status from content and exit code
  * .why = determines judge verdict from output
+ *
+ * critical: when exitCode is null (read from file), we only trust
+ * explicit passed: true. any ambiguity defaults to failed to prevent
+ * false cache of failures as passes.
  */
-const parsePassed = (content: string, exitCode: number): boolean => {
+const parsePassed = (content: string, exitCode: number | null): boolean => {
   // first check explicit passed: true/false in content
   const passedMatch = content.match(/passed:\s*(true|false)/i);
   if (passedMatch?.[1]) {
     return passedMatch[1].toLowerCase() === 'true';
   }
 
-  // fallback to exit code
-  return exitCode === 0;
+  // check for failure indicators in content
+  // if file shows error output, treat as failed
+  if (content.includes('command failed') || content.includes('exit code')) {
+    return false;
+  }
+
+  // if we have exitCode from live execution, use it
+  if (exitCode !== null) {
+    return exitCode === 0;
+  }
+
+  // when read from file without exitCode context, default to failed
+  // this prevents false cache of failures as passes
+  return false;
 };
 
 /**
@@ -301,7 +317,10 @@ const parsePassed = (content: string, exitCode: number): boolean => {
  * failfast: returns first line of stderr if no explicit reason found
  * this ensures errors like "command not found" are visible
  */
-const parseReason = (content: string): string | null => {
+const parseReason = (
+  content: string,
+  exitCode: number | null,
+): string | null => {
   // check for explicit reason: line first
   const reasonMatch = content.match(/reason:\s*(.+)/i);
   if (reasonMatch?.[1]) {
@@ -321,6 +340,11 @@ const parseReason = (content: string): string | null => {
   const stderrLineMatch = content.match(/stderr:\s*(.+)/i);
   if (stderrLineMatch?.[1] && stderrLineMatch[1] !== '(none)') {
     return stderrLineMatch[1].trim();
+  }
+
+  // fallback: if command failed but no reason extracted, include exit code + hint
+  if (exitCode !== null && exitCode !== 0) {
+    return `command exited ${exitCode}; see judge artifact for details`;
   }
 
   return null;


### PR DESCRIPTION
- parseReason now shows exit code when no explicit reason found
- parsePassed defaults to false when read from file without explicit metadata
- prevents failed judges from being cached as passed on retry
- adds blank line after failure reason for visual separation
- adds acceptance test coverage with snapshots

Co-authored-by: Ulad Kasach <uladkasach@gmail.com>
