### PR TITLE
fix(route): exclude .temp, dist, artifact dirs from bind flag scan

### DIFF
--- a/src/domain.operations/route/bind/delRouteBind.ts
+++ b/src/domain.operations/route/bind/delRouteBind.ts
@@ -1,26 +1,14 @@
-import { execSync } from 'child_process';
 import * as fs from 'fs/promises';
 
-import { sanitizeBranchName } from '@src/domain.operations/review/sanitizeBranchName';
-import { enumFilesFromGlob } from '@src/utils/enumFilesFromGlob';
+import { getAllBindFlagsByBranch } from './getAllBindFlagsByBranch';
 
 /**
  * .what = removes the bind flag for the current branch
  * .why = enables clean unbind with idempotent semantics
  */
 export const delRouteBind = async (): Promise<{ deleted: boolean }> => {
-  // get current branch, flatten
-  const branch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
-  const branchFlat = sanitizeBranchName({ branch });
-
   // scan for bind flags
-  const flagGlob = `**/.route/.bind.${branchFlat}.flag`;
-  const flagFiles = await enumFilesFromGlob({
-    glob: flagGlob,
-    cwd: process.cwd(),
-    dot: true,
-    ignore: ['**/node_modules/**'],
-  });
+  const { flagFiles } = await getAllBindFlagsByBranch({ branch: null });
 
   // not found → idempotent success
   if (flagFiles.length === 0) return { deleted: false };

--- a/src/domain.operations/route/bind/getAllBindFlagsByBranch.integration.test.ts
+++ b/src/domain.operations/route/bind/getAllBindFlagsByBranch.integration.test.ts
@@ -1,0 +1,177 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { genTempDir, given, then, when } from 'test-fns';
+
+import { getAllBindFlagsByBranch } from './getAllBindFlagsByBranch';
+
+describe('getAllBindFlagsByBranch', () => {
+  given('[case1] bind flag in valid location', () => {
+    const tempDir = genTempDir({ slug: 'test-bind-flags-valid' });
+
+    beforeEach(async () => {
+      const routeDir = path.join(tempDir, '.behavior', 'my-feature', '.route');
+      await fs.mkdir(routeDir, { recursive: true });
+      await fs.writeFile(
+        path.join(routeDir, '.bind.vlad.test-branch.flag'),
+        'branch: vlad/test-branch\n',
+      );
+    });
+
+    when('[t0] lookup executed', () => {
+      then('finds the flag', async () => {
+        const originalCwd = process.cwd();
+        process.chdir(tempDir);
+        try {
+          const result = await getAllBindFlagsByBranch({
+            branch: 'vlad/test-branch',
+          });
+          expect(result.flagFiles).toHaveLength(1);
+          expect(result.flagFiles[0]).toContain('.bind.vlad.test-branch.flag');
+        } finally {
+          process.chdir(originalCwd);
+        }
+      });
+    });
+  });
+
+  given('[case2] bind flag in .temp directory', () => {
+    const tempDir = genTempDir({ slug: 'test-bind-flags-temp' });
+
+    beforeEach(async () => {
+      // flag in .temp should be ignored
+      const routeDir = path.join(tempDir, '.temp', 'some-test', '.route');
+      await fs.mkdir(routeDir, { recursive: true });
+      await fs.writeFile(
+        path.join(routeDir, '.bind.vlad.ignored-branch.flag'),
+        'branch: vlad/ignored-branch\n',
+      );
+    });
+
+    when('[t0] lookup executed', () => {
+      then('ignores flag in .temp', async () => {
+        const originalCwd = process.cwd();
+        process.chdir(tempDir);
+        try {
+          const result = await getAllBindFlagsByBranch({
+            branch: 'vlad/ignored-branch',
+          });
+          expect(result.flagFiles).toHaveLength(0);
+        } finally {
+          process.chdir(originalCwd);
+        }
+      });
+    });
+  });
+
+  given('[case3] bind flag in dist directory', () => {
+    const tempDir = genTempDir({ slug: 'test-bind-flags-dist' });
+
+    beforeEach(async () => {
+      // flag in dist should be ignored
+      const routeDir = path.join(tempDir, 'dist', 'some-build', '.route');
+      await fs.mkdir(routeDir, { recursive: true });
+      await fs.writeFile(
+        path.join(routeDir, '.bind.vlad.ignored-branch.flag'),
+        'branch: vlad/ignored-branch\n',
+      );
+    });
+
+    when('[t0] lookup executed', () => {
+      then('ignores flag in dist', async () => {
+        const originalCwd = process.cwd();
+        process.chdir(tempDir);
+        try {
+          const result = await getAllBindFlagsByBranch({
+            branch: 'vlad/ignored-branch',
+          });
+          expect(result.flagFiles).toHaveLength(0);
+        } finally {
+          process.chdir(originalCwd);
+        }
+      });
+    });
+  });
+
+  given('[case4] bind flag in node_modules directory', () => {
+    const tempDir = genTempDir({ slug: 'test-bind-flags-nm' });
+
+    beforeEach(async () => {
+      // flag in node_modules should be ignored
+      const routeDir = path.join(tempDir, 'node_modules', 'some-pkg', '.route');
+      await fs.mkdir(routeDir, { recursive: true });
+      await fs.writeFile(
+        path.join(routeDir, '.bind.vlad.ignored-branch.flag'),
+        'branch: vlad/ignored-branch\n',
+      );
+    });
+
+    when('[t0] lookup executed', () => {
+      then('ignores flag in node_modules', async () => {
+        const originalCwd = process.cwd();
+        process.chdir(tempDir);
+        try {
+          const result = await getAllBindFlagsByBranch({
+            branch: 'vlad/ignored-branch',
+          });
+          expect(result.flagFiles).toHaveLength(0);
+        } finally {
+          process.chdir(originalCwd);
+        }
+      });
+    });
+  });
+
+  given('[case5] bind flags in mixed locations', () => {
+    const tempDir = genTempDir({ slug: 'test-bind-flags-mixed' });
+
+    beforeEach(async () => {
+      // valid flag
+      const validRouteDir = path.join(
+        tempDir,
+        '.behavior',
+        'my-feature',
+        '.route',
+      );
+      await fs.mkdir(validRouteDir, { recursive: true });
+      await fs.writeFile(
+        path.join(validRouteDir, '.bind.vlad.mixed-branch.flag'),
+        'branch: vlad/mixed-branch\n',
+      );
+
+      // ignored flags
+      const tempRouteDir = path.join(tempDir, '.temp', 'test', '.route');
+      const distRouteDir = path.join(tempDir, 'dist', 'build', '.route');
+      await fs.mkdir(tempRouteDir, { recursive: true });
+      await fs.mkdir(distRouteDir, { recursive: true });
+      await fs.writeFile(
+        path.join(tempRouteDir, '.bind.vlad.mixed-branch.flag'),
+        'branch: vlad/mixed-branch\n',
+      );
+      await fs.writeFile(
+        path.join(distRouteDir, '.bind.vlad.mixed-branch.flag'),
+        'branch: vlad/mixed-branch\n',
+      );
+    });
+
+    when('[t0] lookup executed', () => {
+      then('finds only valid flag, ignores others', async () => {
+        const originalCwd = process.cwd();
+        process.chdir(tempDir);
+        try {
+          const result = await getAllBindFlagsByBranch({
+            branch: 'vlad/mixed-branch',
+          });
+          expect(result.flagFiles).toHaveLength(1);
+          // check path contains valid location, not ignored dirs relative to cwd
+          const flagPath = result.flagFiles[0]!;
+          expect(flagPath).toContain('.behavior/my-feature');
+          // ensure it's the valid one (not from .temp or dist subdirs we created)
+          expect(flagPath).not.toMatch(/\/.temp\/test\//);
+          expect(flagPath).not.toMatch(/\/dist\/build\//);
+        } finally {
+          process.chdir(originalCwd);
+        }
+      });
+    });
+  });
+});

--- a/src/domain.operations/route/bind/getAllBindFlagsByBranch.ts
+++ b/src/domain.operations/route/bind/getAllBindFlagsByBranch.ts
@@ -1,0 +1,36 @@
+import { execSync } from 'child_process';
+
+import { sanitizeBranchName } from '@src/domain.operations/review/sanitizeBranchName';
+import { enumFilesFromGlob } from '@src/utils/enumFilesFromGlob';
+
+/**
+ * .what = finds all bind flag files for a branch
+ * .why = shared lookup used by get/set/del bind operations
+ */
+export const getAllBindFlagsByBranch = async (input: {
+  branch: string | null;
+}): Promise<{ branch: string; branchFlat: string; flagFiles: string[] }> => {
+  // get branch name (from input or git)
+  const branch =
+    input.branch ??
+    execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
+
+  // flatten branch name for flag file lookup
+  const branchFlat = sanitizeBranchName({ branch });
+
+  // scan for bind flag files (dot: true to traverse .behavior/ etc)
+  const flagGlob = `**/.route/.bind.${branchFlat}.flag`;
+  const flagFiles = await enumFilesFromGlob({
+    glob: flagGlob,
+    cwd: process.cwd(),
+    dot: true,
+    ignore: [
+      '**/node_modules/**',
+      '**/{dist,.dist}/**',
+      '**/{temp,.temp}/**',
+      '**/{artifact,.artifact}/**',
+    ],
+  });
+
+  return { branch, branchFlat, flagFiles };
+};

--- a/src/domain.operations/route/bind/getRouteBindByBranch.ts
+++ b/src/domain.operations/route/bind/getRouteBindByBranch.ts
@@ -1,32 +1,18 @@
-import { execSync } from 'child_process';
 import { BadRequestError } from 'helpful-errors';
 import * as path from 'path';
 
-import { sanitizeBranchName } from '@src/domain.operations/review/sanitizeBranchName';
-import { enumFilesFromGlob } from '@src/utils/enumFilesFromGlob';
+import { getAllBindFlagsByBranch } from './getAllBindFlagsByBranch';
 
 /**
- * .what = resolves the bound route for the current (or given) branch
- * .why = enables auto-resolve of --route from bind flag files
+ * .what = looks up the bound route for the current (or given) branch
+ * .why = enables auto-lookup of --route from bind flag files
  */
 export const getRouteBindByBranch = async (input: {
   branch: string | null;
 }): Promise<{ route: string } | null> => {
-  // get branch name (from input or git)
-  const branch =
-    input.branch ??
-    execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
-
-  // flatten branch name for flag file lookup
-  const branchFlat = sanitizeBranchName({ branch });
-
-  // scan for bind flag files (dot: true to traverse .behavior/ etc)
-  const flagGlob = `**/.route/.bind.${branchFlat}.flag`;
-  const flagFiles = await enumFilesFromGlob({
-    glob: flagGlob,
-    cwd: process.cwd(),
-    dot: true,
-    ignore: ['**/node_modules/**'],
+  // scan for bind flag files
+  const { branch, flagFiles } = await getAllBindFlagsByBranch({
+    branch: input.branch,
   });
 
   // no flags found → not bound

--- a/src/domain.operations/route/bind/setRouteBind.ts
+++ b/src/domain.operations/route/bind/setRouteBind.ts
@@ -1,14 +1,12 @@
-import { execSync } from 'child_process';
 import * as fs from 'fs/promises';
 import { BadRequestError } from 'helpful-errors';
 import * as path from 'path';
 
-import { sanitizeBranchName } from '@src/domain.operations/review/sanitizeBranchName';
-import { enumFilesFromGlob } from '@src/utils/enumFilesFromGlob';
+import { getAllBindFlagsByBranch } from './getAllBindFlagsByBranch';
 
 /**
  * .what = binds a route to the current branch via flag file
- * .why = enables subsequent route commands to auto-resolve --route
+ * .why = enables subsequent route commands to auto-lookup --route
  */
 export const setRouteBind = async (input: {
   route: string;
@@ -26,8 +24,12 @@ export const setRouteBind = async (input: {
     );
   }
 
-  // get current branch
-  const branch = execSync('git rev-parse --abbrev-ref HEAD').toString().trim();
+  // scan for pre-bound flags for this branch
+  const {
+    branch,
+    branchFlat,
+    flagFiles: flagFilesFound,
+  } = await getAllBindFlagsByBranch({ branch: null });
 
   // reject protected branches
   const protectedBranches = ['main', 'master'];
@@ -35,18 +37,6 @@ export const setRouteBind = async (input: {
     throw new BadRequestError('cannot bind route on protected branch', {
       branch,
     });
-
-  // flatten branch name
-  const branchFlat = sanitizeBranchName({ branch });
-
-  // scan for pre-bound flags for this branch
-  const flagGlob = `**/.route/.bind.${branchFlat}.flag`;
-  const flagFilesFound = await enumFilesFromGlob({
-    glob: flagGlob,
-    cwd: process.cwd(),
-    dot: true,
-    ignore: ['**/node_modules/**'],
-  });
 
   // if found, check if same route or different
   if (flagFilesFound.length > 0) {


### PR DESCRIPTION
- extract getAllBindFlagsByBranch as shared operation
- add ignore patterns for node_modules, dist, .temp, .artifact
- add integration tests for ignore behavior
- prevents EACCES errors when .temp contains restricted symlinks

Co-authored-by: Ulad Kasach <uladkasach@gmail.com>
