### PR TITLE
fix(driver): zen up route output + add gardened routes philosophy

### DIFF
--- a/blackbox/__snapshots__/driver.route.escape-hatch.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.escape-hatch.acceptance.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`driver.route.escape-hatch.acceptance given: [escape-hatch] stone with perma-fail review when: [t0] artifact created and pass attempted then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    ├─ stone = 1.design
@@ -24,7 +24,7 @@ exports[`driver.route.escape-hatch.acceptance given: [escape-hatch] stone with p
 `;
 
 exports[`driver.route.escape-hatch.acceptance given: [escape-hatch] stone with perma-fail review when: [t2] pass is reattempted after guard edit then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    └─ stone = 1.design

--- a/blackbox/__snapshots__/driver.route.guard-cwd.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.guard-cwd.acceptance.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`driver.route.guard-cwd.acceptance given: [case1] guard with $route in judge command when: [t0] artifact created but no approval then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    ├─ stone = 1.vision
@@ -23,7 +23,7 @@ exports[`driver.route.guard-cwd.acceptance given: [case1] guard with $route in j
 `;
 
 exports[`driver.route.guard-cwd.acceptance given: [case1] guard with $route in judge command when: [t1] approval granted and pass reattempted then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    ├─ stone = 1.vision
@@ -42,7 +42,7 @@ exports[`driver.route.guard-cwd.acceptance given: [case1] guard with $route in j
 `;
 
 exports[`driver.route.guard-cwd.acceptance given: [case2] guard with $route works from nested route directory when: [t0] judge runs on nested route then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    ├─ stone = 1.vision
@@ -64,7 +64,7 @@ exports[`driver.route.guard-cwd.acceptance given: [case2] guard with $route work
 `;
 
 exports[`driver.route.guard-cwd.acceptance given: [case2] guard with $route works from nested route directory when: [t1] approval granted on nested route then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    ├─ stone = 1.vision

--- a/blackbox/__snapshots__/driver.route.journey.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.journey.acceptance.test.ts.snap
@@ -10,7 +10,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
 `;
 
 exports[`driver.route.journey.acceptance given: [journey] weather api route when: [t1] 1.vision artifact is created and pass attempted then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    ├─ stone = 1.vision
@@ -28,7 +28,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
 `;
 
 exports[`driver.route.journey.acceptance given: [journey] weather api route when: [t2] 1.vision is approved by human then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    └─ stone = 1.vision
@@ -37,7 +37,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
 `;
 
 exports[`driver.route.journey.acceptance given: [journey] weather api route when: [t3] 1.vision pass is reattempted after approval then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    ├─ stone = 1.vision
@@ -64,7 +64,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
 exports[`driver.route.journey.acceptance given: [journey] weather api route when: [t5] 2.research pass attempted without artifact then: stdout has good vibes 1`] = `""`;
 
 exports[`driver.route.journey.acceptance given: [journey] weather api route when: [t6] 2.research artifact created and pass attempted then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    └─ stone = 2.research
@@ -82,7 +82,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
 `;
 
 exports[`driver.route.journey.acceptance given: [journey] weather api route when: [t8.5] 3.blueprint review.self is promised then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    └─ stone = 3.blueprint
@@ -91,7 +91,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
 `;
 
 exports[`driver.route.journey.acceptance given: [journey] weather api route when: [t8] 3.blueprint artifact created and pass attempted then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    ├─ stone = 3.blueprint
@@ -153,7 +153,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
 `;
 
 exports[`driver.route.journey.acceptance given: [journey] weather api route when: [t9.5] 3.blueprint review set to pass and pass reattempted then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    ├─ stone = 3.blueprint
@@ -176,7 +176,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
 `;
 
 exports[`driver.route.journey.acceptance given: [journey] weather api route when: [t9] 3.blueprint pass reattempted after promise then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    ├─ stone = 3.blueprint
@@ -203,7 +203,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
 `;
 
 exports[`driver.route.journey.acceptance given: [journey] weather api route when: [t10] 3.blueprint approved and pass reattempted then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    ├─ stone = 3.blueprint
@@ -234,7 +234,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
 `;
 
 exports[`driver.route.journey.acceptance given: [journey] weather api route when: [t12] 5.execute artifact created and pass attempted then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    ├─ stone = 5.execute

--- a/blackbox/__snapshots__/driver.route.judge-failure.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.judge-failure.acceptance.test.ts.snap
@@ -16,7 +16,7 @@ exports[`driver.route.judge-failure.acceptance given: [case1] judge command fail
 `;
 
 exports[`driver.route.judge-failure.acceptance given: [case1] judge command fails without proper passed: metadata when: [t0] route.stone.set --as passed is invoked then: stdout matches snapshot 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    ├─ stone = 1
@@ -49,7 +49,7 @@ exports[`driver.route.judge-failure.acceptance given: [case1] judge command fail
 `;
 
 exports[`driver.route.judge-failure.acceptance given: [case1] judge command fails without proper passed: metadata when: [t1] route.stone.set --as passed is invoked again then: stdout matches snapshot 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    ├─ stone = 1

--- a/blackbox/__snapshots__/driver.route.review-blocks-approval.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.review-blocks-approval.acceptance.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`driver.route.review-blocks-approval.acceptance given: [review-blocks] stone with review + approval guard when: [t1] human approves the stone then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    └─ stone = 1.plan
@@ -10,7 +10,7 @@ exports[`driver.route.review-blocks-approval.acceptance given: [review-blocks] s
 `;
 
 exports[`driver.route.review-blocks-approval.acceptance given: [review-blocks] stone with review + approval guard when: [t2] pass attempted with approval but reviews still fail then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    ├─ stone = 1.plan
@@ -36,7 +36,7 @@ exports[`driver.route.review-blocks-approval.acceptance given: [review-blocks] s
 `;
 
 exports[`driver.route.review-blocks-approval.acceptance given: [review-blocks] stone with review + approval guard when: [t4] pass reattempted after fix then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    ├─ stone = 1.plan

--- a/blackbox/__snapshots__/driver.route.self-review.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.self-review.acceptance.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`driver.route.review.self.acceptance given: [case1] stone with reviews.self defined when: [t0] pass attempted without promises then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    ├─ stone = 1
@@ -63,7 +63,7 @@ exports[`driver.route.review.self.acceptance given: [case1] stone with reviews.s
 `;
 
 exports[`driver.route.review.self.acceptance given: [case1] stone with reviews.self defined when: [t1] first review is promised then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    └─ stone = 1
@@ -125,7 +125,7 @@ exports[`driver.route.review.self.acceptance given: [case1] stone with reviews.s
 `;
 
 exports[`driver.route.review.self.acceptance given: [case1] stone with reviews.self defined when: [t2] second review is promised then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    └─ stone = 1
@@ -134,7 +134,7 @@ exports[`driver.route.review.self.acceptance given: [case1] stone with reviews.s
 `;
 
 exports[`driver.route.review.self.acceptance given: [case1] stone with reviews.self defined when: [t3] pass attempted with all promises then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    ├─ stone = 1
@@ -154,7 +154,7 @@ exports[`driver.route.review.self.acceptance given: [case1] stone with reviews.s
 `;
 
 exports[`driver.route.review.self.acceptance given: [case3] hashless promises survive hash changes (firm checkpoint) when: [t2] pass attempted after edit then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    ├─ stone = 1
@@ -216,7 +216,7 @@ exports[`driver.route.review.self.acceptance given: [case3] hashless promises su
 `;
 
 exports[`driver.route.review.self.acceptance given: [case4] flat reviews array (backwards compatible) when: [t0] pass attempted with flat reviews then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    ├─ stone = 1
@@ -236,9 +236,9 @@ exports[`driver.route.review.self.acceptance given: [case4] flat reviews array (
 `;
 
 exports[`driver.route.review.self.acceptance given: [case5] clone promises too quickly (time enforcement) when: [t1] promise attempted immediately (before 90 seconds) then: stdout has good vibes 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
-🦉 patience, friend
+🗿 patience, friend
    │
    ├─ the pond barely rippled
    │

--- a/blackbox/__snapshots__/driver.route.set.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.set.acceptance.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`driver.route.set.acceptance given: [case5] route.stone.set with flexible pattern lookup when: [t0] partial pattern matches single stone then: stdout matches snapshot 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    └─ stone = 1.vision
@@ -10,7 +10,7 @@ exports[`driver.route.set.acceptance given: [case5] route.stone.set with flexibl
 `;
 
 exports[`driver.route.set.acceptance given: [case5] route.stone.set with flexible pattern lookup when: [t1] numeric prefix pattern agent approval locked then: stdout matches snapshot 1`] = `
-"🦉 so you're saying there's a chance?
+"🦉 the way speaks for itself
 
 🗿 route.stone.set
    └─ stone = 2.criteria

--- a/src/domain.operations/route/formatRouteStoneEmit.ts
+++ b/src/domain.operations/route/formatRouteStoneEmit.ts
@@ -10,7 +10,7 @@ import { formatPatienceFriend } from './guard/formatPatienceFriend';
  */
 
 const HEADER_GET = '🦉 and then?';
-const HEADER_SET = `🦉 so you're saying there's a chance?`;
+const HEADER_SET = `🦉 the way speaks for itself`;
 const HEADER_DEL = `🦉 hoo needs 'em`;
 
 type FormatInput =

--- a/src/domain.operations/route/guard/__snapshots__/formatPatienceFriend.test.ts.snap
+++ b/src/domain.operations/route/guard/__snapshots__/formatPatienceFriend.test.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`formatPatienceFriend given: [case1] challenged review.self when: [t0] formatPatienceFriend called then: output matches snapshot (vibecheck) 1`] = `
-"🦉 patience, friend
+"🗿 patience, friend
    │
    ├─ the pond barely rippled
    │

--- a/src/domain.operations/route/guard/formatPatienceFriend.test.ts
+++ b/src/domain.operations/route/guard/formatPatienceFriend.test.ts
@@ -11,10 +11,10 @@ describe('formatPatienceFriend', () => {
         expect(output).toMatchSnapshot();
       });
 
-      then('contains owl header', () => {
+      then('contains stone header', () => {
         const output = formatPatienceFriend();
 
-        expect(output).toContain('🦉 patience, friend');
+        expect(output).toContain('🗿 patience, friend');
       });
 
       then('contains zen challenge sections', () => {

--- a/src/domain.operations/route/guard/formatPatienceFriend.ts
+++ b/src/domain.operations/route/guard/formatPatienceFriend.ts
@@ -6,7 +6,7 @@ export const formatPatienceFriend = (): string => {
   const lines: string[] = [];
 
   // header
-  lines.push(`🦉 patience, friend`);
+  lines.push(`🗿 patience, friend`);
   lines.push(`   │`);
 
   // pond rippled line

--- a/src/domain.roles/driver/briefs/define.routes-are-gardened.[philosophy].md
+++ b/src/domain.roles/driver/briefs/define.routes-are-gardened.[philosophy].md
@@ -1,0 +1,73 @@
+# routes are gardened
+
+## .what
+
+routes are paved paths — best born from desire paths, always evolved from practice, as lessons emerge along the way.
+
+seeded with purpose, tended by practice.
+
+## .two modes of design
+
+both modes are important — but with practice emerges the way.
+
+### predicted design (architected)
+
+design is planned, documented, and approved before implementation starts. the blueprint precedes the build.
+
+- blueprint precedes construction
+- designers anticipate problem areas
+- top-down structure guides reality
+- change requires rework
+
+### emergent design (gardened)
+
+design evolves as you build and learn. the path reveals itself through action.
+
+- observe what grows, cultivate what works
+- architecture emerges through scale-up
+- feedback shapes the structure
+- change is expected and absorbed
+
+## .the desire paths principle
+
+> in finland, city officials document where people walk in parks after the first snowfall, then integrate that data into iterative trail planning.
+> — [99% Invisible](https://99percentinvisible.org/article/least-resistance-desire-paths-can-lead-better-design/)
+
+"pave the cow path" = formalize and reinforce behavior that already exists.
+
+desire paths are trails worn into grass. you notice them, then pave.
+
+## .the daoist connection
+
+> "she steps out of the way and lets the Tao speak for itself."
+> — Tao Te Ching
+
+this is wu wei applied to process design. the route is already there in the ad-hoc work. you just listen for it. that's the Dao — it speaks for itself.
+
+## .the nuance
+
+some paths should stay unpaved:
+- some foundations must be right the first time (hardware, infrastructure)
+- hasty emergence wastes time via rewrites and regressions
+- cows walk where cows walk, yet sometimes that's inefficient or unsafe
+
+the sweet spot: **guardrails enable discovery**. you need a park before paths can form. intentional structure creates space for emergence.
+
+> "both big design up front and doing no design up front are extremes. the sweet spot is somewhere in between."
+> — [Random Acts of Architecture](https://randomactsofarchitecture.com/2013/07/08/big-design-up-front-versus-emergent-design/)
+
+## .implication for routes
+
+to create routes:
+- predict from fundamentals, hold loosely
+- observe from practice, evolve based on emergence
+- describe the path walked, refine as you go
+- that description becomes the route
+
+## .implication for evolution
+
+routes evolve:
+- expect imperfection, welcome refinement
+- when stones reveal lessons, commit changes upstream
+- branch for variations, merge what works
+- the garden is never finished


### PR DESCRIPTION
- change patience friend emoji from owl to stone (one owl, one stone)
- change HEADER_SET to 'the way speaks for itself' (daoist vibe)
- add define.routes-are-gardened.[philosophy].md brief
- update tests and snapshots

Co-authored-by: Ulad Kasach <uladkasach@gmail.com>
