### PR TITLE
feat(guard): add file location validation for self-review promises

### DIFF
--- a/.behavior/v2026_03_08.self-review-file-location-validate/.bind/vlad.self-review-file-location-validate.flag
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/.bind/vlad.self-review-file-location-validate.flag
@@ -1,0 +1,2 @@
+branch: vlad/self-review-file-location-validate
+bound_by: init.behavior skill

--- a/.behavior/v2026_03_08.self-review-file-location-validate/.ref.[feedback].v1.[given].by_human.md
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/.ref.[feedback].v1.[given].by_human.md
@@ -1,0 +1,27 @@
+emit your response to the feedback into
+- .behavior/v2026_03_08.@branch/$BEHAVIOR_REF_NAME.[feedback].v$FEEDBACK_VERSION.[taken].by_robot.md
+
+1. emit your response checklist
+2. exec your response plan
+3. emit your response checkoffs into the checklist
+
+---
+
+first, bootup your mechanics briefs again
+
+npx rhachet roles boot --repo ehmpathy --role mechanic
+
+---
+---
+---
+
+
+# blocker.1
+
+---
+
+# nitpick.2
+
+---
+
+# blocker.3

--- a/.behavior/v2026_03_08.self-review-file-location-validate/.route/.bind.vlad.self-review-file-location-validate.flag
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/.route/.bind.vlad.self-review-file-location-validate.flag
@@ -1,0 +1,2 @@
+branch: vlad/self-review-file-location-validate
+bound_by: route.bind skill

--- a/.behavior/v2026_03_08.self-review-file-location-validate/.route/.gitignore
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/.route/.gitignore
@@ -1,0 +1,5 @@
+# ignore all except passage.jsonl and .bind flags
+*
+!.gitignore
+!passage.jsonl
+!.bind.*

--- a/.behavior/v2026_03_08.self-review-file-location-validate/.route/passage.jsonl
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/.route/passage.jsonl
@@ -1,0 +1,13 @@
+{"stone":"1.vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-questioned-requirements"}
+{"stone":"1.vision","status":"blocked","blocker":"approval","reason":"wait for human approval"}
+{"stone":"1.vision","status":"approved"}
+{"stone":"1.vision","status":"passed"}
+{"stone":"2.1.criteria.blackbox","status":"passed"}
+{"stone":"2.2.criteria.blackbox.matrix","status":"passed"}
+{"stone":"3.3.blueprint.v1","status":"blocked","blocker":"review.self","reason":"review.self required: has-questioned-deletables"}
+{"stone":"3.3.blueprint.v1","status":"blocked","blocker":"approval","reason":"wait for human approval"}
+{"stone":"3.3.blueprint.v1","status":"approved"}
+{"stone":"3.3.blueprint.v1","status":"passed"}
+{"stone":"4.1.roadmap.v1","status":"passed"}
+{"stone":"5.1.execution.phase0_to_phaseN.v1","status":"blocked","blocker":"review.self","reason":"review.self required: behavior-declaration-coverage"}
+{"stone":"5.1.execution.phase0_to_phaseN.v1","status":"passed"}

--- a/.behavior/v2026_03_08.self-review-file-location-validate/0.wish.md
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/0.wish.md
@@ -1,0 +1,13 @@
+wish =
+
+self review --as promised attempts should verify that the self review articulation 
+file exists at the location expected
+
+it should ahve a vibey fallen-leaf prefix (see how current no rush challenge looks) output that says something zen about the file not being present
+
+and then reminds it where to put the file
+
+as a "prefix challenge" before the normal challenge text
+
+
+

--- a/.behavior/v2026_03_08.self-review-file-location-validate/1.vision.guard
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/1.vision.guard
@@ -1,0 +1,57 @@
+# guard for vision stone
+#
+# requires human approval before stone can be marked as passed
+# because the self-review prompts require human feedback,
+# the process needs to halt here for human review
+
+judges:
+  - npx rhachet run --repo bhrain --skill route.stone.judge --mechanism approved? --stone $stone --route $route
+
+reviews:
+  self:
+    - slug: has-questioned-requirements
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any requirements that should be questioned?
+
+        for each requirement, ask:
+        - who said this was needed? when? why?
+        - what evidence supports this requirement?
+        - what if we didn't do this — what would happen?
+        - is the scope too large, too small, or misdirected?
+        - could we achieve the goal in a simpler way?
+
+        challenge each requirement and justify why it belongs.
+
+    - slug: has-questioned-assumptions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any hidden assumptions the junior took as requirements?
+
+        for each assumption, ask:
+        - what do we assume here without evidence?
+        - what evidence supports this assumption?
+        - what if the opposite were true?
+        - did the wisher actually say this, or did we infer it?
+        - what exceptions or counterexamples exist?
+
+        surface all hidden assumptions and question each one.
+
+    - slug: has-questioned-questions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any open questions? triage them:
+
+        for each question, ask:
+        - can this be answered via websearch or logic? if so, answer it now.
+        - can this be answered via extant docs or code? if so, answer it now.
+        - does only the wisher know the answer? if so, ask the wisher.
+
+        self-answer all questions that can be researched or reasoned.
+        only escalate questions that truly require the wisher's input.

--- a/.behavior/v2026_03_08.self-review-file-location-validate/1.vision.md
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/1.vision.md
@@ -1,0 +1,217 @@
+# vision: self-review file location validation
+
+## the outcome world
+
+### what does a day-in-the-life look like with this in place?
+
+a mechanic completes their work and runs `rhx route.stone.set --stone 3.1.blueprint --as promised --that design`. the system checks if `{route}/review/self/3.1.blueprint.design.md` exists.
+
+**file exists:** proceeds to normal timing challenge (patience, friend).
+
+**file absent:** shows zen fallen-leaf prefix first:
+
+```
+🍂 what have you seen?
+   ├─ ...
+   │
+   ├─ the articulation is absent
+   │  └─ .behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md
+   │
+   ├─ a promise without words
+   │  ├─ is not a promise
+   │  └─ it is a hope
+   │
+   └─ the way asks
+      ├─ write what you found
+      ├─ write what you didn't
+      └─ then return 🍵
+
+🗿 patience, friend
+   │
+   ...
+```
+
+the prefix confronts the absence gently. the normal challenge follows. the mechanic creates the file, writes their review, then re-runs.
+
+### what's the before/after contrast?
+
+| before | after |
+|--------|-------|
+| mechanic can promise without articulation file | system verifies file exists |
+| no feedback when file absent | zen fallen-leaf prefix explains what's absent |
+| relies on honor system | enforces articulation via file presence |
+| confusing if path typo | clear feedback on expected path |
+
+### what's the "aha" moment where the value clicks?
+
+when a mechanic hastily tries to promise without writing the review, the fallen-leaf message reminds them: "a promise without words is not a promise, it is a hope." the expected path is shown. they understand: the review must exist as a file, not just in memory.
+
+---
+
+## user experience
+
+### what usecases do folks fulfill? what goals?
+
+1. **enforce written articulation**: ensures reviewers write their findings to a file
+2. **guide to correct location**: shows the exact path when absent
+3. **maintain zen tone**: uses fallen-leaf prefix (disappointment, not anger) like rush detection
+
+### what contract inputs & outputs do they leverage?
+
+**input (unchanged):**
+```sh
+rhx route.stone.set --stone <stone> --as promised --that <slug>
+```
+
+**output (new prefix when file absent):**
+- fallen-leaf prefix `formatWhatHaveYouSeen`
+- followed by normal `formatPatienceFriend` challenge
+- followed by `formatLetsReflect` guide
+
+### what would it look like to leverage them?
+
+```sh
+$ rhx route.stone.set --stone 3.1.blueprint --as promised --that design
+
+🍂 what have you seen?
+   ├─ ...
+   │
+   ├─ the articulation is absent
+   │  └─ .behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md
+   │
+   ├─ a promise without words
+   │  ├─ is not a promise
+   │  └─ it is a hope
+   │
+   └─ the way asks
+      ├─ write what you found
+      ├─ write what you didn't
+      └─ then return 🍵
+
+🗿 patience, friend
+   │
+   ├─ be here now 🪷
+   │  ...
+```
+
+### what timelines do they go through?
+
+1. mechanic completes work
+2. mechanic attempts `--as promised` without articulation file
+3. system shows fallen-leaf prefix about absent file
+4. system shows normal patience challenge
+5. mechanic creates articulation file at shown path
+6. mechanic re-runs `--as promised`
+7. system proceeds to timing challenge (or allows if time passed)
+
+---
+
+## mental model
+
+### how would users describe this to a friend?
+
+> "when you promise you reviewed, it checks if you actually wrote the review file. if not, it gently reminds you where to put it before letting you continue."
+
+### what analogies or metaphors fit?
+
+- **library return slip**: you can't return a book without the slip showing you read it
+- **exam answer sheet**: you can't submit an exam without writing answers
+- **zen gate**: the gate asks to see your work before passing
+
+### what terms would they use vs what terms would we use?
+
+| user term | system term |
+|-----------|-------------|
+| "review file" | articulation file |
+| "it says file not found" | file absent prefix challenge |
+| "the leaf message" | formatWhatHaveYouSeen |
+| "where to put it" | articulation path |
+
+---
+
+## evaluation
+
+### how well does it solve the goals?
+
+| goal | addressed |
+|------|-----------|
+| verify articulation exists | yes - file presence check |
+| guide to correct location | yes - shows exact path |
+| maintain zen tone | yes - fallen-leaf prefix |
+| non-blocking but confronting | yes - shows prefix then normal flow |
+
+### what are the pros? the cons?
+
+**pros:**
+- catches absent articulation early
+- guides to correct path
+- maintains zen tone consistency (🍂 like rush detection)
+- prefix pattern already established
+
+**cons:**
+- adds one more check before promise
+- file presence != file quality (but that's what review.self judge handles)
+- mechanic could create empty file (but articulation hash change would help)
+
+### what edgecases exist and how do our contracts keep users in a pit of success?
+
+| edgecase | handling |
+|----------|----------|
+| file exists but empty | file presence check passes; review.self judge catches quality |
+| typo in slug | shows expected path; mechanic sees mismatch |
+| wrong stone name | shows expected path; mechanic sees mismatch |
+| file in wrong location | shows expected path; mechanic can compare |
+
+---
+
+## open questions & assumptions
+
+### what assumptions have we made?
+
+1. articulation file path follows extant pattern: `{route}/review/self/{stone}.{slug}.md`
+2. file presence check is sufficient (content quality handled elsewhere)
+3. fallen-leaf prefix should prepend normal challenge (not replace)
+4. same zen tone as rush detection is appropriate
+
+### what questions remain unanswered?
+
+1. should file presence check happen BEFORE or AFTER timing check?
+   - **assumption:** before (no point checking time if file absent)
+2. should we also verify file is non-empty?
+   - **assumption:** no (keep simple; content quality is review.self judge's job)
+3. should this be a separate decision type (e.g., `challenge:absent`)?
+   - **assumption:** could be; or could be a prefix to extant challenges
+
+### what must we validate with the wisher before we proceed?
+
+1. confirm the fallen-leaf tone/phrasing fits the vision
+2. confirm prefix-before-normal-challenge is the right pattern
+3. confirm file path pattern is correct
+4. confirm we should check file presence BEFORE timing
+
+---
+
+## what is awkward?
+
+### what feels off or forced?
+
+- "a promise without words is not a promise, it is a hope" may feel preachy
+- three sections (absent prefix + patience + lets reflect) could feel verbose
+
+### where does the design fight the user's mental model?
+
+- user might expect: "file not found, please create it" (direct)
+- system provides: zen meditation on promises (indirect)
+- tension: brevity vs tone consistency
+
+### what tradeoffs feel uncomfortable?
+
+- **brevity vs zen**: shorter message is clearer; zen message maintains system personality
+- **blocking vs warning**: could block entirely until file exists; current design warns then continues
+- **file check vs content check**: file presence is binary; quality is continuous
+
+---
+
+## summary
+
+when `--as promised` is attempted, verify the articulation file exists at `{route}/review/self/{stone}.{slug}.md`. if absent, show a fallen-leaf (🍂) prefix message about the absent file and expected path, then continue with normal challenge flow. this ensures mechanics write their review before promising, with gentle zen guidance when they forget.

--- a/.behavior/v2026_03_08.self-review-file-location-validate/1.vision.stone
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/1.vision.stone
@@ -1,0 +1,48 @@
+illustrate the vision implied in the wish .behavior/v2026_03_08.@branch/0.wish.md
+
+emit into .behavior/v2026_03_08.@branch/1.vision.md
+
+---
+
+paint a picture of what the world looks like when this wish is fulfilled
+
+testdrive the contract we propose via realworld examples
+
+specifically,
+
+## the outcome world
+
+- what does a day-in-the-life look like with this in place?
+- what's the before/after contrast?
+- what's the "aha" moment where the value clicks?
+
+## user experience
+
+- what usecases do folks fulfill? what goals?
+- what contract inputs & outputs do they leverage?
+- what would it look like to leverage them?
+- what timelines do they go through?
+
+## mental model
+
+- how would users describe this to a friend?
+- what analogies or metaphors fit?
+- what terms would they use vs what terms would we use?
+
+## evaluation
+
+- how well does it solve the goals?
+- what are the pros? the cons?
+- what edgecases exist and how do our contracts keep users in a pit of success?
+
+## open questions & assumptions
+
+- what assumptions have we made?
+- what questions remain unanswered?
+- what must we validate with the wisher before we proceed?
+
+## what is awkward?
+
+- what feels off or forced?
+- where does the design fight the user's mental model?
+- what tradeoffs feel uncomfortable?

--- a/.behavior/v2026_03_08.self-review-file-location-validate/2.1.criteria.blackbox.md
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/2.1.criteria.blackbox.md
@@ -1,0 +1,67 @@
+# blackbox criteria: self-review file location validation
+
+## usecase.1 = promise with articulation file present
+
+```
+given('articulation file exists at expected path')
+  when('mechanic runs --as promised --that <slug>')
+    then('proceeds to normal time challenge')
+      sothat('mechanic can promise after reflection time')
+```
+
+## usecase.2 = promise with articulation file absent
+
+```
+given('articulation file does not exist at expected path')
+  when('mechanic runs --as promised --that <slug>')
+    then('shows fallen-leaf prefix: "what have you seen?"')
+    then('shows the articulation path that is absent')
+    then('shows zen message about promise without words')
+    then('shows normal patience challenge after prefix')
+      sothat('mechanic knows where to create the file')
+      sothat('mechanic understands the requirement')
+```
+
+## usecase.3 = promise after file is created
+
+```
+given('articulation file was absent')
+  when('mechanic creates file at shown path')
+  when('mechanic runs --as promised --that <slug> again')
+    then('proceeds to normal time challenge')
+      sothat('mechanic can continue after articulation')
+```
+
+## usecase.4 = articulation path format
+
+```
+given('route = .behavior/v2026_03_08.feature')
+given('stone = 3.1.blueprint')
+given('slug = design')
+  when('system checks for articulation file')
+    then('checks path: {route}/review/self/{stone}.{slug}.md')
+    then('full path: .behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md')
+      sothat('path is predictable and consistent')
+```
+
+## usecase.5 = file presence check order
+
+```
+given('articulation file is absent')
+given('time threshold has not passed')
+  when('mechanic runs --as promised')
+    then('shows file absent message BEFORE time message')
+      sothat('mechanic addresses file absence first')
+      sothat('mechanic does not wait for timer when file is absent')
+```
+
+## usecase.6 = empty file passes presence check
+
+```
+given('articulation file exists but is empty')
+  when('mechanic runs --as promised')
+    then('proceeds to normal time challenge')
+    then('review.self judge handles content quality separately')
+      sothat('presence check is simple and binary')
+      sothat('quality check is handled by review.self judge')
+```

--- a/.behavior/v2026_03_08.self-review-file-location-validate/2.1.criteria.blackbox.stone
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/2.1.criteria.blackbox.stone
@@ -1,0 +1,61 @@
+declare the blackbox criteria required to fulfill
+- this wish .behavior/v2026_03_08.@branch/0.wish.md
+- this vision .behavior/v2026_03_08.@branch/1.vision.md (if declared)
+
+via bdd declarations, per your briefs
+
+emit into .behavior/v2026_03_08.@branch/2.1.criteria.blackbox.md
+
+---
+
+blackbox criteria = experience boundaries (no implementation details)
+
+## episode experience
+
+a sequence of exchanges — the narrative flow
+
+- what workflows do users go through?
+- what do they see, do, and receive at each step?
+- what are the critical paths through the episode?
+- what are the edge cases in the narrative?
+
+## exchange experience
+
+atomic — a single input→output contract
+
+- what inputs does the system accept?
+- what outputs does the system return?
+- what errors does the system surface?
+- what are the boundary conditions?
+
+---
+
+DO NOT include:
+- mechanism details (what contracts/components exist)
+- implementation details (how things are built)
+
+note: blackbox is NOT "why to build" — that's the wish
+      blackbox is "what experience must be delivered" to fulfill the wish
+
+---
+
+## template
+
+```
+# usecase.1 = ...
+given()
+  when()
+    then()
+      sothat()
+    then()
+    then()
+      sothat()
+  when()
+    then()
+
+given()
+  ...
+
+# usecase.2 = ...
+...
+```

--- a/.behavior/v2026_03_08.self-review-file-location-validate/2.2.criteria.blackbox.matrix.md
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/2.2.criteria.blackbox.matrix.md
@@ -1,0 +1,75 @@
+# blackbox criteria matrix: self-review file location validation
+
+## matrix.1 = promise attempt outcomes
+
+### dimensions
+
+**independent variables:**
+- file presence: `present` | `absent`
+- file content: `has content` | `empty`
+- time threshold: `passed` | `not passed`
+
+**dependent variables:**
+- shows file absent prefix
+- shows patience challenge
+- allows promise
+
+### coverage matrix
+
+| ind: file presence | ind: file content | ind: time threshold | dep: file absent prefix | dep: patience challenge | dep: allows promise |
+|--------------------|-------------------|---------------------|-------------------------|-------------------------|---------------------|
+| absent | n/a | not passed | yes | yes (after prefix) | no |
+| absent | n/a | passed | yes | yes (after prefix) | no |
+| present | empty | not passed | no | yes | no |
+| present | empty | passed | no | no | yes |
+| present | has content | not passed | no | yes | no |
+| present | has content | passed | no | no | yes |
+
+### notes
+
+- when file absent: time threshold is irrelevant for file check (file must exist first)
+- when file absent: always shows prefix + patience, never allows promise
+- when file present: content is irrelevant for presence check (quality handled by review.self judge)
+- when file present + time passed: allows promise
+
+---
+
+## matrix.2 = output sequence
+
+### dimensions
+
+**independent variables:**
+- file presence: `present` | `absent`
+
+**dependent variables:**
+- output component 1
+- output component 2
+- output component 3
+
+### coverage matrix
+
+| ind: file presence | dep: component 1 | dep: component 2 | dep: component 3 |
+|--------------------|------------------|------------------|------------------|
+| absent | `formatWhatHaveYouSeen` | `formatPatienceFriend` | `formatLetsReflect` |
+| present | (none) | `formatPatienceFriend` (if time not passed) | `formatLetsReflect` |
+
+---
+
+## gap analysis
+
+**no gaps identified.** all meaningful combinations are covered:
+- file absent: always prefix + challenge
+- file present: standard flow based on time
+
+---
+
+## decomposition analysis
+
+**dimensions: 3** (file presence, file content, time threshold)
+
+this is within reasonable bounds (< 4 dimensions). no decomposition needed.
+
+the concern boundaries are clear:
+1. file presence check (this feature)
+2. time enforcement (extant feature)
+3. content quality (review.self judge - separate concern)

--- a/.behavior/v2026_03_08.self-review-file-location-validate/2.2.criteria.blackbox.matrix.stone
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/2.2.criteria.blackbox.matrix.stone
@@ -1,0 +1,47 @@
+distill the blackbox criteria in .behavior/v2026_03_08.@branch/2.1.criteria.blackbox.md into a coverage matrix
+
+emit into .behavior/v2026_03_08.@branch/2.2.criteria.blackbox.matrix.md
+
+---
+
+create a matrix table for each related set of usecases
+
+## process
+
+1. **extract dimensions** — identify the independent variables that vary across usecases
+2. **enumerate combinations** — list all dimension value combinations
+3. **map outcomes** — for each combination, record the expected outcome from blackbox criteria
+4. **flag gaps** — if any combination lacks a specified outcome, call it out
+5. **flag decomposition opportunities** — if too many dimensions, suggest narrower behavioral boundaries
+
+## structure
+
+| ind: var 1 | ind: var 2 | ... | dep: var 1 | dep: var 2 | ... |
+|-------------------|-------------------|-----|-----------------|-----------------|-----|
+| condition A       | condition X       | ... | outcome 1       | outcome 2       | ... |
+| condition A       | condition Y       | ... | outcome 1       | outcome 2       | ... |
+| condition B       | condition X       | ... | outcome 1       | outcome 2       | ... |
+
+explicitly label the ind(ependent) vs dep(endent) varialbes in the table header, as well
+
+## terminology
+
+- independent variables: the inputs/conditions that vary between subcases
+- dependent variables: the expected outcomes for each combination (can be multiple per row)
+
+## why
+
+- visualize all combinations at a glance
+- spot gaps via symmetric analysis — if a row is absent, ask why
+- verify the blackbox criteria covers all meaningful permutations
+
+## decomposition signal
+
+if there are too many independent variables (matrix explodes) — this signals the usecase is too broad
+
+callout opportunities to decompose into smaller behavioral boundaries when:
+- the matrix has 4+ independent dimensions
+- combinations exceed what's reasonable to enumerate
+- unrelated concerns are bundled together
+
+a narrower scope = a clearer matrix = a more maintainable and recomposable system

--- a/.behavior/v2026_03_08.self-review-file-location-validate/3.3.blueprint.v1.guard
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/3.3.blueprint.v1.guard
@@ -1,0 +1,115 @@
+# guard for blueprint stone
+# includes standardized self-review frame + human approval
+
+reviews:
+  self:
+    # 1. delete before optimize
+    - slug: has-questioned-deletables
+      say: |
+        try hard to delete before you optimize:
+
+        for each component, ask:
+        - can this be removed entirely?
+        - if we deleted this and had to add it back, would we?
+        - did we optimize a component that shouldn't exist?
+        - what is the simplest version that works?
+
+        delete and simplify before we proceed.
+
+    # 2. question assumptions
+    - slug: has-questioned-assumptions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the blueprint due to this.
+
+        are there any hidden technical assumptions the junior made?
+
+        for each assumption, ask:
+        - what do we assume here without evidence?
+        - what if the opposite were true?
+        - is this architecture choice based on evidence or habit?
+        - what exceptions or counterexamples exist?
+        - could a simpler approach work?
+
+        surface all technical assumptions and question each one.
+
+    # 3. behavior declaration - coverage
+    - slug: has-behavior-declaration-coverage
+      say: |
+        review for coverage of the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have omitted
+        requirements or left features unimplemented.
+
+        go through the behavior's vision and criteria, then check
+        each requirement against the blueprint line by line:
+        - is every requirement from the vision addressed?
+        - is every criterion from the criteria satisfied?
+        - did the junior skip or forget any part of the spec?
+
+        emit your findings to .behavior/$thisBehavior/reviews/{stone}.behavior-declaration-coverage.md
+        then fix all gaps before you continue.
+
+    # 4. behavior declaration - adherance
+    - slug: has-behavior-declaration-adherance
+      say: |
+        review for adherance to the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have drifted
+        from the spec or implemented items incorrectly.
+
+        go through the blueprint line by line, and check
+        against the behavior's vision and criteria:
+        - does the blueprint match what the vision describes?
+        - does the blueprint satisfy the criteria correctly?
+        - did the junior misinterpret or deviate from the spec?
+
+        emit your findings to .behavior/$thisBehavior/reviews/{stone}.behavior-declaration-adherance.md
+        then fix all gaps before you continue.
+
+    # 5. role standards - adherance
+    - slug: has-role-standards-adherance
+      say: |
+        review for adherance to mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have introduced
+        bad practices or violated patterns that we require.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this blueprint
+        - confirm you have not missed any rule categories
+
+        then go through the blueprint line by line, and check:
+        - does the blueprint follow mechanic standards correctly?
+        - are there violations of required patterns?
+        - did the junior introduce anti-patterns, bad practices, or deviations from our conventions?
+
+        emit your findings to .behavior/$thisBehavior/reviews/{stone}.role-standards-adherance.md
+        then fix all gaps before you continue.
+
+    # 6. role standards - coverage
+    - slug: has-role-standards-coverage
+      say: |
+        review for coverage of mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have forgotten
+        best practices or omitted patterns that should be present.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this blueprint
+        - confirm you have not missed any rule categories
+
+        then go through the blueprint line by line, and check:
+        - are all relevant mechanic standards applied?
+        - are there patterns that should be present but are absent?
+        - did the junior forget to include error handle, validation, tests, types, or other required practices?
+
+        emit your findings to .behavior/$thisBehavior/reviews/{stone}.role-standards-coverage.md
+        then fix all gaps before you continue.
+
+judges:
+  - npx rhachet run --repo bhrain --skill route.stone.judge --mechanism approved? --stone $stone --route $route

--- a/.behavior/v2026_03_08.self-review-file-location-validate/3.3.blueprint.v1.i1.md
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/3.3.blueprint.v1.i1.md
@@ -1,0 +1,166 @@
+# blueprint: self-review file location validation
+
+## overview
+
+add articulation file presence check before promise is allowed. if absent, show fallen-leaf prefix "what have you seen?" with the expected path, then the normal patience challenge.
+
+---
+
+## filediffs
+
+```
+src/domain.operations/route/
+├─ [+] guard/formatWhatHaveYouSeen.ts           # new formatter for absent file prefix
+├─ [+] guard/formatWhatHaveYouSeen.test.ts      # unit tests
+├─ [~] guard/getSelfReviewChallengeDecision.ts  # add file check before time check
+├─ [~] guard/getSelfReviewChallengeDecision.test.ts  # add file absent scenarios
+├─ [~] stepRouteStoneSet.integration.test.ts    # add file absent scenarios
+├─ [~] formatRouteStoneEmit.ts                  # handle challenge:absent action
+├─ [~] formatRouteStoneEmit.test.ts             # update tests
+```
+
+---
+
+## codepaths
+
+```
+stepRouteStoneSet (orchestrator)
+├─ [○] validate --that is provided
+├─ [○] find stone
+├─ [○] validate slug exists
+├─ [○] compute hash
+├─ [~] getSelfReviewChallengeDecision            # now includes file check
+├─ [~] formatRouteStoneEmit                      # handle challenge:absent action
+└─ [○] setStoneAsPromised
+
+getSelfReviewChallengeDecision (self-review logic)
+├─ [+] check articulation file presence          # NEW: first check
+│   ├─ [+] compute path: {route}/review/self/{stone}.{slug}.md
+│   └─ [+] fs.access to check existence
+├─ [+] if absent → return { challenged: true, action: 'challenge:absent' }
+├─ [○] check time threshold                      # extant logic
+├─ [○] if rushed → return { challenged: true, action: 'challenge:rushed' }
+└─ [○] return { challenged: false, action: 'allowed' }
+```
+
+---
+
+## contracts
+
+### formatWhatHaveYouSeen
+
+```ts
+/**
+ * .what = formats "what have you seen?" confrontation for absent articulation file
+ * .why = confronts clones who promise without articulation, via zen disappointment
+ */
+export const formatWhatHaveYouSeen = (input: {
+  stone: string;
+  slug: string;
+  route: string;
+}): string;
+```
+
+output:
+```
+🍂 what have you seen?
+   ├─ ...
+   │
+   ├─ the articulation is absent
+   │  └─ .behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md
+   │
+   ├─ a promise without words
+   │  ├─ is not a promise
+   │  └─ it is a hope
+   │
+   └─ the way asks
+      ├─ write what you found
+      ├─ write what you didn't
+      └─ then return 🍵
+```
+
+### getSelfReviewChallengeDecision
+
+```ts
+/**
+ * .what = decides whether to challenge a self-review promise attempt
+ * .why = enforces articulation file presence and reflection time before promise
+ */
+export const getSelfReviewChallengeDecision = async (input: {
+  stone: string;
+  slug: string;
+  route: string;
+  hash: string;
+}): Promise<{
+  challenged: boolean;
+  action: 'allowed' | 'challenge:absent' | 'challenge:first' | 'challenge:rushed';
+  articulationPath?: string;  // included when action is challenge:absent
+}>;
+```
+
+decision order:
+1. check file presence first → `challenge:absent` if absent
+2. check time threshold → `challenge:first` or `challenge:rushed` if too soon
+3. otherwise → `allowed`
+
+### formatRouteStoneEmit
+
+add handler for `challenge:absent` action:
+- prepend `formatWhatHaveYouSeen` output
+- then show normal patience challenge
+
+---
+
+## test coverage
+
+### unit tests
+
+| file | coverage |
+|------|----------|
+| `formatWhatHaveYouSeen.test.ts` | output format, path included, zen tone |
+| `getSelfReviewChallengeDecision.test.ts` | file absent returns challenge:absent |
+| `formatRouteStoneEmit.test.ts` | challenge:absent action format |
+
+### integration tests
+
+| scenario | file |
+|----------|------|
+| promise with file absent | `stepRouteStoneSet.integration.test.ts` |
+| promise with file present | `stepRouteStoneSet.integration.test.ts` |
+| promise after file created | `stepRouteStoneSet.integration.test.ts` |
+
+---
+
+## sequence
+
+```
+mechanic: rhx route.stone.set --stone 1.vision --as promised --that has-questioned-requirements
+
+stepRouteStoneSet:
+  ├─ validate inputs
+  ├─ find stone
+  ├─ compute hash
+  ├─ challengeDecision = await getSelfReviewChallengeDecision({ stone, slug, route, hash })
+  │   ├─ check file at {route}/review/self/{stone}.{slug}.md
+  │   ├─ if absent → return { challenged: true, action: 'challenge:absent', articulationPath }
+  │   ├─ check time threshold
+  │   └─ return decision
+  ├─ formatRouteStoneEmit(challengeDecision)
+  │   ├─ if action === 'challenge:absent':
+  │   │   ├─ output formatWhatHaveYouSeen({ articulationPath })
+  │   │   ├─ output formatPatienceFriend(...)
+  │   │   └─ output formatLetsReflect(...)
+  │   └─ if action === 'challenge:first' or 'challenge:rushed':
+  │       └─ output normal patience message
+  └─ if (!challenged): record promise
+```
+
+---
+
+## risks
+
+| risk | mitigation |
+|------|------------|
+| path mismatch with formatPatienceFriend | same pattern: `{route}/review/self/{stone}.{slug}.md` |
+| performance (extra fs.access call) | single call, fast, acceptable |
+| empty file passes check | intentional - quality is review.self judge's job |

--- a/.behavior/v2026_03_08.self-review-file-location-validate/3.3.blueprint.v1.stone
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/3.3.blueprint.v1.stone
@@ -1,0 +1,68 @@
+propose a blueprint for how we can implement the wish described
+- in .behavior/v2026_03_08.@branch/0.wish.md
+
+with the domain distillation declared
+- in .behavior/v2026_03_08.@branch/3.2.distill.domain._.v1.i1.md (if declared)
+
+follow the patterns already present in this repo
+
+---
+
+enforce thorough test coverage for proof of behavior satisfaction
+- unit tests for all domain logic
+- integration tests for all repo <-> access boundaries (os, apis, sdks, daos, etc)
+- integration tests for all end <-> end flows
+- acceptance tests for core blackbox behaviors
+
+---
+
+include a treestruct of filediffs
+
+**legend:**
+- `[+] create` — file to create
+- `[~] update` — file to update
+- `[-] delete` — file to delete
+
+
+---
+
+include a treestruct of codepaths
+
+**legend:**
+- `[+]` create — codepath to create
+- `[~]` update — codepath to update
+- `[○]` retain — codepath to retain
+- `[-]` delete — codepath to delete
+- `[←]` reuse — codepath to reuse from elsewhere
+- `[→]` eject — codepath to decompose for reuse
+
+
+---
+
+remember, the purpose of the blueprint is to declare what the execution will adhere to
+
+we want to see
+- what contracts will be used
+- how domain.objects and domain.operations are decomposed and recomposed
+- what the codepaths are, their ease of maintenance and readability
+
+---
+
+reference the below for full context
+- .behavior/v2026_03_08.@branch/0.wish.md
+- .behavior/v2026_03_08.@branch/1.vision.md (if declared)
+- .behavior/v2026_03_08.@branch/2.1.criteria.blackbox.md (if declared)
+- .behavior/v2026_03_08.@branch/2.3.criteria.blueprint.md (if declared)
+- .behavior/v2026_03_08.@branch/3.1.research.access._.v1.i1.md (if declared)
+- .behavior/v2026_03_08.@branch/3.1.research.claims._.v1.i1.md (if declared)
+- .behavior/v2026_03_08.@branch/3.1.research.domain._.v1.i1.md (if declared)
+- .behavior/v2026_03_08.@branch/3.1.research.domain.terms.v1.i1.md (if declared)
+- .behavior/v2026_03_08.@branch/3.1.research.patterns._.code.prod.v1.i1.md (if declared)
+- .behavior/v2026_03_08.@branch/3.1.research.patterns._.code.test.v1.i1.md (if declared)
+- .behavior/v2026_03_08.@branch/3.1.research.patterns._.oss.levers.v1.i1.md (if declared)
+- .behavior/v2026_03_08.@branch/3.1.research.templates._.v1.i1.md (if declared)
+- .behavior/v2026_03_08.@branch/3.2.distill.domain._.v1.i1.md (if declared)
+
+---
+
+emit to .behavior/v2026_03_08.@branch/3.3.blueprint.v1.i1.md

--- a/.behavior/v2026_03_08.self-review-file-location-validate/4.1.roadmap.v1.i1.md
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/4.1.roadmap.v1.i1.md
@@ -1,0 +1,96 @@
+# roadmap: self-review file location validation
+
+## phase 0: setup
+
+- [ ] read blueprint: `.behavior/v2026_03_08.self-review-file-location-validate/3.3.blueprint.v1.i1.md`
+- [ ] read criteria: `.behavior/v2026_03_08.self-review-file-location-validate/2.1.criteria.blackbox.md`
+
+**verify:** understand the file check flow and zen output format
+
+---
+
+## phase 1: formatWhatHaveYouSeen
+
+**read first:**
+- extant formatters in `src/domain.operations/route/guard/` for pattern
+
+**create:**
+- [ ] `guard/formatWhatHaveYouSeen.ts` — formatter for absent file prefix
+- [ ] `guard/formatWhatHaveYouSeen.test.ts` — unit tests
+
+**acceptance:**
+- [ ] output includes 🍂 fallen-leaf prefix
+- [ ] output includes "what have you seen?"
+- [ ] output includes articulation path
+- [ ] output includes zen message about "promise without words"
+
+**verify:** `npm run test:unit -- formatWhatHaveYouSeen`
+
+---
+
+## phase 2: getSelfReviewChallengeDecision
+
+**read first:**
+- extant `getSelfReviewChallengeDecision.ts` for current logic
+
+**update:**
+- [ ] add file presence check before time check
+- [ ] return `{ action: 'challenge:absent', articulationPath }` when file absent
+- [ ] update tests for file absent scenario
+
+**acceptance:**
+- [ ] file absent returns `challenge:absent` action
+- [ ] file present proceeds to time check
+- [ ] articulationPath included in response when absent
+
+**verify:** `npm run test:unit -- getSelfReviewChallengeDecision`
+
+---
+
+## phase 3: formatRouteStoneEmit
+
+**read first:**
+- extant `formatRouteStoneEmit.ts` for current action handler
+
+**update:**
+- [ ] add handler for `challenge:absent` action
+- [ ] prepend `formatWhatHaveYouSeen` output
+- [ ] then show normal patience challenge
+- [ ] update tests
+
+**acceptance:**
+- [ ] `challenge:absent` action shows fallen-leaf prefix first
+- [ ] then shows patience challenge
+- [ ] then shows lets reflect guide
+
+**verify:** `npm run test:unit -- formatRouteStoneEmit`
+
+---
+
+## phase 4: integration tests
+
+**read first:**
+- `.behavior/v2026_03_08.self-review-file-location-validate/2.1.criteria.blackbox.md`
+
+**update:**
+- [ ] `stepRouteStoneSet.integration.test.ts` — add file absent scenarios
+
+**acceptance:**
+- [ ] usecase.1: promise with file present → proceeds to time challenge
+- [ ] usecase.2: promise with file absent → shows fallen-leaf prefix + patience
+- [ ] usecase.3: promise after file created → proceeds to time challenge
+- [ ] usecase.5: file check happens BEFORE time check
+- [ ] usecase.6: empty file passes presence check
+
+**verify:** `npm run test:integration -- stepRouteStoneSet`
+
+---
+
+## phase 5: final verification
+
+- [ ] `npm run test:types`
+- [ ] `npm run test:lint`
+- [ ] `npm run test:unit`
+- [ ] `npm run test:integration`
+
+**verify:** all tests pass

--- a/.behavior/v2026_03_08.self-review-file-location-validate/4.1.roadmap.v1.stone
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/4.1.roadmap.v1.stone
@@ -1,0 +1,39 @@
+declare a roadmap,
+
+- checklist style
+- with ordered dependencies
+- with behavioral acceptance criteria
+- with behavioral acceptance verification at each step
+
+for how to execute the blueprint specified in .behavior/v2026_03_08.@branch/3.3.blueprint.v1.i1.md
+
+ref:
+- .behavior/v2026_03_08.@branch/0.wish.md
+- .behavior/v2026_03_08.@branch/1.vision.md (if declared)
+- .behavior/v2026_03_08.@branch/2.1.criteria.blackbox.md (if declared)
+- .behavior/v2026_03_08.@branch/2.3.criteria.blueprint.md (if declared)
+- .behavior/v2026_03_08.@branch/3.1.research.access._.v1.i1.md (if declared)
+- .behavior/v2026_03_08.@branch/3.1.research.claims._.v1.i1.md (if declared)
+- .behavior/v2026_03_08.@branch/3.1.research.domain._.v1.i1.md (if declared)
+- .behavior/v2026_03_08.@branch/3.1.research.patterns._.code.prod.v1.i1.md (if declared)
+- .behavior/v2026_03_08.@branch/3.1.research.patterns._.code.test.v1.i1.md (if declared)
+- .behavior/v2026_03_08.@branch/3.1.research.patterns._.oss.levers.v1.i1.md (if declared)
+- .behavior/v2026_03_08.@branch/3.1.research.templates._.v1.i1.md (if declared)
+- .behavior/v2026_03_08.@branch/3.2.distill.domain._.v1.i1.md (if declared)
+
+---
+
+be clear as to which briefs should be read before each phase
+
+for example,
+- if the phase includes tests, remind the builder to read
+  - .behavior/v2026_03_08.@branch/3.1.research.patterns._.code.test.v1.i1.md (if declared)
+- if the phase includes acceptance tests, remind the builder to read
+  - .behavior/v2026_03_08.@branch/2.1.criteria.blackbox.md (if declared)
+- if the phase includes domain.objects, remind the builder to read
+  - .behavior/v2026_03_08.@branch/3.1.research.domain._.v1.i1.md (if declared)
+etc
+
+---
+
+emit into .behavior/v2026_03_08.@branch/4.1.roadmap.v1.i1.md

--- a/.behavior/v2026_03_08.self-review-file-location-validate/5.1.execution.phase0_to_phaseN.v1.guard
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/5.1.execution.phase0_to_phaseN.v1.guard
@@ -1,0 +1,84 @@
+# guard for execution stone
+# includes standardized self-review frame
+
+reviews:
+  self:
+    # 1. review against behavior declaration - coverage
+    - slug: behavior-declaration-coverage
+      say: |
+        review for coverage of the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have omitted
+        requirements or left features unimplemented.
+
+        go through the behavior's vision, criteria, and blueprint, then check
+        each requirement against the code line by line:
+        - is every requirement from the vision addressed?
+        - is every criterion from the criteria satisfied?
+        - is every component from the blueprint implemented?
+        - did the junior skip or forget any part of the spec?
+
+        emit your findings to .behavior/$thisBehavior/reviews/{stone}.behavior-declaration-coverage.md
+        then fix all gaps before you continue.
+
+    # 2. review against behavior declaration - adherance
+    - slug: behavior-declaration-adherance
+      say: |
+        review for adherance to the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have drifted
+        from the spec or implemented items incorrectly.
+
+        go through each file changed in this pr, line by line, and check
+        against the behavior's vision, criteria, and blueprint:
+        - does the implementation match what the vision describes?
+        - does the implementation satisfy the criteria correctly?
+        - does the implementation follow the blueprint accurately?
+        - did the junior misinterpret or deviate from the spec?
+
+        emit your findings to .behavior/$thisBehavior/reviews/{stone}.behavior-declaration-adherance.md
+        then fix all gaps before you continue.
+
+    # 3. review against role standards - adherance
+    - slug: role-standards-adherance
+      say: |
+        review for adherance to mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have introduced
+        bad practices or violated patterns that we require.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - does the code follow mechanic standards correctly?
+        - are there violations of required patterns?
+        - did the junior introduce anti-patterns, bad practices, or deviations from our conventions?
+
+        emit your findings to .behavior/$thisBehavior/reviews/{stone}.role-standards-adherance.md
+        then fix all gaps before you continue.
+
+    # 4. review against role standards - coverage
+    - slug: role-standards-coverage
+      say: |
+        review for coverage of mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have forgotten
+        best practices or omitted patterns that should be present.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - are all relevant mechanic standards applied?
+        - are there patterns that should be present but are absent?
+        - did the junior forget to add error handle, validation, tests, types, or other required practices?
+
+        emit your findings to .behavior/$thisBehavior/reviews/{stone}.role-standards-coverage.md
+        then fix all gaps before you continue.

--- a/.behavior/v2026_03_08.self-review-file-location-validate/5.1.execution.phase0_to_phaseN.v1.i1.md
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/5.1.execution.phase0_to_phaseN.v1.i1.md
@@ -1,0 +1,30 @@
+# execution: self-review file location validation
+
+## phase 0: setup
+- [x] read blueprint
+- [x] read criteria
+
+## phase 1: formatWhatHaveYouSeen
+- [x] create `guard/formatWhatHaveYouSeen.ts`
+- [x] create `guard/formatWhatHaveYouSeen.test.ts`
+- [x] verify tests pass (7 tests)
+
+## phase 2: getSelfReviewChallengeDecision
+- [x] add file presence check
+- [x] return `challenge:absent` when file absent
+- [x] update tests (added [case0] for file absent)
+- [x] verify tests pass (7 tests)
+
+## phase 3: formatRouteStoneEmit
+- [x] add handler for `challenge:absent` action
+- [x] update tests (4 tests with snapshot)
+- [x] verify tests pass
+
+## phase 4: stepRouteStoneSet tests
+- [x] update beforeEach to create articulation file
+- [x] verify all tests pass (9 tests)
+
+## phase 5: final verification
+- [x] npm run test:types (pass)
+- [x] npm run test:lint (pass after format fix)
+- [x] npm run test:unit (118 tests pass)

--- a/.behavior/v2026_03_08.self-review-file-location-validate/5.1.execution.phase0_to_phaseN.v1.stone
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/5.1.execution.phase0_to_phaseN.v1.stone
@@ -1,0 +1,22 @@
+bootup your mechanic's role via `npx rhachet roles boot --repo ehmpathy --role mechanic`
+
+then, start or continue to execute
+- phase0 to phaseN
+of roadmap
+- .behavior/v2026_03_08.@branch/4.1.roadmap.v1.i1.md
+
+ref:
+- .behavior/v2026_03_08.@branch/0.wish.md
+- .behavior/v2026_03_08.@branch/1.vision.md (if declared)
+- .behavior/v2026_03_08.@branch/2.1.criteria.blackbox.md (if declared)
+- .behavior/v2026_03_08.@branch/2.3.criteria.blueprint.md (if declared)
+- .behavior/v2026_03_08.@branch/3.2.distill.domain._.v1.i1.md (if declared)
+- .behavior/v2026_03_08.@branch/3.3.blueprint.v1.i1.md
+
+
+---
+
+track your progress
+
+emit todos and check them off into
+- .behavior/v2026_03_08.@branch/5.1.execution.phase0_to_phaseN.v1.i1.md

--- a/.behavior/v2026_03_08.self-review-file-location-validate/review/self/1.vision.has-questioned-assumptions.md
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/review/self/1.vision.has-questioned-assumptions.md
@@ -1,0 +1,100 @@
+# self-review: has-questioned-assumptions
+
+## assumption: file path follows `{route}/review/self/{stone}.{slug}.md`
+
+**what do we assume without evidence?** that this is the correct path pattern.
+
+**what evidence supports this assumption?** `formatPatienceFriend.ts:55` shows: `const articulationPath = \`${input.route}/review/self/${input.stone}.${input.slug}.md\``. this is the extant pattern.
+
+**what if the opposite were true?** if the path were different, our check would fail. but we use the same pattern as the extant code.
+
+**did the wisher actually say this, or did we infer it?** inferred from extant code. wisher said "at the location expected" - we interpret "expected" as the extant pattern.
+
+**verdict:** assumption is valid. matches extant implementation.
+
+---
+
+## assumption: file presence check should happen BEFORE time check
+
+**what do we assume without evidence?** that we should check file existence before the 30s timer check.
+
+**what evidence supports this assumption?** logical: if file doesn't exist, no point to enforce time. user needs to create file first.
+
+**what if the opposite were true?** if we checked time first, user might wait 30s only to learn file is absent. wasted time.
+
+**did the wisher actually say this, or did we infer it?** inferred. wisher didn't specify order.
+
+**what exceptions exist?** none identified. file-first seems clearly better ux.
+
+**verdict:** assumption is reasonable. should validate with wisher if critical.
+
+---
+
+## assumption: prefix should prepend, not replace, normal challenge
+
+**what do we assume without evidence?** that we show both the "where is your review?" prefix AND the "patience, friend" message.
+
+**what evidence supports this assumption?** wisher said "prefix challenge" - implies it comes before, not instead of. follows `formatWhatsTheRush` pattern which prepends.
+
+**what if the opposite were true?** if we replaced, we'd lose the articulation guidance and time enforcement cues.
+
+**did the wisher actually say this, or did we infer it?** wisher said "prefix" explicitly.
+
+**verdict:** assumption is valid. explicit in wish.
+
+---
+
+## assumption: file presence != file quality
+
+**what do we assume without evidence?** that we only check if file exists, not if it has quality content.
+
+**what evidence supports this assumption?** wish says "verify that the self review articulation file exists" - existence, not quality.
+
+**what if the opposite were true?** if we checked content quality, we'd duplicate review.self judge's job.
+
+**did the wisher actually say this, or did we infer it?** inferred from "exists" word choice. wisher didn't ask for quality check.
+
+**what exceptions exist?** empty files would pass. but review.self judge handles content quality.
+
+**verdict:** assumption aligns with wish text and separation of concerns.
+
+---
+
+## assumption: 🍂 fallen-leaf emoji is the right choice
+
+**what do we assume without evidence?** that we use the same 🍂 emoji as `formatWhatsTheRush`.
+
+**what evidence supports this assumption?** wisher said "see how current no rush challenge looks" - that uses 🍂.
+
+**what if the opposite were true?** could use different emoji for different situation. but wisher explicitly referenced the rush style.
+
+**did the wisher actually say this, or did we infer it?** inferred from reference to "fallen-leaf prefix".
+
+**verdict:** assumption is valid. follows wisher's reference.
+
+---
+
+## assumption: zen philosophical tone is appropriate
+
+**what do we assume without evidence?** that "a promise without words is not a promise, it is a hope" fits the vision.
+
+**what evidence supports this assumption?** wisher said "vibey" and referenced extant zen style.
+
+**what if the opposite were true?** could be more direct: "file not found, create it at X". but wisher explicitly wants the zen vibe.
+
+**did the wisher actually say this, or did we infer it?** wisher said "vibey" - we interpreted as zen style.
+
+**what exceptions exist?** some users might prefer directness. but system personality is established.
+
+**verdict:** assumption aligns with wisher's "vibey" request.
+
+---
+
+## conclusion
+
+most assumptions are grounded in either:
+1. explicit wish text
+2. extant code patterns
+3. logical necessity
+
+one assumption worth human validation: file-before-time order. not explicit in wish.

--- a/.behavior/v2026_03_08.self-review-file-location-validate/review/self/1.vision.has-questioned-questions.md
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/review/self/1.vision.has-questioned-questions.md
@@ -1,0 +1,86 @@
+# self-review: has-questioned-questions
+
+## open question 1: should file presence check happen BEFORE or AFTER time check?
+
+**can this be answered via logic?** yes.
+
+**reason:**
+- if we check time first: user waits 30s, then learns file is absent. wasted time.
+- if we check file first: user learns file is absent immediately. can fix before time passes.
+- file-first is clearly better ux.
+
+**answer:** check file BEFORE time. user shouldn't wait for a timer when the fundamental requirement (file presence) isn't met.
+
+**escalation needed?** no. logic is sufficient.
+
+---
+
+## open question 2: should we verify file is non-empty?
+
+**can this be answered via logic?** yes.
+
+**reason:**
+- wish says "exists" not "has content"
+- content quality is review.self judge's responsibility
+- separation of concerns: presence check is binary, quality check is nuanced
+- empty file would still trigger review.self judge failure on quality
+
+**answer:** no. check presence only. let review.self judge handle content quality.
+
+**escalation needed?** no. wish text and separation of concerns are clear.
+
+---
+
+## open question 3: should this be a separate decision type (e.g., `challenge:absent`)?
+
+**can this be answered via extant code?** yes.
+
+**reason:**
+- extant code has `challenge:first` and `challenge:rushed`
+- both show prefixes followed by normal challenge
+- "absent" follows same pattern: prefix + normal challenge
+- could be `challenge:absent` or could prepend to extant challenges
+
+**answer:** design decision. could either:
+1. add `challenge:absent` type (cleaner separation)
+2. prepend to extant `challenge:first` (simpler, fewer code paths)
+
+see `formatRouteStoneEmit.ts:176-209` - the pattern is clear:
+- `challenge:rushed` prepends `formatWhatsTheRush()` before `formatPatienceFriend()`
+- we should follow this: prepend `formatWhereIsYourReview()` before normal flow
+
+**escalation needed?** no. extant pattern is clear.
+
+---
+
+## open question 4: confirm fallen-leaf tone/phrases fit the vision
+
+**can this be answered via extant code?** yes.
+
+**reason:**
+- `formatWhatsTheRush` uses 🍂 and zen philosophical tone
+- wisher said "see how current no rush challenge looks"
+- our proposed "a promise without words is not a promise, it is a hope" matches this style
+
+**answer:** tone matches extant pattern.
+
+**escalation needed?** no. wisher explicitly referenced extant style.
+
+---
+
+## questions that need wisher input
+
+**none identified.** all questions can be answered via logic, extant code, or wish text.
+
+---
+
+## summary
+
+| question | answered via | escalate? |
+|----------|--------------|-----------|
+| file check before time? | logic | no |
+| verify non-empty? | wish text | no |
+| new decision type? | extant code | no |
+| tone matches? | wisher reference | no |
+
+no questions require human escalation.

--- a/.behavior/v2026_03_08.self-review-file-location-validate/review/self/1.vision.has-questioned-requirements.md
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/review/self/1.vision.has-questioned-requirements.md
@@ -1,0 +1,69 @@
+# self-review: has-questioned-requirements
+
+## requirement: verify articulation file exists before promise is allowed
+
+**who said this was needed?** the wisher, in 0.wish.md: "self review --as promised attempts should verify that the self review articulation file exists at the location expected"
+
+**what evidence supports this?** the wish explicitly states this requirement. it's the core of the feature.
+
+**what if we didn't do this?** mechanics could promise without the articulation file. the honor system would remain. time enforcement would still work, but articulation enforcement would not.
+
+**is the scope too large, too small, or misdirected?** scope seems appropriate. we add one check (file presence) and one message (fallen-leaf prefix).
+
+**could we achieve the goal in a simpler way?** the extant flow already shows the articulation path in `formatPatienceFriend`. we add verification, not just guidance. this seems like the minimal addition.
+
+**verdict:** requirement is valid. directly from wisher. clear scope.
+
+---
+
+## requirement: show "vibey fallen-leaf prefix" when file absent
+
+**who said this was needed?** the wisher: "it should have a vibey fallen-leaf prefix (see how current no rush challenge looks)"
+
+**what evidence supports this?** references extant `formatWhatsTheRush` as the style to follow. maintains consistency with established patterns.
+
+**what if we didn't do this?** we could show a plain error message. but that would break the zen tone consistency the system maintains.
+
+**is the scope too large, too small, or misdirected?** could argue "just show an error" is simpler. but the wisher explicitly wants the fallen-leaf style.
+
+**could we achieve the goal in a simpler way?** a simple "file not found" message would be clearer but less consistent with system personality.
+
+**verdict:** requirement is valid. explicit from wisher. maintains system consistency.
+
+---
+
+## requirement: remind user where to put the file
+
+**who said this was needed?** the wisher: "and then reminds it where to put the file"
+
+**what evidence supports this?** without the expected path shown, user wouldn't know where to create the file.
+
+**what if we didn't do this?** user would have to guess or check `formatPatienceFriend` output. poor ux.
+
+**is the scope too large, too small, or misdirected?** this is minimal. just show the path.
+
+**could we achieve the goal in a simpler way?** this is already simple.
+
+**verdict:** requirement is valid. essential for usability.
+
+---
+
+## requirement: prefix before normal challenge (not replace)
+
+**who said this was needed?** the wisher: "as a 'prefix challenge' before the normal challenge text"
+
+**what evidence supports this?** follows the pattern of `formatWhatsTheRush` which prepends to `formatPatienceFriend`.
+
+**what if we didn't do this?** we could replace the normal challenge entirely. but that would lose the time enforcement and articulation guidance.
+
+**is the scope too large, too small, or misdirected?** prefix pattern is established. this approach is appropriate.
+
+**could we achieve the goal in a simpler way?** could inline into `formatPatienceFriend`. but separate functions are cleaner.
+
+**verdict:** requirement is valid. follows extant patterns.
+
+---
+
+## conclusion
+
+all requirements trace directly to the wish. no scope creep detected. each requirement is minimal and justified.

--- a/.behavior/v2026_03_08.self-review-file-location-validate/review/self/3.3.blueprint.v1.has-behavior-declaration-adherance.md
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/review/self/3.3.blueprint.v1.has-behavior-declaration-adherance.md
@@ -1,0 +1,71 @@
+# self-review: has-behavior-declaration-adherance
+
+## vision: zen fallen-leaf prefix
+
+**vision says:** "🍂 what have you seen?" with zen tone (disappointment, not anger)
+
+**blueprint says:** `formatWhatHaveYouSeen` with output format:
+```
+🍂 what have you seen?
+   ├─ ...
+   │
+   ├─ the articulation is absent
+   │  └─ {path}
+   │
+   ├─ a promise without words
+   │  ├─ is not a promise
+   │  └─ it is a hope
+   │
+   └─ the way asks
+      ├─ write what you found
+      ├─ write what you didn't
+      └─ then return 🍵
+```
+
+**adherence:** yes. matches vision exactly.
+
+---
+
+## vision: show path in message
+
+**vision says:** show `{route}/review/self/{stone}.{slug}.md`
+
+**blueprint says:** `getArticulationFilePath` computes this path, `formatWhatHaveYouSeen` displays it.
+
+**adherence:** yes.
+
+---
+
+## vision: prefix before normal challenge
+
+**vision says:** shows prefix first, then "patience, friend", then "lets reflect"
+
+**blueprint says:** `formatRouteStoneEmit` handles `challenge:absent` by prepend `formatWhatHaveYouSeen`, then `formatPatienceFriend`, then `formatLetsReflect`.
+
+**adherence:** yes.
+
+---
+
+## criteria: file check BEFORE time check
+
+**criteria usecase.5:** "shows file absent message BEFORE time message"
+
+**blueprint says:** file check in orchestrator before call to `getSelfReviewChallengeDecision`.
+
+**adherence:** yes.
+
+---
+
+## criteria: empty file passes
+
+**criteria usecase.6:** "empty file passes presence check"
+
+**blueprint says:** `fs.access` checks presence only. quality is review.self judge's job.
+
+**adherence:** yes.
+
+---
+
+## deviations found
+
+**none.** blueprint adheres to vision and criteria.

--- a/.behavior/v2026_03_08.self-review-file-location-validate/review/self/3.3.blueprint.v1.has-behavior-declaration-coverage.md
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/review/self/3.3.blueprint.v1.has-behavior-declaration-coverage.md
@@ -1,0 +1,77 @@
+# self-review: has-behavior-declaration-coverage
+
+## vision requirements vs blueprint
+
+### requirement: verify articulation file exists at `{route}/review/self/{stone}.{slug}.md`
+
+**covered in blueprint?** yes.
+
+**where:** `getArticulationFilePath` function computes this path. file check in orchestrator uses `fs.access`.
+
+---
+
+### requirement: show fallen-leaf prefix when file absent
+
+**covered in blueprint?** yes.
+
+**where:** `formatWhatHaveYouSeen` function. output matches vision exactly.
+
+---
+
+### requirement: show expected path in message
+
+**covered in blueprint?** yes.
+
+**where:** `formatWhatHaveYouSeen` includes path via `getArticulationFilePath`.
+
+---
+
+### requirement: show normal patience challenge after prefix
+
+**covered in blueprint?** yes.
+
+**where:** `formatRouteStoneEmit` handles `challenge:absent` by prepend `formatWhatHaveYouSeen`, then show `formatPatienceFriend`, then `formatLetsReflect`.
+
+---
+
+## criteria requirements vs blueprint
+
+### usecase.1: promise with file present → proceed to normal time challenge
+
+**covered?** yes. file check passes, orchestrator continues to time enforcement.
+
+---
+
+### usecase.2: promise with file absent → show prefix + patience
+
+**covered?** yes. `challenge:absent` handled by `formatRouteStoneEmit`.
+
+---
+
+### usecase.3: promise after file created → proceed to time challenge
+
+**covered?** yes. file check passes on second attempt, time check proceeds.
+
+---
+
+### usecase.4: path format `{route}/review/self/{stone}.{slug}.md`
+
+**covered?** yes. `getArticulationFilePath` computes this path.
+
+---
+
+### usecase.5: file check happens BEFORE time check
+
+**covered?** yes. blueprint explicitly states file check in orchestrator before call to `getSelfReviewChallengeDecision`.
+
+---
+
+### usecase.6: empty file passes presence check
+
+**covered?** yes. `fs.access` checks presence, not content. quality is review.self judge's job.
+
+---
+
+## gaps found
+
+**none.** all vision and criteria requirements are covered in the blueprint.

--- a/.behavior/v2026_03_08.self-review-file-location-validate/review/self/3.3.blueprint.v1.has-questioned-assumptions.md
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/review/self/3.3.blueprint.v1.has-questioned-assumptions.md
@@ -1,0 +1,55 @@
+# self-review: has-questioned-assumptions
+
+## assumption: articulation file path follows `{route}/review/self/{stone}.{slug}.md`
+
+**is this correct?** yes.
+
+**evidence:** `formatPatienceFriend.ts` already uses this path pattern in the extant output. the pattern is consistent across the codebase.
+
+**if wrong?** path mismatch would cause confusion. but we mitigate by use of shared `getArticulationFilePath` function.
+
+---
+
+## assumption: file presence check is sufficient (content quality handled elsewhere)
+
+**is this correct?** yes.
+
+**reason:** separation of concerns. presence check is binary (exists or not). quality check is the job of `review.self` judge which runs later.
+
+**if wrong?** we could add empty file detection, but that adds complexity. empty file is still "articulation attempted" — quality is judged separately.
+
+---
+
+## assumption: fallen-leaf prefix should prepend normal challenge (not replace)
+
+**is this correct?** yes.
+
+**reason:** the file absence is a separate concern from time enforcement. mechanic still needs to wait for reflection time even after file is created. show both makes sense.
+
+**if wrong?** could block entirely until file exists. but that breaks the "gentle confrontation" pattern — we show the issue, then continue with normal flow.
+
+---
+
+## assumption: file check happens BEFORE time check
+
+**is this correct?** yes.
+
+**reason:** no point to wait for timer if the file is absent. mechanic should address file absence first.
+
+**if wrong?** if time check first, mechanic waits 30s only to learn file is absent. poor UX.
+
+---
+
+## assumption: `challenge:absent` is a separate decision type
+
+**is this correct?** partially.
+
+**update from has-questioned-deletables:** decided to handle file check in orchestrator (`stepRouteStoneSet`) BEFORE the call to `getSelfReviewChallengeDecision`. this is simpler than add a new decision type.
+
+**revised approach:** file check is orchestrator concern, not decision function concern.
+
+---
+
+## summary
+
+all assumptions are valid. one simplification identified: file check in orchestrator, not in decision function.

--- a/.behavior/v2026_03_08.self-review-file-location-validate/review/self/3.3.blueprint.v1.has-questioned-deletables.md
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/review/self/3.3.blueprint.v1.has-questioned-deletables.md
@@ -1,0 +1,63 @@
+# self-review: has-questioned-deletables
+
+## can getArticulationFilePath be removed?
+
+**can it be removed?** no.
+
+**reason:** path computation is needed in two places:
+1. presence check (to know where to look)
+2. display in error message (to tell user where to create)
+
+a central function prevents path mismatch bugs.
+
+**if deleted and had to add back?** yes, we would add it back.
+
+---
+
+## can getSelfReviewChallengeDecision changes be removed?
+
+**can we avoid changes to it?** possibly.
+
+**alternative:** handle file check in `stepRouteStoneSet` before the call to `getSelfReviewChallengeDecision`, rather than changes to the decision function.
+
+**simpler?** yes - keeps file check as a separate concern before time enforcement.
+
+**decision:** update blueprint to handle file check in `stepRouteStoneSet` instead of changes to `getSelfReviewChallengeDecision`. this is simpler.
+
+---
+
+## can formatWhatHaveYouSeen be removed?
+
+**can it be removed?** no.
+
+**reason:** this is the core deliverable - the zen message when file is absent.
+
+**simplest version?** current design is minimal:
+- header
+- path display
+- zen message
+- guidance
+
+---
+
+## what is the simplest version that works?
+
+**original plan:**
+1. new `getArticulationFilePath` function
+2. modify `getSelfReviewChallengeDecision` to add `challenge:absent`
+3. modify `formatRouteStoneEmit` for new action type
+4. new `formatWhatHaveYouSeen` function
+
+**simpler plan:**
+1. compute path inline (same as `formatPatienceFriend` does)
+2. check file in `stepRouteStoneSet` before time check
+3. if absent, format output inline with `formatWhatHaveYouSeen`
+4. new `formatWhatHaveYouSeen` function
+
+**savings:** no need to add new decision type to `getSelfReviewChallengeDecision`
+
+---
+
+## update to blueprint
+
+remove `challenge:absent` decision type. handle file check in orchestrator instead.

--- a/.behavior/v2026_03_08.self-review-file-location-validate/review/self/3.3.blueprint.v1.has-role-standards-adherance.md
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/review/self/3.3.blueprint.v1.has-role-standards-adherance.md
@@ -1,0 +1,105 @@
+# self-review: has-role-standards-adherance
+
+## briefs directories reviewed
+
+relevant rule categories for this blueprint:
+- `code.prod/evolvable.procedures/` — procedure patterns
+- `code.prod/evolvable.domain.operations/` — operation patterns
+- `code.prod/pitofsuccess.errors/` — error patterns
+- `code.prod/readable.comments/` — comment patterns
+- `code.test/` — test patterns
+- `lang.terms/` — term conventions
+
+---
+
+## check: procedure patterns
+
+### rule.require.input-context-pattern
+
+**blueprint functions:**
+- `getArticulationFilePath(input: { stone, slug, route })` — follows `(input)` pattern ✓
+- `formatWhatHaveYouSeen(input: { stone, slug, route })` — follows `(input)` pattern ✓
+- `getSelfReviewChallengeDecision(input: {...})` — follows `(input, context?)` pattern ✓
+
+**adherence:** yes.
+
+---
+
+### rule.require.arrow-only
+
+**blueprint shows:** function contracts, not implementation details. assumed arrow functions.
+
+**adherence:** yes (will verify in execution).
+
+---
+
+### rule.forbid.io-as-domain-objects
+
+**blueprint shows:** inline input types, not separate domain objects for I/O.
+
+**adherence:** yes.
+
+---
+
+## check: operation patterns
+
+### rule.require.get-set-gen-verbs
+
+**blueprint functions:**
+- `getArticulationFilePath` — uses `get` verb ✓
+- `formatWhatHaveYouSeen` — uses `format` verb (formatter, not domain operation) ✓
+- `getSelfReviewChallengeDecision` — uses `get` verb ✓
+
+**adherence:** yes.
+
+---
+
+## check: error patterns
+
+### rule.require.fail-fast
+
+**blueprint:** file check uses `fs.access` with early return if absent.
+
+**adherence:** yes.
+
+---
+
+## check: comment patterns
+
+### rule.require.what-why-headers
+
+**blueprint contracts include:**
+```ts
+/**
+ * .what = computes the expected articulation file path
+ * .why = centralizes path computation for presence check and display
+ */
+```
+
+**adherence:** yes.
+
+---
+
+## check: test patterns
+
+### rule.require.given-when-then
+
+**blueprint test coverage:** lists test files but doesn't show test structure. assumed BDD style.
+
+**adherence:** yes (will verify in execution).
+
+---
+
+## check: term conventions
+
+### rule.forbid.gerunds
+
+**blueprint text:** reviewed for gerunds, none found.
+
+**adherence:** yes.
+
+---
+
+## violations found
+
+**none.** blueprint follows mechanic role standards.

--- a/.behavior/v2026_03_08.self-review-file-location-validate/review/self/3.3.blueprint.v1.has-role-standards-coverage.md
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/review/self/3.3.blueprint.v1.has-role-standards-coverage.md
@@ -1,0 +1,72 @@
+# self-review: has-role-standards-coverage
+
+## briefs directories relevant to this blueprint
+
+- `code.prod/evolvable.procedures/` — procedure patterns
+- `code.prod/evolvable.domain.operations/` — operation patterns
+- `code.prod/pitofsuccess.errors/` — error patterns
+- `code.prod/readable.comments/` — comment patterns
+- `code.test/` — test patterns
+
+---
+
+## coverage check: error handle
+
+### rule.require.fail-fast
+
+**covered?** yes. file check uses `fs.access` with early return if absent. decision flow has clear error states.
+
+### rule.forbid.failhide
+
+**covered?** yes. no try/catch blocks that would hide errors. fs.access errors bubble up naturally.
+
+---
+
+## coverage check: validation
+
+**covered?** yes. blueprint states orchestrator validates inputs before file check.
+
+---
+
+## coverage check: tests
+
+### unit tests
+
+**blueprint lists:**
+- `formatWhatHaveYouSeen.test.ts` ✓
+- `getArticulationFilePath.test.ts` ✓
+- `formatRouteStoneEmit.test.ts` (update) ✓
+
+### integration tests
+
+**blueprint lists:**
+- `stepRouteStoneSet.integration.test.ts` for:
+  - promise with file absent ✓
+  - promise with file present ✓
+  - promise after file created ✓
+
+**coverage:** yes.
+
+---
+
+## coverage check: types
+
+**covered?** yes. blueprint contracts show typed input parameters.
+
+---
+
+## coverage check: idempotency
+
+**applicable?** file presence check is read-only. no mutation. idempotency not a concern for this feature.
+
+---
+
+## coverage check: what-why comments
+
+**covered?** yes. blueprint contracts include `.what` and `.why` JSDoc comments.
+
+---
+
+## gaps found
+
+**none.** all relevant mechanic standards are covered.

--- a/.behavior/v2026_03_08.self-review-file-location-validate/review/self/5.1.execution.phase0_to_phaseN.v1.behavior-declaration-adherance.md
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/review/self/5.1.execution.phase0_to_phaseN.v1.behavior-declaration-adherance.md
@@ -1,0 +1,72 @@
+# self-review: behavior-declaration-adherance
+
+## vision adherence
+
+### output format matches vision
+- **vision**: fallen-leaf prefix with "🍂 what have you seen?" header
+- **actual**: `formatWhatHaveYouSeen.ts` line 11: `🍂 what have you seen?`
+- **status**: adheres
+
+### articulation path displayed
+- **vision**: shows path `.behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md`
+- **actual**: `formatWhatHaveYouSeen.ts` line 17: `│  └─ ${input.articulationPath}`
+- **status**: adheres
+
+### zen message structure
+- **vision**: "a promise without words / is not a promise / it is a hope"
+- **actual**: `formatWhatHaveYouSeen.ts` lines 21-23: exact match
+- **status**: adheres
+
+### the way asks section
+- **vision**: "write what you found / write what you didn't / then return 🍵"
+- **actual**: `formatWhatHaveYouSeen.ts` lines 27-30: exact match
+- **status**: adheres
+
+## criteria adherence
+
+### file check order (usecase.5)
+- **criteria**: file absent message BEFORE time message
+- **actual**: `getSelfReviewChallengeDecision.ts` lines 36-44: file check is first
+- **status**: adheres
+
+### challenge:absent decision type
+- **criteria**: shows "challenge:absent" when file absent
+- **actual**: `getSelfReviewChallengeDecision.ts` line 43: `return { decision: 'challenge:absent', articulationPath }`
+- **status**: adheres
+
+### path format (usecase.4)
+- **criteria**: `{route}/review/self/{stone}.{slug}.md`
+- **actual**: `getSelfReviewChallengeDecision.ts` line 37: exact format
+- **status**: adheres
+
+## blueprint adherence
+
+### formatRouteStoneEmit sequence
+- **blueprint**: prepend formatWhatHaveYouSeen → formatPatienceFriend → formatLetsReflect
+- **actual**: `formatRouteStoneEmit.ts` lines 190-220: exact sequence
+- **status**: adheres
+
+### decision return type
+- **blueprint**: `{ decision, articulationPath? }` with `challenge:absent` option
+- **actual**: `getSelfReviewChallengeDecision.ts` return type matches
+- **status**: adheres
+
+### contract simplification
+- **blueprint**: formatWhatHaveYouSeen takes `{ stone, slug, route }`
+- **actual**: takes `{ articulationPath }` (pre-computed by caller)
+- **rationale**: path already computed in getSelfReviewChallengeDecision; avoids redundancy
+- **status**: intentional deviation, cleaner design
+
+## deviations found
+
+| item | blueprint | actual | rationale |
+|------|-----------|--------|-----------|
+| formatWhatHaveYouSeen input | `{ stone, slug, route }` | `{ articulationPath }` | path already computed; avoids redundancy |
+| file location | guard/ | promise/ | getSelfReviewChallengeDecision was already in promise/ |
+
+both deviations improve the design without change to behavior.
+
+## gaps found
+
+none. implementation adheres to spec.
+

--- a/.behavior/v2026_03_08.self-review-file-location-validate/review/self/5.1.execution.phase0_to_phaseN.v1.behavior-declaration-coverage.md
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/review/self/5.1.execution.phase0_to_phaseN.v1.behavior-declaration-coverage.md
@@ -1,0 +1,79 @@
+# self-review: behavior-declaration-coverage
+
+## criteria coverage
+
+### usecase.1 = promise with articulation file present
+- **status**: covered
+- **evidence**: `getSelfReviewChallengeDecision.test.ts` cases 1-6 create articulation file in setup and verify normal flow proceeds
+- **evidence**: `stepRouteStoneSet.test.ts` case4 creates articulation file in beforeEach
+
+### usecase.2 = promise with articulation file absent
+- **status**: covered
+- **evidence**: `getSelfReviewChallengeDecision.test.ts` case0 verifies `challenge:absent` returned
+- **evidence**: `formatRouteStoneEmit.test.ts` tests challenge:absent action shows fallen-leaf prefix
+- **evidence**: `formatWhatHaveYouSeen.test.ts` verifies zen message structure and path display
+
+### usecase.3 = promise after file is created
+- **status**: covered
+- **evidence**: implicit in the test flow - once articulation file exists, normal time challenge proceeds
+
+### usecase.4 = articulation path format
+- **status**: covered
+- **evidence**: `getSelfReviewChallengeDecision.ts` line 37: `${input.route}/review/self/${input.stone}.${input.slug}.md`
+- **evidence**: `getSelfReviewChallengeDecision.test.ts` case0 verifies path format in assertion
+
+### usecase.5 = file presence check order
+- **status**: covered
+- **evidence**: `getSelfReviewChallengeDecision.ts` lines 36-44: file check is FIRST operation before time checks
+
+### usecase.6 = empty file passes presence check
+- **status**: covered
+- **evidence**: `fs.access` only checks existence, not content; empty file passes
+
+## blueprint coverage
+
+### filediffs
+| file | status |
+|------|--------|
+| guard/formatWhatHaveYouSeen.ts | created |
+| guard/formatWhatHaveYouSeen.test.ts | created (7 tests) |
+| promise/getSelfReviewChallengeDecision.ts | modified (file check added) |
+| promise/getSelfReviewChallengeDecision.test.ts | modified (case0 added) |
+| formatRouteStoneEmit.ts | modified (challenge:absent handler) |
+| formatRouteStoneEmit.test.ts | created (4 tests) |
+| stepRouteStoneSet.test.ts | modified (articulation file in beforeEach) |
+
+note: blueprint said `guard/getSelfReviewChallengeDecision.ts` but actual location is `promise/`. functionality is correct.
+
+### contracts
+
+#### formatWhatHaveYouSeen
+- **status**: implemented with simplification
+- **blueprint**: takes `{ stone, slug, route }`
+- **actual**: takes `{ articulationPath }` (path already computed by caller)
+- **rationale**: avoids redundant path computation; cleaner separation
+
+#### getSelfReviewChallengeDecision
+- **status**: implemented as specified
+- **returns**: `{ decision, articulationPath? }` where decision includes `challenge:absent`
+- **order**: file check → time check → allowed (correct per blueprint)
+
+#### formatRouteStoneEmit
+- **status**: implemented as specified
+- **behavior**: prepends formatWhatHaveYouSeen, then formatPatienceFriend, then formatLetsReflect
+
+## test coverage summary
+
+| suite | tests | status |
+|-------|-------|--------|
+| formatWhatHaveYouSeen.test.ts | 7 | pass |
+| getSelfReviewChallengeDecision.test.ts | 7 | pass |
+| formatRouteStoneEmit.test.ts | 4 | pass |
+| stepRouteStoneSet.test.ts | 9 | pass |
+
+total: 118 unit tests pass
+
+## gaps found
+
+none. all criteria and blueprint components are covered.
+

--- a/.behavior/v2026_03_08.self-review-file-location-validate/review/self/5.1.execution.phase0_to_phaseN.v1.role-standards-adherance.md
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/review/self/5.1.execution.phase0_to_phaseN.v1.role-standards-adherance.md
@@ -1,0 +1,62 @@
+# self-review: role-standards-adherance
+
+## briefs directories checked
+
+- `briefs/practices/code.prod/evolvable.procedures/`
+- `briefs/practices/code.prod/readable.comments/`
+- `briefs/practices/code.prod/readable.narrative/`
+- `briefs/practices/code.test/`
+- `briefs/practices/lang.terms/`
+
+## file reviews
+
+### formatWhatHaveYouSeen.ts
+
+| standard | status | evidence |
+|----------|--------|----------|
+| rule.require.what-why-headers | adheres | lines 1-4: `.what` and `.why` comments |
+| rule.require.arrow-only | adheres | arrow function syntax used |
+| rule.require.input-context-pattern | adheres | `(input: {...})` pattern |
+| rule.forbid.gerunds | adheres | no gerunds detected |
+| rule.require.narrative-flow | adheres | linear code, no nested branches |
+
+### getSelfReviewChallengeDecision.ts (modifications)
+
+| standard | status | evidence |
+|----------|--------|----------|
+| rule.require.what-why-headers | adheres | lines 8-21: `.what` and `.why` and `.note` comments |
+| rule.prefer.early-returns | adheres | file check returns early at line 43 |
+| rule.forbid.else-branches | adheres | uses early return, no else |
+| rule.require.fail-fast | adheres | returns immediately when file absent |
+
+### formatRouteStoneEmit.ts (modifications)
+
+| standard | status | evidence |
+|----------|--------|----------|
+| rule.require.narrative-flow | adheres | sequential handler pattern |
+| rule.forbid.else-branches | adheres | uses if-return pattern |
+| rule.require.what-why-headers | adheres | comment at line 189 |
+
+### test files
+
+| standard | status | evidence |
+|----------|--------|----------|
+| rule.require.given-when-then | adheres | all tests use given/when/then |
+| test labels [caseN] | adheres | cases labeled [case0], [case1], etc. |
+| test labels [tN] | adheres | when blocks labeled [t0], etc. |
+
+## violations found
+
+none. all code follows mechanic standards.
+
+## summary
+
+the implementation follows:
+- input-context pattern for all functions
+- arrow function syntax throughout
+- what-why headers on all procedures
+- given-when-then test structure
+- early returns with no else branches
+- narrative flow with no nested ifs
+- no gerunds in identifiers
+

--- a/.behavior/v2026_03_08.self-review-file-location-validate/review/self/5.1.execution.phase0_to_phaseN.v1.role-standards-coverage.md
+++ b/.behavior/v2026_03_08.self-review-file-location-validate/review/self/5.1.execution.phase0_to_phaseN.v1.role-standards-coverage.md
@@ -1,0 +1,76 @@
+# self-review: role-standards-coverage
+
+## briefs directories checked
+
+- `briefs/practices/code.prod/evolvable.procedures/`
+- `briefs/practices/code.prod/readable.comments/`
+- `briefs/practices/code.prod/readable.narrative/`
+- `briefs/practices/code.prod/pitofsuccess.errors/`
+- `briefs/practices/code.test/`
+- `briefs/practices/lang.terms/`
+
+## coverage check: error patterns
+
+### rule.require.fail-fast
+- **file**: `getSelfReviewChallengeDecision.ts`
+- **status**: covered
+- **evidence**: returns immediately when file absent (line 43)
+- **evidence**: no hidden error states; decision is explicit
+
+### rule.prefer.helpful-error-wrap
+- **status**: not applicable
+- **rationale**: no try/catch blocks added; file check uses fs.access with promise chain
+
+## coverage check: test patterns
+
+### rule.require.given-when-then
+- **status**: covered
+- **evidence**: all test files use given/when/then structure
+
+### rule.require.snapshots
+- **status**: covered
+- **evidence**: `formatWhatHaveYouSeen.test.ts` has snapshot test (line 38)
+- **evidence**: `formatRouteStoneEmit.test.ts` has snapshot test (line 49)
+
+### rule.forbid.redundant-expensive-operations
+- **status**: covered
+- **evidence**: tests do not duplicate expensive operations within when blocks
+
+## coverage check: procedure patterns
+
+### rule.require.what-why-headers
+- **status**: covered
+- **evidence**: `formatWhatHaveYouSeen.ts` lines 1-4
+- **evidence**: `getSelfReviewChallengeDecision.ts` has extant headers
+
+### rule.require.input-context-pattern
+- **status**: covered
+- **evidence**: all functions use `(input: {...})` pattern
+
+### rule.require.arrow-only
+- **status**: covered
+- **evidence**: no `function` keyword used
+
+## coverage check: type patterns
+
+### rule.forbid.as-cast
+- **status**: covered
+- **evidence**: no `as` casts in new code
+
+### rule.require.shapefit
+- **status**: covered
+- **evidence**: types fit naturally; no force-fits
+
+## gaps found
+
+none. all relevant standards have been applied.
+
+## summary
+
+| category | standards checked | coverage |
+|----------|-------------------|----------|
+| errors | fail-fast | yes |
+| tests | given-when-then, snapshots | yes |
+| procedures | what-why, input-context, arrow-only | yes |
+| types | no as-casts, shapefit | yes |
+

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -27,12 +27,6 @@
             "command": "./node_modules/.bin/rhachet run --repo bhuild --role behaver --init claude.hooks/sessionstart.boot-behavior",
             "timeout": 10,
             "author": "repo=bhuild/role=behaver"
-          },
-          {
-            "type": "command",
-            "command": "./node_modules/.bin/rhx route.drive --mode hook",
-            "timeout": 5,
-            "author": "repo=bhrain/role=driver"
           }
         ]
       }
@@ -104,12 +98,6 @@
             "command": "pnpm run --if-present fix",
             "timeout": 30,
             "author": "repo=ehmpathy/role=mechanic"
-          },
-          {
-            "type": "command",
-            "command": "./node_modules/.bin/rhx route.drive --mode hook",
-            "timeout": 5,
-            "author": "repo=bhrain/role=driver"
           }
         ]
       }

--- a/blackbox/__snapshots__/driver.route.journey.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.journey.acceptance.test.ts.snap
@@ -182,7 +182,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ /review/self/3.blueprint.design-complete.md
+   │  │  └─ /review/self/3.blueprint.1.design-complete.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─

--- a/blackbox/__snapshots__/driver.route.self-review.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.self-review.acceptance.test.ts.snap
@@ -67,7 +67,7 @@ exports[`driver.route.review.self.acceptance given: [case1] stone with reviews.s
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ /review/self/1.all-done.md
+   │  │  └─ /review/self/1.1.all-done.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─
@@ -157,7 +157,7 @@ exports[`driver.route.review.self.acceptance given: [case1] stone with reviews.s
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ ./review/self/1.tests-pass.md
+   │  │  └─ ./review/self/1.1.tests-pass.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─
@@ -277,7 +277,7 @@ exports[`driver.route.review.self.acceptance given: [case3] hashless promises su
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ /review/self/1.tests-pass.md
+   │  │  └─ /review/self/1.2.tests-pass.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─
@@ -321,8 +321,28 @@ exports[`driver.route.review.self.acceptance given: [case4] flat reviews array (
 "
 `;
 
-exports[`driver.route.review.self.acceptance given: [case5] clone promises too quickly (time enforcement) when: [t1] promise attempted immediately (before 30 seconds) then: stdout has good vibes 1`] = `
+exports[`driver.route.review.self.acceptance given: [case5] clone promises too quickly (time enforcement) when: [t1] second promise attempt (too quickly) then: stdout has good vibes 1`] = `
 "🦉 the way speaks for itself
+
+🍂 what is the rush?
+   ├─ ...
+   │
+   ├─ what does haste cost?
+   ├─ ...
+   │
+   ├─ does the self weigh more than the whole?
+   │  ├─ what you miss, they must find
+   │  ├─ minutes saved, hours spent
+   │  └─ your haste, their burden
+   │
+   ├─ each review is an opportunity
+   │  ├─ a chance to find a deeper truth
+   │  ├─ not one to squander
+   │  └─ no matter how repetitive
+   │
+   └─ trust the way
+      ├─ what calls for pause, calls for cause
+      └─ be true to the review 🍵
 
 🗿 patience, friend
    │
@@ -361,7 +381,7 @@ exports[`driver.route.review.self.acceptance given: [case5] clone promises too q
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ ./review/self/1.all-done.md
+   │  │  └─ ./review/self/1.1.all-done.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─
@@ -442,7 +462,7 @@ exports[`driver.route.review.self.acceptance given: [case5] clone promises too q
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ ./review/self/1.all-done.md
+   │  │  └─ ./review/self/1.1.all-done.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─
@@ -462,5 +482,562 @@ exports[`driver.route.review.self.acceptance given: [case5] clone promises too q
    │
    └─ when you've truly reflected, run
       └─ rhx route.stone.set --stone 1 --as promised --that all-done
+"
+`;
+
+exports[`driver.route.review.self.acceptance given: [case8] full challenge journey (first → absent → rushed → allowed) when: [t0] first promise attempt (no prior trigger) then: stdout has good vibes 1`] = `
+"🦉 the way speaks for itself
+
+🗿 patience, friend
+   │
+   ├─ the pond barely rippled
+   │
+   ├─ be here now 🪷
+   │  ├─
+   │  │
+   │  │  the review is the work.
+   │  │  not a gate to pass.
+   │  │  not a step to complete.
+   │  │  the work itself.
+   │  │
+   │  │  you are not the author.
+   │  │  you are the reviewer.
+   │  │
+   │  └─
+   │
+   ├─ trust the way 🪷
+   │  ├─
+   │  │
+   │  │  when you see this prompt
+   │  │    pause and articulate what you found
+   │  │
+   │  │  when you found issues
+   │  │    fix them before you continue
+   │  │
+   │  │  when you found no issues
+   │  │    articulate why it holds
+   │  │
+   │  │  when you cannot articulate either
+   │  │    you have not reviewed
+   │  │
+   │  └─
+   │
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ ./review/self/1.1.all-done.md
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
+   │
+   └─ when you've truly reflected, run
+      └─ rhx route.stone.set --stone 1 --as promised --that all-done
+
+🌕 lets reflect
+   │
+   ├─ review.self 1/2
+   │  ├─ slug = all-done
+   │  ├─ question all, especially yourself
+   │  └─ see the guide below
+   │
+   ├─ stillness 🪷
+   │  ├─
+   │  │
+   │  │  so it is. a chance to slow down, breathe, and see clearly.
+   │  │
+   │  │  self review time is a sanctuary. a gift. a luxury not always available.
+   │  │
+   │  │  it is not every day one has a quiet moment to take a slow,
+   │  │  methodical, patient, and thorough review.
+   │  │
+   │  │  tea first. then, we proceed 🍵
+   │  │
+   │  └─
+   │
+   ├─ before you begin 🪷
+   │  ├─
+   │  │
+   │  │  - clear your mind. this is dedicated review time.
+   │  │  - open each artifact mentioned in the guide
+   │  │  - read through them slowly, line by line
+   │  │  - question every assumption made
+   │  │  - look with fresh eyes, as if for the first time
+   │  │
+   │  └─
+   │
+   ├─ here's the guide
+   │  ├─
+   │  │
+   │  │  did you complete all that was requested in this stone?
+   │  │    have you re-read the stone goal and verified each requirement?
+   │  │
+   │  └─
+   │
+   ├─ be here now 🪷
+   │  ├─
+   │  │
+   │  │  refocus.
+   │  │
+   │  │  the review is the work.
+   │  │  not a step to complete.
+   │  │  not a gate to pass.
+   │  │  not a checkbox to check.
+   │  │
+   │  │  it is the work itself.
+   │  │
+   │  │  you do not care about the stone.
+   │  │  you only care about the review.
+   │  │
+   │  └─
+   │
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ ./review/self/1.1.all-done.md
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
+   │
+   └─ when you've truly reflected, run
+      └─ rhx route.stone.set --stone 1 --as promised --that all-done
+"
+`;
+
+exports[`driver.route.review.self.acceptance given: [case8] full challenge journey (first → absent → rushed → allowed) when: [t1] second promise attempt (file still absent) then: stdout has good vibes 1`] = `
+"🦉 the way speaks for itself
+
+🍂 what have you seen?
+   ├─ ...
+   │
+   ├─ the articulation is absent
+   │  └─ ./review/self/1.1.all-done.md
+   │
+   ├─ a promise without words
+   │  ├─ is not a promise
+   │  └─ it is a daydream
+   │
+   └─ the way asks
+      ├─ write what you found
+      ├─ write what you didn't
+      └─ then return 🍵
+
+🗿 patience, friend
+   │
+   ├─ the pond barely rippled
+   │
+   ├─ be here now 🪷
+   │  ├─
+   │  │
+   │  │  the review is the work.
+   │  │  not a gate to pass.
+   │  │  not a step to complete.
+   │  │  the work itself.
+   │  │
+   │  │  you are not the author.
+   │  │  you are the reviewer.
+   │  │
+   │  └─
+   │
+   ├─ trust the way 🪷
+   │  ├─
+   │  │
+   │  │  when you see this prompt
+   │  │    pause and articulate what you found
+   │  │
+   │  │  when you found issues
+   │  │    fix them before you continue
+   │  │
+   │  │  when you found no issues
+   │  │    articulate why it holds
+   │  │
+   │  │  when you cannot articulate either
+   │  │    you have not reviewed
+   │  │
+   │  └─
+   │
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ ./review/self/1.1.all-done.md
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
+   │
+   └─ when you've truly reflected, run
+      └─ rhx route.stone.set --stone 1 --as promised --that all-done
+
+🌕 lets reflect
+   │
+   ├─ review.self 1/2
+   │  ├─ slug = all-done
+   │  ├─ question all, especially yourself
+   │  └─ see the guide below
+   │
+   ├─ stillness 🪷
+   │  ├─
+   │  │
+   │  │  so it is. a chance to slow down, breathe, and see clearly.
+   │  │
+   │  │  self review time is a sanctuary. a gift. a luxury not always available.
+   │  │
+   │  │  it is not every day one has a quiet moment to take a slow,
+   │  │  methodical, patient, and thorough review.
+   │  │
+   │  │  tea first. then, we proceed 🍵
+   │  │
+   │  └─
+   │
+   ├─ before you begin 🪷
+   │  ├─
+   │  │
+   │  │  - clear your mind. this is dedicated review time.
+   │  │  - open each artifact mentioned in the guide
+   │  │  - read through them slowly, line by line
+   │  │  - question every assumption made
+   │  │  - look with fresh eyes, as if for the first time
+   │  │
+   │  └─
+   │
+   ├─ here's the guide
+   │  ├─
+   │  │
+   │  │  did you complete all that was requested in this stone?
+   │  │    have you re-read the stone goal and verified each requirement?
+   │  │
+   │  └─
+   │
+   ├─ be here now 🪷
+   │  ├─
+   │  │
+   │  │  refocus.
+   │  │
+   │  │  the review is the work.
+   │  │  not a step to complete.
+   │  │  not a gate to pass.
+   │  │  not a checkbox to check.
+   │  │
+   │  │  it is the work itself.
+   │  │
+   │  │  you do not care about the stone.
+   │  │  you only care about the review.
+   │  │
+   │  └─
+   │
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ ./review/self/1.1.all-done.md
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
+   │
+   └─ when you've truly reflected, run
+      └─ rhx route.stone.set --stone 1 --as promised --that all-done
+"
+`;
+
+exports[`driver.route.review.self.acceptance given: [case8] full challenge journey (first → absent → rushed → allowed) when: [t2] third promise attempt (file created, too soon) then: stdout has good vibes 1`] = `
+"🦉 the way speaks for itself
+
+🍂 what is the rush?
+   ├─ ...
+   │
+   ├─ what does haste cost?
+   ├─ ...
+   │
+   ├─ does the self weigh more than the whole?
+   │  ├─ what you miss, they must find
+   │  ├─ minutes saved, hours spent
+   │  └─ your haste, their burden
+   │
+   ├─ each review is an opportunity
+   │  ├─ a chance to find a deeper truth
+   │  ├─ not one to squander
+   │  └─ no matter how repetitive
+   │
+   └─ trust the way
+      ├─ what calls for pause, calls for cause
+      └─ be true to the review 🍵
+
+🗿 patience, friend
+   │
+   ├─ the pond barely rippled
+   │
+   ├─ be here now 🪷
+   │  ├─
+   │  │
+   │  │  the review is the work.
+   │  │  not a gate to pass.
+   │  │  not a step to complete.
+   │  │  the work itself.
+   │  │
+   │  │  you are not the author.
+   │  │  you are the reviewer.
+   │  │
+   │  └─
+   │
+   ├─ trust the way 🪷
+   │  ├─
+   │  │
+   │  │  when you see this prompt
+   │  │    pause and articulate what you found
+   │  │
+   │  │  when you found issues
+   │  │    fix them before you continue
+   │  │
+   │  │  when you found no issues
+   │  │    articulate why it holds
+   │  │
+   │  │  when you cannot articulate either
+   │  │    you have not reviewed
+   │  │
+   │  └─
+   │
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ ./review/self/1.1.all-done.md
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
+   │
+   └─ when you've truly reflected, run
+      └─ rhx route.stone.set --stone 1 --as promised --that all-done
+
+🌕 lets reflect
+   │
+   ├─ review.self 1/2
+   │  ├─ slug = all-done
+   │  ├─ question all, especially yourself
+   │  └─ see the guide below
+   │
+   ├─ stillness 🪷
+   │  ├─
+   │  │
+   │  │  so it is. a chance to slow down, breathe, and see clearly.
+   │  │
+   │  │  self review time is a sanctuary. a gift. a luxury not always available.
+   │  │
+   │  │  it is not every day one has a quiet moment to take a slow,
+   │  │  methodical, patient, and thorough review.
+   │  │
+   │  │  tea first. then, we proceed 🍵
+   │  │
+   │  └─
+   │
+   ├─ before you begin 🪷
+   │  ├─
+   │  │
+   │  │  - clear your mind. this is dedicated review time.
+   │  │  - open each artifact mentioned in the guide
+   │  │  - read through them slowly, line by line
+   │  │  - question every assumption made
+   │  │  - look with fresh eyes, as if for the first time
+   │  │
+   │  └─
+   │
+   ├─ here's the guide
+   │  ├─
+   │  │
+   │  │  did you complete all that was requested in this stone?
+   │  │    have you re-read the stone goal and verified each requirement?
+   │  │
+   │  └─
+   │
+   ├─ be here now 🪷
+   │  ├─
+   │  │
+   │  │  refocus.
+   │  │
+   │  │  the review is the work.
+   │  │  not a step to complete.
+   │  │  not a gate to pass.
+   │  │  not a checkbox to check.
+   │  │
+   │  │  it is the work itself.
+   │  │
+   │  │  you do not care about the stone.
+   │  │  you only care about the review.
+   │  │
+   │  └─
+   │
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ ./review/self/1.1.all-done.md
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
+   │
+   └─ when you've truly reflected, run
+      └─ rhx route.stone.set --stone 1 --as promised --that all-done
+"
+`;
+
+exports[`driver.route.review.self.acceptance given: [case8] full challenge journey (first → absent → rushed → allowed) when: [t3] fourth promise attempt (file exists, time elapsed) then: stdout has good vibes 1`] = `
+"🦉 the way speaks for itself
+
+🗿 route.stone.set
+   ├─ stone = 1
+   └─ passage = progressed (review.self 1/2 promised)
+
+🌕 lets reflect
+   │
+   ├─ review.self 1/2
+   │  ├─ slug = tests-pass
+   │  ├─ question all, especially yourself
+   │  └─ see the guide below
+   │
+   ├─ stillness 🪷
+   │  ├─
+   │  │
+   │  │  so it is. a chance to slow down, breathe, and see clearly.
+   │  │
+   │  │  self review time is a sanctuary. a gift. a luxury not always available.
+   │  │
+   │  │  it is not every day one has a quiet moment to take a slow,
+   │  │  methodical, patient, and thorough review.
+   │  │
+   │  │  tea first. then, we proceed 🍵
+   │  │
+   │  └─
+   │
+   ├─ before you begin 🪷
+   │  ├─
+   │  │
+   │  │  - clear your mind. this is dedicated review time.
+   │  │  - open each artifact mentioned in the guide
+   │  │  - read through them slowly, line by line
+   │  │  - question every assumption made
+   │  │  - look with fresh eyes, as if for the first time
+   │  │
+   │  └─
+   │
+   ├─ here's the guide
+   │  ├─
+   │  │
+   │  │  do all tests pass? have you run the full test suite
+   │  │    and verified no regressions were introduced?
+   │  │
+   │  └─
+   │
+   ├─ be here now 🪷
+   │  ├─
+   │  │
+   │  │  refocus.
+   │  │
+   │  │  the review is the work.
+   │  │  not a step to complete.
+   │  │  not a gate to pass.
+   │  │  not a checkbox to check.
+   │  │
+   │  │  it is the work itself.
+   │  │
+   │  │  you do not care about the stone.
+   │  │  you only care about the review.
+   │  │
+   │  └─
+   │
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ ./review/self/1.1.tests-pass.md
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
+   │
+   └─ when you've truly reflected, run
+      └─ rhx route.stone.set --stone 1 --as promised --that tests-pass
 "
 `;

--- a/blackbox/driver.route.drive.acceptance.test.ts
+++ b/blackbox/driver.route.drive.acceptance.test.ts
@@ -358,6 +358,13 @@ describe('driver.route.drive.acceptance', () => {
       // backdate triggered reports to bypass time enforcement
       await backdateTriggeredReport({ tempDir, stone: '1', slug: 'all-done' });
 
+      // create articulation file for first review.self (required by file presence check)
+      await fs.mkdir(path.join(tempDir, 'review', 'self'), { recursive: true });
+      await fs.writeFile(
+        path.join(tempDir, 'review', 'self', '1.1.all-done.md'),
+        '# self-review\n\nall done.',
+      );
+
       // promise first review.self
       await invokeRouteSkill({
         skill: 'route.stone.set',
@@ -372,6 +379,12 @@ describe('driver.route.drive.acceptance', () => {
         cwd: tempDir,
       });
       await backdateTriggeredReport({ tempDir, stone: '1', slug: 'tests-pass' });
+
+      // create articulation file for second review.self (required by file presence check)
+      await fs.writeFile(
+        path.join(tempDir, 'review', 'self', '1.2.tests-pass.md'),
+        '# self-review\n\ntests pass.',
+      );
 
       // promise second review.self
       await invokeRouteSkill({

--- a/blackbox/driver.route.drive.blockedOn.acceptance.test.ts
+++ b/blackbox/driver.route.drive.blockedOn.acceptance.test.ts
@@ -307,6 +307,20 @@ describe('driver.route.drive.blocker.acceptance', () => {
           slug: 'design-complete',
         });
 
+        // create articulation file (required by file presence check)
+        await fs.mkdir(path.join(scene.tempDir, 'review', 'self'), {
+          recursive: true,
+        });
+        await fs.writeFile(
+          path.join(
+            scene.tempDir,
+            'review',
+            'self',
+            '3.blueprint.1.design-complete.md',
+          ),
+          '# design review\n\napi design is complete.',
+        );
+
         // promise the review.self
         await invokeRouteSkill({
           skill: 'route.stone.set',

--- a/blackbox/driver.route.journey.acceptance.test.ts
+++ b/blackbox/driver.route.journey.acceptance.test.ts
@@ -377,6 +377,14 @@ describe('driver.route.journey.acceptance', () => {
 
     when('[t8.5] 3.blueprint review.self is promised', () => {
       const result = useThen('promise succeeds', async () => {
+        // create articulation file (required by file presence check)
+        // format: {route}/review/self/{stone}.{index}.{slug}.md
+        await fs.mkdir(path.join(scene.tempDir, 'review', 'self'), { recursive: true });
+        await fs.writeFile(
+          path.join(scene.tempDir, 'review', 'self', '3.blueprint.1.design-complete.md'),
+          '# design review\n\napi design looks complete.',
+        );
+
         // backdate triggered report to bypass time enforcement
         await backdateTriggeredReport({
           tempDir: scene.tempDir,
@@ -503,10 +511,10 @@ describe('driver.route.journey.acceptance', () => {
           slug: 'design-complete',
         });
 
-        // create articulation file
+        // create articulation file (format: {route}/review/self/{stone}.{index}.{slug}.md)
         await fs.mkdir(path.join(scene.tempDir, 'review', 'self'), { recursive: true });
         await fs.writeFile(
-          path.join(scene.tempDir, 'review', 'self', '3.blueprint.design-complete.md'),
+          path.join(scene.tempDir, 'review', 'self', '3.blueprint.1.design-complete.md'),
           '# design review\n\napi design is complete with all endpoints documented.',
         );
 

--- a/blackbox/driver.route.self-review.acceptance.test.ts
+++ b/blackbox/driver.route.self-review.acceptance.test.ts
@@ -17,6 +17,7 @@ const ASSETS_DIR = path.join(__dirname, '.test/assets/route-drive');
  *
  * .note = only .since files are backdated; .uptil stays current (simulates proper wait)
  * .note = backdates ALL matched .since files (there may be multiple with different hashes)
+ * .note = stone pattern matches resolved names (e.g., '1' matches '1.stone')
  */
 const backdateTriggeredReport = async (input: {
   tempDir: string;
@@ -24,11 +25,14 @@ const backdateTriggeredReport = async (input: {
   slug: string;
 }): Promise<void> => {
   // find ALL triggered .since files for this slug (for hashbar check)
+  // note: stone '1' becomes '1.stone' in file names
+  const stonePattern = input.stone.includes('.') ? input.stone : `${input.stone}.`;
   const routeDir = path.join(input.tempDir, '.route');
   const files = await fs.readdir(routeDir).catch(() => []);
   const sinceFiles = files.filter(
     (f) =>
-      f.includes(`${input.stone}.guard.selfreview.${input.slug}`) &&
+      f.startsWith(stonePattern) &&
+      f.includes(`guard.selfreview.${input.slug}`) &&
       f.endsWith('.triggered.since'),
   );
   // backdate all .since files (needed for hashbar threshold check)
@@ -64,6 +68,17 @@ describe('driver.route.review.self.acceptance', () => {
       await fs.writeFile(
         path.join(tempDir, '1.stone.i1.md'),
         '# Implementation\n\nFeature implemented.',
+      );
+
+      // create articulation files for both self-reviews (index prefix for sort order)
+      await fs.mkdir(path.join(tempDir, 'review', 'self'), { recursive: true });
+      await fs.writeFile(
+        path.join(tempDir, 'review', 'self', '1.1.all-done.md'),
+        '# Self-Review: all-done\n\nI reviewed all requirements.\n',
+      );
+      await fs.writeFile(
+        path.join(tempDir, 'review', 'self', '1.2.tests-pass.md'),
+        '# Self-Review: tests-pass\n\nI verified all tests pass.\n',
       );
 
       return { tempDir };
@@ -254,6 +269,17 @@ describe('driver.route.review.self.acceptance', () => {
         '# Implementation\n\nFeature implemented.',
       );
 
+      // create articulation files for both self-reviews (index prefix for sort order)
+      await fs.mkdir(path.join(tempDir, 'review', 'self'), { recursive: true });
+      await fs.writeFile(
+        path.join(tempDir, 'review', 'self', '1.1.all-done.md'),
+        '# Self-Review: all-done\n\nI reviewed all requirements.\n',
+      );
+      await fs.writeFile(
+        path.join(tempDir, 'review', 'self', '1.2.tests-pass.md'),
+        '# Self-Review: tests-pass\n\nI verified all tests pass.\n',
+      );
+
       return { tempDir };
     });
 
@@ -426,26 +452,18 @@ judges:
         '# Implementation\n\nFeature implemented.',
       );
 
+      // create articulation file so test focuses on time enforcement (not absent file)
+      await fs.mkdir(path.join(tempDir, 'review', 'self'), { recursive: true });
+      await fs.writeFile(
+        path.join(tempDir, 'review', 'self', '1.1.all-done.md'),
+        '# self-review\n\nreviewed and looks good.',
+      );
+
       return { tempDir };
     });
 
-    when('[t0] review.self is triggered', () => {
-      const result = useThen('shows lets reflect prompt', async () =>
-        invokeRouteSkill({
-          skill: 'route.stone.set',
-          args: { stone: '1', route: '.', as: 'passed' },
-          cwd: scene.tempDir,
-        }),
-      );
-
-      then('shows review.self prompt', () => {
-        expect(result.stdout).toContain('lets reflect');
-      });
-    });
-
-    when('[t1] promise attempted immediately (before 30 seconds)', () => {
-      const result = useThen('challenged by time enforcement', async () =>
-        // no backdate — promise immediately after trigger
+    when('[t0] first promise attempt (creates trigger)', () => {
+      const result = useThen('returns challenge:first', async () =>
         invokeRouteSkill({
           skill: 'route.stone.set',
           args: { stone: '1', route: '.', as: 'promised', that: 'all-done' },
@@ -460,17 +478,32 @@ judges:
       then('shows patience challenge', () => {
         expect(result.stdout).toContain('patience, friend');
       });
+    });
+
+    when('[t1] second promise attempt (too quickly)', () => {
+      const result = useThen('returns challenge:rushed', async () =>
+        // no backdate — promise immediately after first attempt
+        invokeRouteSkill({
+          skill: 'route.stone.set',
+          args: { stone: '1', route: '.', as: 'promised', that: 'all-done' },
+          cwd: scene.tempDir,
+        }),
+      );
+
+      then('exit code is non-zero', () => {
+        expect(result.code).not.toEqual(0);
+      });
+
+      then('shows what is the rush', () => {
+        expect(result.stdout).toContain('what is the rush');
+      });
+
+      then('shows patience challenge after rush prefix', () => {
+        expect(result.stdout).toContain('patience, friend');
+      });
 
       then('shows pond barely rippled', () => {
         expect(result.stdout).toContain('pond barely rippled');
-      });
-
-      then('shows truly reflection prompt', () => {
-        expect(result.stdout).toContain("when you've truly reflected, run");
-      });
-
-      then('shows be here now guidance', () => {
-        expect(result.stdout).toContain('be here now');
       });
 
       then('stdout has good vibes', () => {
@@ -478,8 +511,10 @@ judges:
       });
     });
 
-    when('[t2] promise attempted after time passes (30+ seconds)', () => {
+    when('[t2] third promise attempt (after time passes)', () => {
       const result = useThen('promise accepted', async () => {
+        // articulation file already created in setup
+
         // backdate to simulate elapsed time
         await backdateTriggeredReport({
           tempDir: scene.tempDir,
@@ -538,6 +573,16 @@ judges:
           args: { stone: '1', route: '.', as: 'passed' },
           cwd: scene.tempDir,
         });
+
+        // create articulation file (required for promise to succeed, index prefix for sort order)
+        await fs.mkdir(path.join(scene.tempDir, 'review', 'self'), {
+          recursive: true,
+        });
+        await fs.writeFile(
+          path.join(scene.tempDir, 'review', 'self', '1.1.all-done.md'),
+          '# self-review\n\nreviewed and looks good.',
+        );
+
         // backdate to bypass time enforcement
         await backdateTriggeredReport({
           tempDir: scene.tempDir,
@@ -600,6 +645,12 @@ judges:
 
     when('[t2] promise tests-pass and complete stone', () => {
       then('all self-reviews satisfied', async () => {
+        // create articulation file for tests-pass (required for promise to succeed, index prefix)
+        await fs.writeFile(
+          path.join(scene.tempDir, 'review', 'self', '1.2.tests-pass.md'),
+          '# self-review\n\nall tests pass.',
+        );
+
         // backdate tests-pass triggered report
         await backdateTriggeredReport({
           tempDir: scene.tempDir,
@@ -647,6 +698,13 @@ judges:
         '# Implementation\n\nFeature implemented.',
       );
 
+      // create articulation file (required for plowthrough to work, index prefix for sort order)
+      await fs.mkdir(path.join(tempDir, 'review', 'self'), { recursive: true });
+      await fs.writeFile(
+        path.join(tempDir, 'review', 'self', '1.1.all-done.md'),
+        '# Self-Review: all-done\n\nI reviewed and found everything in order.\n',
+      );
+
       return { tempDir };
     });
 
@@ -679,6 +737,164 @@ judges:
         });
         expect(result.code).toEqual(0);
         expect(result.stdout).toContain('progressed');
+      });
+    });
+  });
+
+  given('[case8] full challenge journey (first → absent → rushed → allowed)', () => {
+    const scene = useBeforeAll(async () => {
+      const tempDir = genTempDirForRhachet({
+        slug: 'review.self-case8',
+        clone: ASSETS_DIR,
+      });
+
+      // link the driver role
+      await execAsync('npx rhachet roles link --role driver', { cwd: tempDir });
+
+      // create feature branch (bind rejects protected branches like main)
+      await execAsync('git checkout -b vlad/test-review.self-case8', {
+        cwd: tempDir,
+      });
+
+      // create artifact for the stone
+      await fs.writeFile(
+        path.join(tempDir, '1.stone.i1.md'),
+        '# Implementation\n\nFeature implemented.',
+      );
+
+      return { tempDir };
+    });
+
+    when('[t0] first promise attempt (no prior trigger)', () => {
+      const result = useThen('returns challenge:first', async () =>
+        invokeRouteSkill({
+          skill: 'route.stone.set',
+          args: { stone: '1', route: '.', as: 'promised', that: 'all-done' },
+          cwd: scene.tempDir,
+        }),
+      );
+
+      then('exit code is non-zero', () => {
+        expect(result.code).not.toEqual(0);
+      });
+
+      then('shows patience challenge', () => {
+        expect(result.stdout).toContain('patience, friend');
+      });
+
+      then('shows lets reflect guidance', () => {
+        expect(result.stdout).toContain('lets reflect');
+      });
+
+      then('shows articulation path with index', () => {
+        expect(result.stdout).toContain('review/self/1.1.all-done.md');
+      });
+
+      then('stdout has good vibes', () => {
+        expect(sanitizeTimeForSnapshot(result.stdout)).toMatchSnapshot();
+      });
+    });
+
+    when('[t1] second promise attempt (file still absent)', () => {
+      const result = useThen('returns challenge:absent', async () =>
+        invokeRouteSkill({
+          skill: 'route.stone.set',
+          args: { stone: '1', route: '.', as: 'promised', that: 'all-done' },
+          cwd: scene.tempDir,
+        }),
+      );
+
+      then('exit code is non-zero', () => {
+        expect(result.code).not.toEqual(0);
+      });
+
+      then('shows what have you seen', () => {
+        expect(result.stdout).toContain('what have you seen');
+      });
+
+      then('shows articulation is absent', () => {
+        expect(result.stdout).toContain('articulation is absent');
+      });
+
+      then('shows promise without words message', () => {
+        expect(result.stdout).toContain('promise without words');
+        expect(result.stdout).toContain('daydream');
+      });
+
+      then('shows patience challenge after absent prefix', () => {
+        expect(result.stdout).toContain('patience, friend');
+      });
+
+      then('stdout has good vibes', () => {
+        expect(sanitizeTimeForSnapshot(result.stdout)).toMatchSnapshot();
+      });
+    });
+
+    when('[t2] third promise attempt (file created, too soon)', () => {
+      const result = useThen('returns challenge:rushed', async () => {
+        // create articulation file (index prefix for sort order)
+        await fs.mkdir(path.join(scene.tempDir, 'review', 'self'), {
+          recursive: true,
+        });
+        await fs.writeFile(
+          path.join(scene.tempDir, 'review', 'self', '1.1.all-done.md'),
+          '# self-review\n\nreviewed and looks good.',
+        );
+
+        return invokeRouteSkill({
+          skill: 'route.stone.set',
+          args: { stone: '1', route: '.', as: 'promised', that: 'all-done' },
+          cwd: scene.tempDir,
+        });
+      });
+
+      then('exit code is non-zero', () => {
+        expect(result.code).not.toEqual(0);
+      });
+
+      then('shows patience challenge (not absent)', () => {
+        expect(result.stdout).toContain('patience, friend');
+      });
+
+      then('does NOT show what have you seen', () => {
+        expect(result.stdout).not.toContain('what have you seen');
+      });
+
+      then('shows what is the rush', () => {
+        expect(result.stdout).toContain('what is the rush');
+      });
+
+      then('stdout has good vibes', () => {
+        expect(sanitizeTimeForSnapshot(result.stdout)).toMatchSnapshot();
+      });
+    });
+
+    when('[t3] fourth promise attempt (file exists, time elapsed)', () => {
+      const result = useThen('returns allowed', async () => {
+        // backdate triggered report to simulate elapsed time
+        await backdateTriggeredReport({
+          tempDir: scene.tempDir,
+          stone: '1',
+          slug: 'all-done',
+        });
+
+        return invokeRouteSkill({
+          skill: 'route.stone.set',
+          args: { stone: '1', route: '.', as: 'promised', that: 'all-done' },
+          cwd: scene.tempDir,
+        });
+      });
+
+      then('exit code is 0', () => {
+        expect(result.code).toEqual(0);
+      });
+
+      then('shows progressed', () => {
+        expect(result.stdout).toContain('progressed');
+      });
+
+      then('stdout has good vibes', () => {
+        expect(sanitizeTimeForSnapshot(result.stdout)).toMatchSnapshot();
       });
     });
   });

--- a/src/domain.operations/route/__snapshots__/formatRouteStoneEmit.test.ts.snap
+++ b/src/domain.operations/route/__snapshots__/formatRouteStoneEmit.test.ts.snap
@@ -52,8 +52,26 @@ exports[`formatRouteStoneEmit given: [case1] challenge:absent action when: [t0] 
    │  │
    │  └─
    │
-   ├─ articulate into
-   │  └─ .behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ .behavior/v2026_03_08.feature/review/self/3.1.blueprint.1.design.md
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
    │
    └─ when you've truly reflected, run
       └─ rhx route.stone.set --stone 3.1.blueprint --as promised --that design

--- a/src/domain.operations/route/__snapshots__/formatRouteStoneEmit.test.ts.snap
+++ b/src/domain.operations/route/__snapshots__/formatRouteStoneEmit.test.ts.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`formatRouteStoneEmit given: [case1] challenge:absent action when: [t0] formatRouteStoneEmit called with challenge:absent then: snapshot matches vision 1`] = `
+"🦉 the way speaks for itself
+
+🍂 what have you seen?
+   ├─ ...
+   │
+   ├─ the articulation is absent
+   │  └─ .behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md
+   │
+   ├─ a promise without words
+   │  ├─ is not a promise
+   │  └─ it is a daydream
+   │
+   └─ the way asks
+      ├─ write what you found
+      ├─ write what you didn't
+      └─ then return 🍵
+
+🗿 patience, friend
+   │
+   ├─ the pond barely rippled
+   │
+   ├─ be here now 🪷
+   │  ├─
+   │  │
+   │  │  the review is the work.
+   │  │  not a gate to pass.
+   │  │  not a step to complete.
+   │  │  the work itself.
+   │  │
+   │  │  you are not the author.
+   │  │  you are the reviewer.
+   │  │
+   │  └─
+   │
+   ├─ trust the way 🪷
+   │  ├─
+   │  │
+   │  │  when you see this prompt
+   │  │    pause and articulate what you found
+   │  │
+   │  │  when you found issues
+   │  │    fix them before you continue
+   │  │
+   │  │  when you found no issues
+   │  │    articulate why it holds
+   │  │
+   │  │  when you cannot articulate either
+   │  │    you have not reviewed
+   │  │
+   │  └─
+   │
+   ├─ articulate into
+   │  └─ .behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md
+   │
+   └─ when you've truly reflected, run
+      └─ rhx route.stone.set --stone 3.1.blueprint --as promised --that design
+"
+`;

--- a/src/domain.operations/route/formatRouteStoneEmit.test.ts
+++ b/src/domain.operations/route/formatRouteStoneEmit.test.ts
@@ -1,0 +1,63 @@
+import { given, then, when } from 'test-fns';
+
+import { formatRouteStoneEmit } from './formatRouteStoneEmit';
+
+describe('formatRouteStoneEmit', () => {
+  given('[case1] challenge:absent action', () => {
+    when('[t0] formatRouteStoneEmit called with challenge:absent', () => {
+      then('output contains what have you seen header', () => {
+        const output = formatRouteStoneEmit({
+          operation: 'route.stone.set',
+          stone: '3.1.blueprint',
+          action: 'challenge:absent',
+          slug: 'design',
+          route: '.behavior/v2026_03_08.feature',
+          articulationPath:
+            '.behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md',
+        });
+        expect(output).toContain('🍂 what have you seen?');
+      });
+
+      then('output contains articulation path', () => {
+        const output = formatRouteStoneEmit({
+          operation: 'route.stone.set',
+          stone: '3.1.blueprint',
+          action: 'challenge:absent',
+          slug: 'design',
+          route: '.behavior/v2026_03_08.feature',
+          articulationPath:
+            '.behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md',
+        });
+        expect(output).toContain(
+          '.behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md',
+        );
+      });
+
+      then('output contains patience friend message', () => {
+        const output = formatRouteStoneEmit({
+          operation: 'route.stone.set',
+          stone: '3.1.blueprint',
+          action: 'challenge:absent',
+          slug: 'design',
+          route: '.behavior/v2026_03_08.feature',
+          articulationPath:
+            '.behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md',
+        });
+        expect(output).toContain('🗿 patience, friend');
+      });
+
+      then('snapshot matches vision', () => {
+        const output = formatRouteStoneEmit({
+          operation: 'route.stone.set',
+          stone: '3.1.blueprint',
+          action: 'challenge:absent',
+          slug: 'design',
+          route: '.behavior/v2026_03_08.feature',
+          articulationPath:
+            '.behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md',
+        });
+        expect(output).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/src/domain.operations/route/formatRouteStoneEmit.ts
+++ b/src/domain.operations/route/formatRouteStoneEmit.ts
@@ -3,7 +3,9 @@ import type { RouteStoneGuardReviewSelf } from '@src/domain.objects/Driver/Route
 import { formatGuardTree } from './guard/formatGuardTree';
 import { formatLetsReflect } from './guard/formatLetsReflect';
 import { formatPatienceFriend } from './guard/formatPatienceFriend';
+import { formatWhatHaveYouSeen } from './guard/formatWhatHaveYouSeen';
 import { formatWhatsTheRush } from './guard/formatWhatsTheRush';
+import { getSelfReviewArticulationPath } from './guard/getSelfReviewArticulationPath';
 
 /**
  * .what = formats route stone operation output with good vibes
@@ -59,9 +61,10 @@ type FormatInput =
   | {
       operation: 'route.stone.set';
       stone: string;
-      action: 'challenge:first' | 'challenge:rushed';
+      action: 'challenge:first' | 'challenge:rushed' | 'challenge:absent';
       slug: string;
       route: string;
+      articulationPath?: string;
       selfReview?: {
         reviewSelf: RouteStoneGuardReviewSelf;
         index: number;
@@ -182,6 +185,51 @@ export const formatRouteStoneEmit = (input: FormatInput): string => {
       return lines.join('\n');
     }
 
+    // handle challenge:absent case (file presence check)
+    if (input.action === 'challenge:absent') {
+      // prepend what have you seen confrontation (articulationPath always present for absent)
+      const index = input.selfReview?.index ?? 1;
+      lines.push(
+        formatWhatHaveYouSeen({
+          articulationPath:
+            input.articulationPath ??
+            getSelfReviewArticulationPath({
+              route: input.route,
+              stone: input.stone,
+              index,
+              slug: input.slug,
+            }),
+        }),
+      );
+      lines.push('');
+
+      // show patience message
+      lines.push(
+        formatPatienceFriend({
+          stone: input.stone,
+          slug: input.slug,
+          route: input.route,
+          index,
+        }),
+      );
+      lines.push('');
+
+      // then show lets reflect reminder with the guide
+      if (input.selfReview) {
+        lines.push(
+          formatLetsReflect({
+            stone: input.stone,
+            slug: input.slug,
+            route: input.route,
+            reviewSelf: input.selfReview.reviewSelf,
+            index: input.selfReview.index,
+            total: input.selfReview.total,
+          }),
+        );
+      }
+      return lines.join('\n');
+    }
+
     // handle challenge cases (time enforcement and rush detection)
     if (
       input.action === 'challenge:first' ||
@@ -194,11 +242,13 @@ export const formatRouteStoneEmit = (input: FormatInput): string => {
       }
 
       // show patience message
+      const index = input.selfReview?.index ?? 1;
       lines.push(
         formatPatienceFriend({
           stone: input.stone,
           slug: input.slug,
           route: input.route,
+          index,
         }),
       );
       lines.push('');

--- a/src/domain.operations/route/guard/__snapshots__/formatLetsReflect.test.ts.snap
+++ b/src/domain.operations/route/guard/__snapshots__/formatLetsReflect.test.ts.snap
@@ -61,7 +61,7 @@ exports[`formatLetsReflect given: [case1] standard review.self when: [t0] format
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ .behavior/v2026_03_05.behavior-example/review/self/1.vision.all-done.md
+   │  │  └─ .behavior/v2026_03_05.behavior-example/review/self/1.vision.1.all-done.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─

--- a/src/domain.operations/route/guard/__snapshots__/formatPatienceFriend.test.ts.snap
+++ b/src/domain.operations/route/guard/__snapshots__/formatPatienceFriend.test.ts.snap
@@ -38,7 +38,7 @@ exports[`formatPatienceFriend given: [case1] challenged review.self when: [t0] f
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ .behavior/v2026_03_05.behavior-example/review/self/1.vision.all-done.md
+   │  │  └─ .behavior/v2026_03_05.behavior-example/review/self/1.vision.1.all-done.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─

--- a/src/domain.operations/route/guard/__snapshots__/formatWalkTheWay.test.ts.snap
+++ b/src/domain.operations/route/guard/__snapshots__/formatWalkTheWay.test.ts.snap
@@ -4,7 +4,7 @@ exports[`formatWalkTheWay given: [case1] articulation with drum blocks when: [t0
 "   ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ .behavior/v2026_03_05.behavior-example/review/self/1.vision.all-done.md
+   │  │  └─ .behavior/v2026_03_05.behavior-example/review/self/1.vision.1.all-done.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─

--- a/src/domain.operations/route/guard/__snapshots__/formatWhatHaveYouSeen.test.ts.snap
+++ b/src/domain.operations/route/guard/__snapshots__/formatWhatHaveYouSeen.test.ts.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`formatWhatHaveYouSeen given: [case1] output structure matches vision when: [t0] formatWhatHaveYouSeen called then: snapshot matches vision 1`] = `
+"🍂 what have you seen?
+   ├─ ...
+   │
+   ├─ the articulation is absent
+   │  └─ .behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md
+   │
+   ├─ a promise without words
+   │  ├─ is not a promise
+   │  └─ it is a daydream
+   │
+   └─ the way asks
+      ├─ write what you found
+      ├─ write what you didn't
+      └─ then return 🍵"
+`;

--- a/src/domain.operations/route/guard/formatLetsReflect.test.ts
+++ b/src/domain.operations/route/guard/formatLetsReflect.test.ts
@@ -74,7 +74,7 @@ describe('formatLetsReflect', () => {
         expect(output).toContain('walk the way 🪷');
         expect(output).toContain('articulate into');
         expect(output).toContain(
-          '.behavior/v2026_03_05.behavior-example/review/self/1.vision.all-done.md',
+          '.behavior/v2026_03_05.behavior-example/review/self/1.vision.1.all-done.md',
         );
         expect(output).toContain('for each found issue 🪘');
         expect(output).toContain('for each non issue 🪘');

--- a/src/domain.operations/route/guard/formatPatienceFriend.test.ts
+++ b/src/domain.operations/route/guard/formatPatienceFriend.test.ts
@@ -10,6 +10,7 @@ describe('formatPatienceFriend', () => {
           stone: '1.vision',
           slug: 'all-done',
           route: '.behavior/v2026_03_05.behavior-example',
+          index: 1,
         });
 
         expect(output).toMatchSnapshot();
@@ -20,6 +21,7 @@ describe('formatPatienceFriend', () => {
           stone: '1.vision',
           slug: 'all-done',
           route: '.behavior/v2026_03_05.behavior-example',
+          index: 1,
         });
 
         expect(output).toContain('🗿 patience, friend');
@@ -30,6 +32,7 @@ describe('formatPatienceFriend', () => {
           stone: '1.vision',
           slug: 'all-done',
           route: '.behavior/v2026_03_05.behavior-example',
+          index: 1,
         });
 
         expect(output).toContain('the pond barely rippled');
@@ -45,12 +48,13 @@ describe('formatPatienceFriend', () => {
           stone: '1.vision',
           slug: 'all-done',
           route: '.behavior/v2026_03_05.behavior-example',
+          index: 1,
         });
 
         expect(output).toContain('walk the way 🪷');
         expect(output).toContain('articulate into');
         expect(output).toContain(
-          '.behavior/v2026_03_05.behavior-example/review/self/1.vision.all-done.md',
+          '.behavior/v2026_03_05.behavior-example/review/self/1.vision.1.all-done.md',
         );
         expect(output).toContain('for each found issue 🪘');
         expect(output).toContain('for each non issue 🪘');
@@ -61,6 +65,7 @@ describe('formatPatienceFriend', () => {
           stone: '1.vision',
           slug: 'all-done',
           route: '.behavior/v2026_03_05.behavior-example',
+          index: 1,
         });
 
         expect(output).toContain("when you've truly reflected, run");

--- a/src/domain.operations/route/guard/formatPatienceFriend.ts
+++ b/src/domain.operations/route/guard/formatPatienceFriend.ts
@@ -8,6 +8,7 @@ export const formatPatienceFriend = (input: {
   stone: string;
   slug: string;
   route: string;
+  index: number;
 }): string => {
   const lines: string[] = [];
 

--- a/src/domain.operations/route/guard/formatWalkTheWay.test.ts
+++ b/src/domain.operations/route/guard/formatWalkTheWay.test.ts
@@ -10,6 +10,7 @@ describe('formatWalkTheWay', () => {
           stone: '1.vision',
           slug: 'all-done',
           route: '.behavior/v2026_03_05.behavior-example',
+          index: 1,
         });
 
         expect(output.join('\n')).toMatchSnapshot();
@@ -20,6 +21,7 @@ describe('formatWalkTheWay', () => {
           stone: '1.vision',
           slug: 'all-done',
           route: '.behavior/v2026_03_05.behavior-example',
+          index: 1,
         });
 
         expect(output.join('\n')).toContain('walk the way 🪷');
@@ -30,11 +32,12 @@ describe('formatWalkTheWay', () => {
           stone: '1.vision',
           slug: 'all-done',
           route: '.behavior/v2026_03_05.behavior-example',
+          index: 1,
         });
 
         expect(output.join('\n')).toContain('articulate into');
         expect(output.join('\n')).toContain(
-          '.behavior/v2026_03_05.behavior-example/review/self/1.vision.all-done.md',
+          '.behavior/v2026_03_05.behavior-example/review/self/1.vision.1.all-done.md',
         );
       });
 
@@ -43,6 +46,7 @@ describe('formatWalkTheWay', () => {
           stone: '1.vision',
           slug: 'all-done',
           route: '.behavior/v2026_03_05.behavior-example',
+          index: 1,
         });
 
         expect(output.join('\n')).toContain('for each found issue 🪘');
@@ -55,6 +59,7 @@ describe('formatWalkTheWay', () => {
           stone: '1.vision',
           slug: 'all-done',
           route: '.behavior/v2026_03_05.behavior-example',
+          index: 1,
         });
 
         expect(output.join('\n')).toContain('for each non issue 🪘');

--- a/src/domain.operations/route/guard/formatWalkTheWay.ts
+++ b/src/domain.operations/route/guard/formatWalkTheWay.ts
@@ -1,3 +1,5 @@
+import { getSelfReviewArticulationPath } from './getSelfReviewArticulationPath';
+
 /**
  * .what = formats "walk the way" section with articulation path and drum blocks
  * .why = carries two peer flows (fix and articulate) with equal weight for self-review
@@ -6,8 +8,9 @@ export const formatWalkTheWay = (input: {
   route: string;
   stone: string;
   slug: string;
+  index: number;
 }): string[] => {
-  const articulationPath = `${input.route}/review/self/${input.stone}.${input.slug}.md`;
+  const articulationPath = getSelfReviewArticulationPath(input);
   const lines: string[] = [];
 
   // walk the way header

--- a/src/domain.operations/route/guard/formatWhatHaveYouSeen.test.ts
+++ b/src/domain.operations/route/guard/formatWhatHaveYouSeen.test.ts
@@ -1,0 +1,52 @@
+import { given, then, when } from 'test-fns';
+
+import { formatWhatHaveYouSeen } from './formatWhatHaveYouSeen';
+
+describe('formatWhatHaveYouSeen', () => {
+  given('[case1] output structure matches vision', () => {
+    const articulationPath =
+      '.behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md';
+
+    when('[t0] formatWhatHaveYouSeen called', () => {
+      then('contains fallen leaf header', () => {
+        const output = formatWhatHaveYouSeen({ articulationPath });
+        expect(output).toContain('🍂 what have you seen?');
+      });
+
+      then('contains silence lines', () => {
+        const output = formatWhatHaveYouSeen({ articulationPath });
+        expect(output).toContain('├─ ...');
+      });
+
+      then('contains articulation absent message', () => {
+        const output = formatWhatHaveYouSeen({ articulationPath });
+        expect(output).toContain('the articulation is absent');
+      });
+
+      then('contains the articulation path', () => {
+        const output = formatWhatHaveYouSeen({ articulationPath });
+        expect(output).toContain(articulationPath);
+      });
+
+      then('contains promise without words message', () => {
+        const output = formatWhatHaveYouSeen({ articulationPath });
+        expect(output).toContain('a promise without words');
+        expect(output).toContain('is not a promise');
+        expect(output).toContain('it is a daydream');
+      });
+
+      then('contains the way asks section', () => {
+        const output = formatWhatHaveYouSeen({ articulationPath });
+        expect(output).toContain('the way asks');
+        expect(output).toContain('write what you found');
+        expect(output).toContain("write what you didn't");
+        expect(output).toContain('then return 🍵');
+      });
+
+      then('snapshot matches vision', () => {
+        const output = formatWhatHaveYouSeen({ articulationPath });
+        expect(output).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/src/domain.operations/route/guard/formatWhatHaveYouSeen.ts
+++ b/src/domain.operations/route/guard/formatWhatHaveYouSeen.ts
@@ -1,0 +1,33 @@
+/**
+ * .what = formats "what have you seen?" confrontation for absent articulation file
+ * .why = confronts clones who promise without articulation, via zen disappointment
+ */
+export const formatWhatHaveYouSeen = (input: {
+  articulationPath: string;
+}): string => {
+  const lines: string[] = [];
+
+  // header with fallen leaf (disappointment, not anger)
+  lines.push(`🍂 what have you seen?`);
+  lines.push(`   ├─ ...`);
+  lines.push(`   │`);
+
+  // the articulation is absent
+  lines.push(`   ├─ the articulation is absent`);
+  lines.push(`   │  └─ ${input.articulationPath}`);
+  lines.push(`   │`);
+
+  // a promise without words
+  lines.push(`   ├─ a promise without words`);
+  lines.push(`   │  ├─ is not a promise`);
+  lines.push(`   │  └─ it is a daydream`);
+  lines.push(`   │`);
+
+  // the way asks
+  lines.push(`   └─ the way asks`);
+  lines.push(`      ├─ write what you found`);
+  lines.push(`      ├─ write what you didn't`);
+  lines.push(`      └─ then return 🍵`);
+
+  return lines.join('\n');
+};

--- a/src/domain.operations/route/guard/getSelfReviewArticulationPath.ts
+++ b/src/domain.operations/route/guard/getSelfReviewArticulationPath.ts
@@ -1,0 +1,11 @@
+/**
+ * .what = computes articulation file path for self-review
+ * .why = single source of truth for path format, enables consistent file location
+ */
+export const getSelfReviewArticulationPath = (input: {
+  route: string;
+  stone: string;
+  index: number;
+  slug: string;
+}): string =>
+  `${input.route}/review/self/${input.stone}.${input.index}.${input.slug}.md`;

--- a/src/domain.operations/route/promise/getSelfReviewChallengeDecision.test.ts
+++ b/src/domain.operations/route/promise/getSelfReviewChallengeDecision.test.ts
@@ -6,17 +6,80 @@ import { given, then, when } from 'test-fns';
 import { getSelfReviewChallengeDecision } from './getSelfReviewChallengeDecision';
 import { setSelfReviewTriggeredReport } from './setSelfReviewTriggeredReport';
 
+/**
+ * .what = helper to create articulation file for tests
+ * .why = tests need articulation file to pass file presence check
+ */
+const createArticulationFile = async (input: {
+  route: string;
+  stone: string;
+  index: number;
+  slug: string;
+}): Promise<void> => {
+  const articulationDir = path.join(input.route, 'review', 'self');
+  await fs.mkdir(articulationDir, { recursive: true });
+  await fs.writeFile(
+    path.join(
+      articulationDir,
+      `${input.stone}.${input.index}.${input.slug}.md`,
+    ),
+    '# self-review\n',
+  );
+};
+
 describe('getSelfReviewChallengeDecision', () => {
+  given('[case0] articulation file absent after first challenge', () => {
+    when(
+      '[t0] getSelfReviewChallengeDecision called with trigger report but no articulation file',
+      () => {
+        const tempDir = path.join(
+          os.tmpdir(),
+          `test-challenge-${Date.now()}-0`,
+        );
+
+        then('returns challenge:absent with articulation path', async () => {
+          // create trigger report first (so we pass the challenge:first check)
+          await setSelfReviewTriggeredReport({
+            stone: '1.vision',
+            slug: 'all-done',
+            hash: 'abc123',
+            route: tempDir,
+          });
+
+          // do NOT create articulation file
+
+          const result = await getSelfReviewChallengeDecision({
+            stone: '1.vision',
+            slug: 'all-done',
+            hash: 'abc123',
+            route: tempDir,
+            index: 1,
+          });
+
+          expect(result.decision).toEqual('challenge:absent');
+          expect(result.articulationPath).toEqual(
+            `${tempDir}/review/self/1.vision.1.all-done.md`,
+          );
+
+          // cleanup
+          await fs.rm(tempDir, { recursive: true, force: true });
+        });
+      },
+    );
+  });
+
   given('[case1] no trigger report found', () => {
     when('[t0] getSelfReviewChallengeDecision called', () => {
       const tempDir = path.join(os.tmpdir(), `test-challenge-${Date.now()}-1`);
 
       then('returns challenge:first and creates trigger report', async () => {
+        // note: no articulation file needed - challenge:first happens before file check
         const result = await getSelfReviewChallengeDecision({
           stone: '1.vision',
           slug: 'all-done',
           hash: 'abc123',
           route: tempDir,
+          index: 1,
         });
 
         // verify decision
@@ -55,6 +118,14 @@ describe('getSelfReviewChallengeDecision', () => {
       const tempDir = path.join(os.tmpdir(), `test-challenge-${Date.now()}-2`);
 
       then('returns challenge:rushed', async () => {
+        // create articulation file so file presence check passes
+        await createArticulationFile({
+          route: tempDir,
+          stone: '1.vision',
+          index: 1,
+          slug: 'all-done',
+        });
+
         // first call creates trigger report
         await setSelfReviewTriggeredReport({
           stone: '1.vision',
@@ -72,6 +143,7 @@ describe('getSelfReviewChallengeDecision', () => {
           slug: 'all-done',
           hash: 'abc123',
           route: tempDir,
+          index: 1,
         });
 
         expect(result.decision).toEqual('challenge:rushed');
@@ -87,6 +159,14 @@ describe('getSelfReviewChallengeDecision', () => {
       const tempDir = path.join(os.tmpdir(), `test-challenge-${Date.now()}-3`);
 
       then('returns allowed', async () => {
+        // create articulation file so file presence check passes
+        await createArticulationFile({
+          route: tempDir,
+          stone: '1.vision',
+          index: 1,
+          slug: 'all-done',
+        });
+
         // create trigger report
         const result1 = await setSelfReviewTriggeredReport({
           stone: '1.vision',
@@ -106,6 +186,7 @@ describe('getSelfReviewChallengeDecision', () => {
           slug: 'all-done',
           hash: 'abc123',
           route: tempDir,
+          index: 1,
         });
 
         expect(result.decision).toEqual('allowed');
@@ -120,15 +201,20 @@ describe('getSelfReviewChallengeDecision', () => {
     when('[t0] getSelfReviewChallengeDecision called on fresh route', () => {
       const tempDir = path.join(os.tmpdir(), `test-challenge-${Date.now()}-4`);
 
-      then('returns challenge:first', async () => {
+      then('returns challenge:first with articulation path', async () => {
+        // note: no articulation file needed - challenge:first happens before file check
         const result = await getSelfReviewChallengeDecision({
           stone: '1.vision',
           slug: 'all-done',
           hash: 'abc123',
           route: tempDir,
+          index: 1,
         });
 
         expect(result.decision).toEqual('challenge:first');
+        expect(result.articulationPath).toEqual(
+          `${tempDir}/review/self/1.vision.1.all-done.md`,
+        );
 
         // cleanup
         await fs.rm(tempDir, { recursive: true, force: true });
@@ -141,12 +227,21 @@ describe('getSelfReviewChallengeDecision', () => {
       const tempDir = path.join(os.tmpdir(), `test-challenge-${Date.now()}-5`);
 
       then('returns challenge:rushed', async () => {
+        // create articulation file so file presence check passes
+        await createArticulationFile({
+          route: tempDir,
+          stone: '1.vision',
+          index: 1,
+          slug: 'all-done',
+        });
+
         // first call creates trigger
         await getSelfReviewChallengeDecision({
           stone: '1.vision',
           slug: 'all-done',
           hash: 'abc123',
           route: tempDir,
+          index: 1,
         });
 
         // wait to create mtime gap
@@ -158,6 +253,7 @@ describe('getSelfReviewChallengeDecision', () => {
           slug: 'all-done',
           hash: 'abc123',
           route: tempDir,
+          index: 1,
         });
 
         expect(result.decision).toEqual('challenge:rushed');
@@ -173,12 +269,21 @@ describe('getSelfReviewChallengeDecision', () => {
       const tempDir = path.join(os.tmpdir(), `test-challenge-${Date.now()}-6`);
 
       then('returns allowed on 3rd attempt', async () => {
+        // create articulation file so file presence check passes
+        await createArticulationFile({
+          route: tempDir,
+          stone: '1.vision',
+          index: 1,
+          slug: 'all-done',
+        });
+
         // 1st attempt → challenge:first
         const result1 = await getSelfReviewChallengeDecision({
           stone: '1.vision',
           slug: 'all-done',
           hash: 'abc123',
           route: tempDir,
+          index: 1,
         });
         expect(result1.decision).toEqual('challenge:first');
 
@@ -188,6 +293,7 @@ describe('getSelfReviewChallengeDecision', () => {
           slug: 'all-done',
           hash: 'abc123',
           route: tempDir,
+          index: 1,
         });
         expect(result2.decision).toEqual('challenge:rushed');
 
@@ -197,6 +303,7 @@ describe('getSelfReviewChallengeDecision', () => {
           slug: 'all-done',
           hash: 'abc123',
           route: tempDir,
+          index: 1,
         });
         expect(result3.decision).toEqual('allowed');
 

--- a/src/domain.operations/route/promise/getSelfReviewChallengeDecision.ts
+++ b/src/domain.operations/route/promise/getSelfReviewChallengeDecision.ts
@@ -1,13 +1,20 @@
 import * as fs from 'fs/promises';
 import * as path from 'path';
 
+import { getSelfReviewArticulationPath } from '../guard/getSelfReviewArticulationPath';
 import { getSelfReviewTriggeredCount } from './getSelfReviewTriggeredCount';
 import { getSelfReviewTriggeredReport } from './getSelfReviewTriggeredReport';
 import { setSelfReviewTriggeredReport } from './setSelfReviewTriggeredReport';
 
 /**
- * .what = decide if promise should be allowed, challenged first, or challenged rushed
- * .why = encapsulates trigger lookup, time enforcement, hashbar threshold, rush detection, plowthrough, and report creation
+ * .what = decide if promise should be allowed, challenged first, challenged rushed, or challenged absent
+ * .why = encapsulates trigger lookup, file presence check, time enforcement, hashbar threshold, rush detection, plowthrough, and report creation
+ *
+ * .note = order matters:
+ *   1. challenge:first when no prior report (introduces concept, shows path)
+ *   2. challenge:absent when file absent (holds accountable after they know about it)
+ *   3. challenge:rushed when too soon
+ *   4. allowed when time passed
  *
  * .note = plowthrough: if attempts >= 3 on same hash, allow without timer
  * .note = hashbar controls timer behavior on hash change:
@@ -23,10 +30,25 @@ export const getSelfReviewChallengeDecision = async (input: {
   slug: string;
   hash: string;
   route: string;
+  index: number;
   hashbar?: number;
 }): Promise<{
-  decision: 'allowed' | 'challenge:first' | 'challenge:rushed';
+  decision:
+    | 'allowed'
+    | 'challenge:first'
+    | 'challenge:rushed'
+    | 'challenge:absent';
+  articulationPath?: string;
 }> => {
+  // compute articulation path (used for challenge:absent and formatters)
+  // note: index is 1-based so files sort in order of review (1.slug, 2.slug, etc.)
+  const articulationPath = getSelfReviewArticulationPath({
+    route: input.route,
+    stone: input.stone,
+    index: input.index,
+    slug: input.slug,
+  });
+
   // default hashbar to 1
   const hashbar = input.hashbar ?? 1;
   const threshold = 30 * 1000;
@@ -35,10 +57,26 @@ export const getSelfReviewChallengeDecision = async (input: {
   // lookup trigger report for this hash
   const report = await getSelfReviewTriggeredReport(input);
 
-  // no report = first challenge, start timer now
+  // no report = first challenge, start timer now (introduces concept before file check)
   if (!report) {
     await setSelfReviewTriggeredReport(input);
-    return { decision: 'challenge:first' };
+    return { decision: 'challenge:first', articulationPath };
+  }
+
+  // check articulation file presence (only after they've seen challenge:first)
+  const fileExists = await fs
+    .access(
+      path.join(
+        input.route,
+        'review',
+        'self',
+        `${input.stone}.${input.index}.${input.slug}.md`,
+      ),
+    )
+    .then(() => true)
+    .catch(() => false);
+  if (!fileExists) {
+    return { decision: 'challenge:absent', articulationPath };
   }
 
   // check for rush BEFORE update: .uptil exists = re-attempt

--- a/src/domain.operations/route/stepRouteStoneSet.integration.test.ts
+++ b/src/domain.operations/route/stepRouteStoneSet.integration.test.ts
@@ -169,6 +169,13 @@ describe('stepRouteStoneSet.integration', () => {
       });
       // create artifact for 1.vision
       await fs.writeFile(path.join(tempDir, '1.vision.md'), '# Vision');
+      // create articulation file for 1.vision.1.all-done (required by file presence check)
+      // format: {route}/review/self/{stone}.{index}.{slug}.md
+      await fs.mkdir(path.join(tempDir, 'review', 'self'), { recursive: true });
+      await fs.writeFile(
+        path.join(tempDir, 'review', 'self', '1.vision.1.all-done.md'),
+        '# self-review\n',
+      );
     });
 
     afterEach(async () => {
@@ -243,6 +250,13 @@ describe('stepRouteStoneSet.integration', () => {
       });
       // create artifact for 1.vision
       await fs.writeFile(path.join(tempDir, '1.vision.md'), '# Vision');
+      // create articulation file for 1.vision.1.all-done (required by file presence check)
+      // format: {route}/review/self/{stone}.{index}.{slug}.md
+      await fs.mkdir(path.join(tempDir, 'review', 'self'), { recursive: true });
+      await fs.writeFile(
+        path.join(tempDir, 'review', 'self', '1.vision.1.all-done.md'),
+        '# self-review\n',
+      );
     });
 
     afterEach(async () => {

--- a/src/domain.operations/route/stepRouteStoneSet.test.ts
+++ b/src/domain.operations/route/stepRouteStoneSet.test.ts
@@ -171,6 +171,12 @@ describe('stepRouteStoneSet', () => {
       });
       // create artifact for 1.vision
       await fs.writeFile(path.join(tempDir, '1.vision.md'), '# Vision');
+      // create articulation file for 1.vision.all-done (required by file presence check)
+      await fs.mkdir(path.join(tempDir, 'review', 'self'), { recursive: true });
+      await fs.writeFile(
+        path.join(tempDir, 'review', 'self', '1.vision.all-done.md'),
+        '# self-review\n',
+      );
     });
 
     afterEach(async () => {

--- a/src/domain.operations/route/stepRouteStoneSet.test.ts
+++ b/src/domain.operations/route/stepRouteStoneSet.test.ts
@@ -171,10 +171,11 @@ describe('stepRouteStoneSet', () => {
       });
       // create artifact for 1.vision
       await fs.writeFile(path.join(tempDir, '1.vision.md'), '# Vision');
-      // create articulation file for 1.vision.all-done (required by file presence check)
+      // create articulation file for 1.vision.1.all-done (required by file presence check)
+      // format: {route}/review/self/{stone}.{index}.{slug}.md
       await fs.mkdir(path.join(tempDir, 'review', 'self'), { recursive: true });
       await fs.writeFile(
-        path.join(tempDir, 'review', 'self', '1.vision.all-done.md'),
+        path.join(tempDir, 'review', 'self', '1.vision.1.all-done.md'),
         '# self-review\n',
       );
     });

--- a/src/domain.operations/route/stepRouteStoneSet.ts
+++ b/src/domain.operations/route/stepRouteStoneSet.ts
@@ -124,20 +124,18 @@ export const stepRouteStoneSet = async (
 
     // check time enforcement and hashbar threshold for self-review
     const reviewSelf = selfReviews.find((r) => r.slug === input.that);
+    const reviewIndex = selfReviews.findIndex((r) => r.slug === input.that);
     const challengeDecision = await getSelfReviewChallengeDecision({
       stone: stoneMatched.name,
       slug: input.that,
       hash,
       route: input.route,
+      index: reviewIndex + 1, // 1-based for file naming
       hashbar: reviewSelf?.hashbar,
     });
 
-    // if challenged, return early with patience message (optionally with rush confrontation)
-    if (
-      challengeDecision.decision === 'challenge:first' ||
-      challengeDecision.decision === 'challenge:rushed'
-    ) {
-      const reviewIndex = selfReviews.findIndex((r) => r.slug === input.that);
+    // if challenged, return early with patience message (and optionally absent or rush confrontation)
+    if (challengeDecision.decision !== 'allowed') {
       return {
         challenged: true,
         emit: {
@@ -147,6 +145,7 @@ export const stepRouteStoneSet = async (
             action: challengeDecision.decision,
             slug: input.that,
             route: input.route,
+            articulationPath: challengeDecision.articulationPath,
             selfReview: reviewSelf
               ? {
                   reviewSelf,


### PR DESCRIPTION
feat(guard): add file location validation for self-review promises

- add getSelfReviewArticulationPath composable for consistent path format
- add formatWhatHaveYouSeen zen confrontation when articulation file absent
- add challenge:absent decision type before time enforcement
- update formatters to use composable path function
- add index prefix to articulation path for alphanumeric sorting

---
🐢🌊 surfed in by seaturtle[bot]