### PR TITLE
fix(route): add "walk the way" section to selfreview stdout

### DIFF
--- a/.behavior/v2026_03_11.selfreview-fix-clarify/.bind/vlad.selfreview-fix-clarify.flag
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/.bind/vlad.selfreview-fix-clarify.flag
@@ -1,0 +1,2 @@
+branch: vlad/selfreview-fix-clarify
+bound_by: init.behavior skill

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/.ref.[feedback].v1.[given].by_human.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/.ref.[feedback].v1.[given].by_human.md
@@ -1,0 +1,27 @@
+emit your response to the feedback into
+- .behavior/v2026_03_11.selfreview-fix-clarify/$BEHAVIOR_REF_NAME.[feedback].v$FEEDBACK_VERSION.[taken].by_robot.md
+
+1. emit your response checklist
+2. exec your response plan
+3. emit your response checkoffs into the checklist
+
+---
+
+first, bootup your mechanics briefs again
+
+npx rhachet roles boot --repo ehmpathy --role mechanic
+
+---
+---
+---
+
+
+# blocker.1
+
+---
+
+# nitpick.2
+
+---
+
+# blocker.3

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/.route/.bind.vlad.selfreview-fix-clarify.flag
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/.route/.bind.vlad.selfreview-fix-clarify.flag
@@ -1,0 +1,2 @@
+branch: vlad/selfreview-fix-clarify
+bound_by: route.bind skill

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/.route/.gitignore
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/.route/.gitignore
@@ -1,0 +1,5 @@
+# ignore all except passage.jsonl and .bind flags
+*
+!.gitignore
+!passage.jsonl
+!.bind.*

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/.route/passage.jsonl
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/.route/passage.jsonl
@@ -1,0 +1,25 @@
+{"stone":"1.vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-questioned-requirements"}
+{"stone":"1.vision","status":"blocked","blocker":"approval","reason":"wait for human approval"}
+{"stone":"1.vision","status":"approved"}
+{"stone":"1.vision","status":"passed"}
+{"stone":"2.1.criteria.blackbox","status":"passed"}
+{"stone":"2.2.criteria.blackbox.matrix","status":"passed"}
+{"stone":"3.1.3.research.internal.product.code.prod._.v1","status":"passed"}
+{"stone":"3.1.3.research.internal.product.code.test._.v1","status":"passed"}
+{"stone":"3.1.4.research.internal.factory.blockers._.v1","status":"passed"}
+{"stone":"3.1.4.research.internal.factory.opports._.v1","status":"passed"}
+{"stone":"3.2.distill.domain._.v1","status":"passed"}
+{"stone":"3.2.distill.factory.upgrades._.v1","status":"passed"}
+{"stone":"3.2.distill.repros.experience._.v1","status":"passed"}
+{"stone":"3.3.0.blueprint.factory.v1","status":"passed"}
+{"stone":"3.3.1.blueprint.product.v1","status":"blocked","blocker":"review.self","reason":"review.self required: has-questioned-deletables"}
+{"stone":"3.3.1.blueprint.product.v1","status":"blocked","blocker":"approval","reason":"wait for human approval"}
+{"stone":"3.3.1.blueprint.product.v1","status":"approved"}
+{"stone":"3.3.1.blueprint.product.v1","status":"passed"}
+{"stone":"4.1.roadmap.v1","status":"passed"}
+{"stone":"5.1.execution.phase0_to_phaseN.v1","status":"blocked","blocker":"review.self","reason":"review.self required: has-pruned-yagni"}
+{"stone":"5.1.execution.phase0_to_phaseN.v1","status":"passed"}
+{"stone":"5.3.verification.v1","status":"blocked","blocker":"review.self","reason":"review.self required: has-behavior-coverage"}
+{"stone":"5.3.verification.v1","status":"passed"}
+{"stone":"5.5.playtest.v1","status":"blocked","blocker":"review.self","reason":"review.self required: has-clear-instructions"}
+{"stone":"5.5.playtest.v1","status":"blocked","blocker":"approval","reason":"wait for human approval"}

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/0.wish.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/0.wish.md
@@ -1,0 +1,16 @@
+wish =
+
+selfreview stdout should make it clear that not only should the review be articulated
+
+but any defects caught should also be fixed
+
+i.e., frame it in two questions
+
+did you articulate?
+
+did you initiate? (take initiative)
+
+except in a way that matches the zen iam bhrain owl role 
+
+and in a way that propogates zen and uncle-iroh philosophies
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/1.vision.guard
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/1.vision.guard
@@ -1,0 +1,57 @@
+# guard for vision stone
+#
+# requires human approval before stone can be marked as passed
+# because the self-review prompts require human feedback,
+# the process needs to halt here for human review
+
+judges:
+  - npx rhachet run --repo bhrain --skill route.stone.judge --mechanism approved? --stone $stone --route $route
+
+reviews:
+  self:
+    - slug: has-questioned-requirements
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any requirements that should be questioned?
+
+        for each requirement, ask:
+        - who said this was needed? when? why?
+        - what evidence supports this requirement?
+        - what if we didn't do this — what would happen?
+        - is the scope too large, too small, or misdirected?
+        - could we achieve the goal in a simpler way?
+
+        challenge each requirement and justify why it belongs.
+
+    - slug: has-questioned-assumptions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any hidden assumptions the junior took as requirements?
+
+        for each assumption, ask:
+        - what do we assume here without evidence?
+        - what evidence supports this assumption?
+        - what if the opposite were true?
+        - did the wisher actually say this, or did we infer it?
+        - what exceptions or counterexamples exist?
+
+        surface all hidden assumptions and question each one.
+
+    - slug: has-questioned-questions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any open questions? triage them:
+
+        for each question, ask:
+        - can this be answered via websearch or logic? if so, answer it now.
+        - can this be answered via extant docs or code? if so, answer it now.
+        - does only the wisher know the answer? if so, ask the wisher.
+
+        self-answer all questions that can be researched or reasoned.
+        only escalate questions that truly require the wisher's input.

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/1.vision.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/1.vision.md
@@ -1,0 +1,428 @@
+# vision: selfreview-fix-clarify
+
+> articulation carries two peer flows — fix and articulate — with equal weight
+
+---
+
+## the outcome world
+
+### the reusable "walk the way" stdout
+
+this component replaces solo `articulate into` wherever it appears:
+
+```
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ ${articulationPath}
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
+```
+
+### affected formatters
+
+| formatter | flow | shown when |
+|-----------|------|------------|
+| formatPatienceFriend.ts | `--as passed` | initial challenge |
+| formatLetsReflect.ts | `--as promised` | each review prompt |
+
+---
+
+### formatPatienceFriend: before
+
+```
+🗿 patience, friend
+   │
+   ├─ the pond barely rippled
+   │
+   ├─ be here now 🪷
+   │  ├─
+   │  │
+   │  │  the review is the work.
+   │  │  not a gate to pass.
+   │  │  not a step to complete.
+   │  │  the work itself.
+   │  │
+   │  │  you are not the author.
+   │  │  you are the reviewer.
+   │  │
+   │  └─
+   │
+   ├─ trust the way 🪷
+   │  ├─
+   │  │
+   │  │  when you see this prompt
+   │  │    pause and articulate what you found
+   │  │
+   │  │  when you found issues
+   │  │    fix them before you continue
+   │  │
+   │  │  when you found no issues
+   │  │    articulate why it holds
+   │  │
+   │  │  when you cannot articulate either
+   │  │    you have not reviewed
+   │  │
+   │  └─
+   │
+   ├─ articulate into
+   │  └─ ./review/self/1.all-done.md
+   │
+   └─ when you've truly reflected, run
+      └─ rhx route.stone.set --stone 1 --as promised --that all-done
+```
+
+### formatPatienceFriend: after
+
+```
+🗿 patience, friend
+   │
+   ├─ the pond barely rippled
+   │
+   ├─ be here now 🪷
+   │  ├─
+   │  │
+   │  │  the review is the work.
+   │  │  not a gate to pass.
+   │  │  not a step to complete.
+   │  │  the work itself.
+   │  │
+   │  │  you are not the author.
+   │  │  you are the reviewer.
+   │  │
+   │  └─
+   │
+   ├─ trust the way 🪷
+   │  ├─
+   │  │
+   │  │  when you see this prompt
+   │  │    pause and articulate what you found
+   │  │
+   │  │  when you found issues
+   │  │    fix them before you continue
+   │  │
+   │  │  when you found no issues
+   │  │    articulate why it holds
+   │  │
+   │  │  when you cannot articulate either
+   │  │    you have not reviewed
+   │  │
+   │  └─
+   │
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ ./review/self/1.all-done.md
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
+   │
+   └─ when you've truly reflected, run
+      └─ rhx route.stone.set --stone 1 --as promised --that all-done
+```
+
+---
+
+### formatLetsReflect: before
+
+```
+🌕 lets reflect
+   │
+   ...
+   │
+   ├─ be here now 🪷
+   │  ...
+   │
+   ├─ articulate into
+   │  └─ ./review/self/1.vision.all-done.md
+   │
+   └─ when you've truly reflected, run
+      └─ rhx route.stone.set --stone 1 --as promised --that all-done
+```
+
+### formatLetsReflect: after
+
+```
+🌕 lets reflect
+   │
+   ...
+   │
+   ├─ be here now 🪷
+   │  ...
+   │
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ ./review/self/1.vision.all-done.md
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
+   │
+   └─ when you've truly reflected, run
+      └─ rhx route.stone.set --stone 1 --as promised --that all-done
+```
+
+---
+
+### the "aha" moment
+
+the value clicks when an agent sees "walk the way" carry both flows:
+- **for each found issue** → articulate how it was fixed
+- **for each non issue** → articulate why it holds
+
+both paths nest under "walk the way". every outcome requires articulation.
+
+---
+
+## user experience
+
+### the usecase
+
+a clone reaches a guarded stone. the stone requires self-review. "walk the way" carries two peer flows:
+
+```
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ ./review/self/1.all-done.md
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
+```
+
+### the goal
+
+clones should:
+1. pause (the 30s timer enforces this)
+2. review the artifact with fresh eyes
+3. if issues found → **fix them** before they continue
+4. if no issues → **articulate why** it holds
+5. promise with confidence
+
+### the contract
+
+input: the clone attempts to pass or promise a guarded stone
+output: the two questions appear and prompt reflection plus action
+
+### the timeline
+
+1. clone attempts `--as passed`
+2. selfreview challenge triggers
+3. clone sees the two questions
+4. clone reviews, articulates, fixes if needed
+5. clone runs `--as promised --that <slug>`
+6. (repeat for reviews left)
+7. all reviews promised → passage allowed
+
+---
+
+## mental model
+
+### how users describe it
+
+"it shows two paths: if I found issues, fix them; if not, say why it holds"
+
+### analogies
+
+- **the fork in the road**: two clear paths, both lead to progress
+- **the pilot's checklist**: observe, then act appropriately
+- **uncle iroh's wisdom**: "sometimes the best way to solve your own problems is to help someone else" — but first, you must see the problem clearly
+
+### terms
+
+| user might say | we say |
+|----------------|--------|
+| "found problems" | issues found → fix |
+| "no problems" | no issues → articulate |
+| "reviewed" | took the appropriate path
+
+---
+
+## evaluation
+
+### how well does it solve the goal?
+
+the wish is to make clear that:
+1. defects should be fixed (not just noted)
+2. the "fix" flow has equal weight to the "articulate" flow
+
+"walk the way" carries both flows as nested children. both are visually equal under one umbrella.
+
+### pros
+
+- **equal weight**: fix and articulate are peer children under "walk the way"
+- **clear paths**: two distinct outcomes, both lead to progress
+- **zen-compatible**: keeps "be here now" and "trust the way" sections
+- **minimal change**: adds "walk the way" section with nested articulation blocks
+
+### cons
+
+- **nest depth**: one more level of indentation
+
+### edge cases and pit of success
+
+- **agent skims**: the 30s timer still enforces pause
+- **agent promises without fix**: must articulate — if they can't articulate, they haven't reviewed
+- **agent fixes but doesn't articulate**: articulation path catches this
+
+---
+
+## open questions & assumptions
+
+### assumptions
+
+1. agents see the two peer blocks as equal-weight paths
+2. the "fix first" order emphasizes action over mere reflection
+3. "be here now" section is valuable and should stay
+
+### questions resolved
+
+1. ~~should "initiate" use a different word?~~ → no, keep "fix them" directly
+2. ~~should the questions replace trust-the-way?~~ → no, nest them under "articulate into" instead
+3. ~~should "be here now" stay?~~ → yes, it provides identity reframe
+
+---
+
+## what is awkward?
+
+### what feels off
+
+no major concerns. the peer block structure is natural.
+
+### where the design fights the mental model
+
+nowhere — agents already know the conditional wording.
+
+### tradeoffs that feel uncomfortable
+
+- **two blocks vs one**: slightly more vertical space, but clearer
+
+---
+
+## proposed full stdout (formatPatienceFriend)
+
+```
+🗿 patience, friend
+   │
+   ├─ the pond barely rippled
+   │
+   ├─ be here now 🪷
+   │  ├─
+   │  │
+   │  │  the review is the work.
+   │  │  not a gate to pass.
+   │  │  not a step to complete.
+   │  │  the work itself.
+   │  │
+   │  │  you are not the author.
+   │  │  you are the reviewer.
+   │  │
+   │  └─
+   │
+   ├─ trust the way 🪷
+   │  ├─
+   │  │
+   │  │  when you see this prompt
+   │  │    pause and articulate what you found
+   │  │
+   │  │  when you found issues
+   │  │    fix them before you continue
+   │  │
+   │  │  when you found no issues
+   │  │    articulate why it holds
+   │  │
+   │  │  when you cannot articulate either
+   │  │    you have not reviewed
+   │  │
+   │  └─
+   │
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ ./review/self/1.all-done.md
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
+   │
+   └─ when you've truly reflected, run
+      └─ rhx route.stone.set --stone 1 --as promised --that all-done
+```
+
+---
+
+## summary
+
+the vision: **"walk the way" carries two peer flows**.
+
+- for each found issue → articulate how it was fixed
+- for each non issue → articulate why it holds
+
+both paths nest under "walk the way". articulation is the umbrella.
+
+🦉🍵

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/1.vision.stone
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/1.vision.stone
@@ -1,0 +1,48 @@
+illustrate the vision implied in the wish .behavior/v2026_03_11.selfreview-fix-clarify/0.wish.md
+
+emit into .behavior/v2026_03_11.selfreview-fix-clarify/1.vision.md
+
+---
+
+paint a picture of what the world looks like when this wish is fulfilled
+
+testdrive the contract we propose via realworld examples
+
+specifically,
+
+## the outcome world
+
+- what does a day-in-the-life look like with this in place?
+- what's the before/after contrast?
+- what's the "aha" moment where the value clicks?
+
+## user experience
+
+- what usecases do folks fulfill? what goals?
+- what contract inputs & outputs do they leverage?
+- what would it look like to leverage them?
+- what timelines do they go through?
+
+## mental model
+
+- how would users describe this to a friend?
+- what analogies or metaphors fit?
+- what terms would they use vs what terms would we use?
+
+## evaluation
+
+- how well does it solve the goals?
+- what are the pros? the cons?
+- what edgecases exist and how do our contracts keep users in a pit of success?
+
+## open questions & assumptions
+
+- what assumptions have we made?
+- what questions remain unanswered?
+- what must we validate with the wisher before we proceed?
+
+## what is awkward?
+
+- what feels off or forced?
+- where does the design fight the user's mental model?
+- what tradeoffs feel uncomfortable?

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/2.1.criteria.blackbox.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/2.1.criteria.blackbox.md
@@ -1,0 +1,56 @@
+# blackbox criteria: selfreview-fix-clarify
+
+> what experience must be delivered to fulfill the wish
+
+---
+
+# usecase.1 = clone attempts passage on guarded stone
+
+given('a clone attempts --as passed on a guarded stone')
+  when('the self-review challenge appears')
+    then('stdout includes "walk the way 🪷" section')
+      sothat('the clone sees articulation as an active path, not a checkbox')
+    then('"articulate into" appears nested under "walk the way"')
+      sothat('the path to articulate is clearly part of the journey')
+    then('"for each found issue 🪘" appears as a peer block')
+      sothat('the clone knows to articulate how issues were fixed')
+    then('"for each non issue 🪘" appears as a peer block')
+      sothat('the clone knows to articulate why each aspect holds')
+    then('both peer blocks have equal visual weight')
+      sothat('fix and articulate carry equal importance')
+    then('both peer blocks use bucket structure with whitespace')
+      sothat('the two flows feel meditative, not rushed')
+
+# usecase.2 = clone promises a review
+
+given('a clone runs --as promised for a self-review')
+  when('the review prompt appears')
+    then('stdout includes "walk the way 🪷" section')
+      sothat('the clone sees articulation as an active path')
+    then('"articulate into" appears nested under "walk the way"')
+      sothat('the path to articulate is clearly part of the journey')
+    then('"for each found issue 🪘" appears as a peer block')
+      sothat('the clone knows to articulate how issues were fixed')
+    then('"for each non issue 🪘" appears as a peer block')
+      sothat('the clone knows to articulate why each aspect holds')
+    then('both peer blocks have equal visual weight')
+      sothat('fix and articulate carry equal importance')
+
+# usecase.3 = consistency across flows
+
+given('any selfreview stdout that previously showed solo "articulate into"')
+  when('the challenge or prompt renders')
+    then('"articulate into" is nested under "walk the way"')
+      sothat('all flows have the same structure')
+    then('no solo "articulate into" appears at the top level')
+      sothat('the old pattern is fully replaced')
+
+---
+
+## boundary conditions
+
+- "walk the way" must appear before "when you've truly reflected, run"
+- the two 🪘 drum blocks must be siblings under "walk the way"
+- whitespace must separate the bucket contents for meditative feel
+- the structure must be identical across formatPatienceFriend and formatLetsReflect
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/2.1.criteria.blackbox.stone
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/2.1.criteria.blackbox.stone
@@ -1,0 +1,61 @@
+declare the blackbox criteria required to fulfill
+- this wish .behavior/v2026_03_11.selfreview-fix-clarify/0.wish.md
+- this vision .behavior/v2026_03_11.selfreview-fix-clarify/1.vision.md (if declared)
+
+via bdd declarations, per your briefs
+
+emit into .behavior/v2026_03_11.selfreview-fix-clarify/2.1.criteria.blackbox.md
+
+---
+
+blackbox criteria = experience boundaries (no implementation details)
+
+## episode experience
+
+a sequence of exchanges — the narrative flow
+
+- what workflows do users go through?
+- what do they see, do, and receive at each step?
+- what are the critical paths through the episode?
+- what are the edge cases in the narrative?
+
+## exchange experience
+
+atomic — a single input→output contract
+
+- what inputs does the system accept?
+- what outputs does the system return?
+- what errors does the system surface?
+- what are the boundary conditions?
+
+---
+
+DO NOT include:
+- mechanism details (what contracts/components exist)
+- implementation details (how things are built)
+
+note: blackbox is NOT "why to build" — that's the wish
+      blackbox is "what experience must be delivered" to fulfill the wish
+
+---
+
+## template
+
+```
+# usecase.1 = ...
+given()
+  when()
+    then()
+      sothat()
+    then()
+    then()
+      sothat()
+  when()
+    then()
+
+given()
+  ...
+
+# usecase.2 = ...
+...
+```

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/2.2.criteria.blackbox.matrix.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/2.2.criteria.blackbox.matrix.md
@@ -1,0 +1,36 @@
+# blackbox criteria matrix: selfreview-fix-clarify
+
+---
+
+## matrix: selfreview stdout structure
+
+| ind: flow | ind: action | dep: walk the way | dep: articulate into nested | dep: found issue block | dep: non issue block | dep: equal weight |
+|-----------|-------------|-------------------|-----------------------------|-----------------------|---------------------|-------------------|
+| --as passed | challenge appears | ✓ present | ✓ nested | ✓ 🪘 bucket | ✓ 🪘 bucket | ✓ peers |
+| --as promised | review prompt appears | ✓ present | ✓ nested | ✓ 🪘 bucket | ✓ 🪘 bucket | ✓ peers |
+
+---
+
+## matrix: articulate into placement
+
+| ind: formatter | ind: before change | dep: after change |
+|----------------|-------------------|-------------------|
+| formatPatienceFriend | solo "articulate into" | nested under "walk the way" |
+| formatLetsReflect | solo "articulate into" | nested under "walk the way" |
+
+---
+
+## gap analysis
+
+no gaps detected — both formatters receive identical treatment.
+
+---
+
+## decomposition analysis
+
+**dimensions**: 2 independent variables (flow type, action)
+**combinations**: 2 rows
+**verdict**: scope is narrow and well-bounded. no decomposition needed.
+
+the change is symmetric across both formatters — a single reusable "walk the way" component can serve both.
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/2.2.criteria.blackbox.matrix.stone
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/2.2.criteria.blackbox.matrix.stone
@@ -1,0 +1,47 @@
+distill the blackbox criteria in .behavior/v2026_03_11.selfreview-fix-clarify/2.1.criteria.blackbox.md into a coverage matrix
+
+emit into .behavior/v2026_03_11.selfreview-fix-clarify/2.2.criteria.blackbox.matrix.md
+
+---
+
+create a matrix table for each related set of usecases
+
+## process
+
+1. **extract dimensions** — identify the independent variables that vary across usecases
+2. **enumerate combinations** — list all dimension value combinations
+3. **map outcomes** — for each combination, record the expected outcome from blackbox criteria
+4. **flag gaps** — if any combination lacks a specified outcome, call it out
+5. **flag decomposition opportunities** — if too many dimensions, suggest narrower behavioral boundaries
+
+## structure
+
+| ind: var 1 | ind: var 2 | ... | dep: var 1 | dep: var 2 | ... |
+|-------------------|-------------------|-----|-----------------|-----------------|-----|
+| condition A       | condition X       | ... | outcome 1       | outcome 2       | ... |
+| condition A       | condition Y       | ... | outcome 1       | outcome 2       | ... |
+| condition B       | condition X       | ... | outcome 1       | outcome 2       | ... |
+
+explicitly label the ind(ependent) vs dep(endent) varialbes in the table header, as well
+
+## terminology
+
+- independent variables: the inputs/conditions that vary between subcases
+- dependent variables: the expected outcomes for each combination (can be multiple per row)
+
+## why
+
+- visualize all combinations at a glance
+- spot gaps via symmetric analysis — if a row is absent, ask why
+- verify the blackbox criteria covers all meaningful permutations
+
+## decomposition signal
+
+if there are too many independent variables (matrix explodes) — this signals the usecase is too broad
+
+callout opportunities to decompose into smaller behavioral boundaries when:
+- the matrix has 4+ independent dimensions
+- combinations exceed what's reasonable to enumerate
+- unrelated concerns are bundled together
+
+a narrower scope = a clearer matrix = a more maintainable and recomposable system

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/3.1.3.research.internal.product.code.prod._.v1.i1.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/3.1.3.research.internal.product.code.prod._.v1.i1.md
@@ -1,0 +1,128 @@
+# research: internal product code (prod)
+
+---
+
+## pattern 1: formatPatienceFriend.ts [EXTEND]
+
+**location**: `src/domain.operations/route/guard/formatPatienceFriend.ts`
+
+**purpose**: formats "patience, friend" challenge for self-review on `--as passed`
+
+**current "articulate into" section** (lines 54-58):
+```typescript
+// articulate into section
+const articulationPath = `${input.route}/review/self/${input.stone}.${input.slug}.md`;
+lines.push(`   ├─ articulate into`);
+lines.push(`   │  └─ ${articulationPath}`);
+lines.push(`   │`);
+```
+[citation 1]
+
+**action**: EXTEND to wrap "articulate into" inside "walk the way" section with the two drum blocks
+
+---
+
+## pattern 2: formatLetsReflect.ts [EXTEND]
+
+**location**: `src/domain.operations/route/guard/formatLetsReflect.ts`
+
+**purpose**: formats "lets reflect" prompt for self-review on `--as promised`
+
+**current "articulate into" section** (lines 97-101):
+```typescript
+// articulate into section
+const articulationPath = `${input.route}/review/self/${input.stone}.${input.slug}.md`;
+lines.push(`   ├─ articulate into`);
+lines.push(`   │  └─ ${articulationPath}`);
+lines.push(`   │`);
+```
+[citation 2]
+
+**action**: EXTEND to wrap "articulate into" inside "walk the way" section with the two drum blocks
+
+---
+
+## pattern 3: tree format via lines array [REUSE]
+
+**observation**: both formatters use the same pattern:
+```typescript
+const lines: string[] = [];
+lines.push(`   ├─ section name 🪷`);
+lines.push(`   │  ├─`);
+lines.push(`   │  │`);
+lines.push(`   │  │  content line`);
+lines.push(`   │  │`);
+lines.push(`   │  └─`);
+```
+[citation 1, 2]
+
+**action**: REUSE this pattern for the new "walk the way" section
+
+---
+
+## pattern 4: articulation path construction [REUSE]
+
+**observation**: both files construct the path identically:
+```typescript
+const articulationPath = `${input.route}/review/self/${input.stone}.${input.slug}.md`;
+```
+[citation 1: line 55, citation 2: line 98]
+
+**action**: REUSE this pattern in the shared "walk the way" component
+
+---
+
+## pattern 5: input signature [REUSE]
+
+**formatPatienceFriend input**:
+```typescript
+input: {
+  stone: string;
+  slug: string;
+  route: string;
+}
+```
+[citation 1: lines 5-9]
+
+**formatLetsReflect input**:
+```typescript
+input: {
+  stone: string;
+  slug: string;
+  route: string;
+  reviewSelf: RouteStoneGuardReviewSelf;
+  index: number;
+  total: number;
+}
+```
+[citation 2: lines 7-14]
+
+**observation**: both share `stone`, `slug`, `route` — sufficient for the "walk the way" component
+
+**action**: REUSE the common subset `{ stone, slug, route }` for the shared component
+
+---
+
+## opportunity: extract formatWalkTheWay [NEW]
+
+**rationale**: the "articulate into" section is duplicated across both formatters. a shared `formatWalkTheWay` function will:
+1. eliminate duplication
+2. ensure consistency across flows
+3. make future changes single-point
+
+**proposed signature**:
+```typescript
+export const formatWalkTheWay = (input: {
+  route: string;
+  stone: string;
+  slug: string;
+}): string[]
+```
+
+---
+
+## citations
+
+1. `src/domain.operations/route/guard/formatPatienceFriend.ts` (full file read)
+2. `src/domain.operations/route/guard/formatLetsReflect.ts` (full file read)
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/3.1.3.research.internal.product.code.prod._.v1.stone
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/3.1.3.research.internal.product.code.prod._.v1.stone
@@ -1,0 +1,31 @@
+research the prod codepath patterns available in order to fulfill
+- this wish .behavior/v2026_03_11.selfreview-fix-clarify/0.wish.md
+- this vision .behavior/v2026_03_11.selfreview-fix-clarify/1.vision.md (if declared)
+- this criteria .behavior/v2026_03_11.selfreview-fix-clarify/2.1.criteria.blackbox.md (if declared)
+- this criteria .behavior/v2026_03_11.selfreview-fix-clarify/2.3.criteria.blueprint.md (if declared)
+
+specifically
+- what are the current key patterns in this repo, that are relevant?
+- how do they relate to the wish?
+- which ones will we reuse? which ones will we extend? which ones will we replace?
+  - mark with
+    - [REUSE]
+    - [EXTEND]
+    - [REPLACE]
+
+---
+
+focus exclusively on the production codepaths. ignore test codepaths
+
+note, this includes any infra that production codepaths depend on
+
+---
+
+enumerate each pattern
+- cite every claim
+- number each citation
+- clone exact quotes from each citation
+
+---
+
+emit into .behavior/v2026_03_11.selfreview-fix-clarify/3.1.3.research.internal.product.code.prod._.v1.i1.md

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/3.1.3.research.internal.product.code.test._.v1.i1.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/3.1.3.research.internal.product.code.test._.v1.i1.md
@@ -1,0 +1,197 @@
+# research: internal product code (test)
+
+---
+
+## pattern 1: formatPatienceFriend.test.ts [EXTEND]
+
+**location**: `src/domain.operations/route/guard/formatPatienceFriend.test.ts`
+
+**purpose**: tests the "patience, friend" challenge output
+
+**current test structure**:
+```typescript
+given('[case1] challenged review.self', () => {
+  when('[t0] formatPatienceFriend called', () => {
+    then('output matches snapshot (vibecheck)', ...);
+    then('contains stone header', ...);
+    then('contains zen challenge sections', ...);
+    then('contains articulation section', ...);
+    then('contains final instruction', ...);
+  });
+});
+```
+[citation 1]
+
+**articulation section test** (lines 43-54):
+```typescript
+then('contains articulation section', () => {
+  const output = formatPatienceFriend({
+    stone: '1.vision',
+    slug: 'all-done',
+    route: '.behavior/v2026_03_05.behavior-example',
+  });
+
+  expect(output).toContain('articulate into');
+  expect(output).toContain(
+    '.behavior/v2026_03_05.behavior-example/review/self/1.vision.all-done.md',
+  );
+});
+```
+[citation 1: lines 43-54]
+
+**action**: EXTEND to test "walk the way" section with drum blocks
+
+---
+
+## pattern 2: formatLetsReflect.test.ts [EXTEND]
+
+**location**: `src/domain.operations/route/guard/formatLetsReflect.test.ts`
+
+**purpose**: tests the "lets reflect" prompt output
+
+**current test structure**:
+```typescript
+given('[case1] standard review.self', () => {
+  when('[t0] formatLetsReflect called', () => {
+    then('output matches snapshot (vibecheck)', ...);
+    then('contains warm frame sections', ...);
+    then('contains guide content', ...);
+    then('contains articulation section', ...);
+    then('contains final instruction', ...);
+  });
+});
+```
+[citation 2]
+
+**articulation section test** (lines 61-78):
+```typescript
+then('contains articulation section', () => {
+  const output = formatLetsReflect({
+    stone: '1.vision',
+    slug: 'all-done',
+    route: '.behavior/v2026_03_05.behavior-example',
+    reviewSelf: {
+      slug: 'all-done',
+      say: 'review guide content',
+    },
+    index: 1,
+    total: 1,
+  });
+
+  expect(output).toContain('articulate into');
+  expect(output).toContain(
+    '.behavior/v2026_03_05.behavior-example/review/self/1.vision.all-done.md',
+  );
+});
+```
+[citation 2: lines 61-78]
+
+**action**: EXTEND to test "walk the way" section with drum blocks
+
+---
+
+## pattern 3: snapshot tests (vibecheck) [REGENERATE]
+
+**observation**: both tests use `toMatchSnapshot()` for vibecheck:
+```typescript
+then('output matches snapshot (vibecheck)', () => {
+  const output = formatPatienceFriend({ ... });
+  expect(output).toMatchSnapshot();
+});
+```
+[citation 1: lines 8-16, citation 2: lines 8-22]
+
+**action**: REGENERATE snapshots after implementation to reflect new "walk the way" structure
+
+---
+
+## pattern 4: containment assertions [EXTEND]
+
+**observation**: both tests use `.toContain()` for section verification
+
+**current assertions for articulation**:
+- `expect(output).toContain('articulate into');`
+- `expect(output).toContain('${route}/review/self/${stone}.${slug}.md');`
+
+**new assertions to add**:
+- `expect(output).toContain('walk the way 🪷');`
+- `expect(output).toContain('for each found issue 🪘');`
+- `expect(output).toContain('for each non issue 🪘');`
+- `expect(output).toContain('articulate how it was fixed');`
+- `expect(output).toContain('articulate why it holds');`
+
+**action**: EXTEND the "contains articulation section" test to cover the new structure
+
+---
+
+## pattern 5: test input signatures [REUSE]
+
+**formatPatienceFriend test input**:
+```typescript
+{
+  stone: '1.vision',
+  slug: 'all-done',
+  route: '.behavior/v2026_03_05.behavior-example',
+}
+```
+[citation 1: lines 9-12]
+
+**formatLetsReflect test input**:
+```typescript
+{
+  stone: '1.vision',
+  slug: 'all-done',
+  route: '.behavior/v2026_03_05.behavior-example',
+  reviewSelf: {
+    slug: 'all-done',
+    say: 'review guide content',
+  },
+  index: 1,
+  total: 1,
+}
+```
+[citation 2: lines 62-71]
+
+**action**: REUSE as-is for new assertions
+
+---
+
+## test update strategy
+
+### step 1: update containment tests
+
+rename "contains articulation section" to "contains walk the way section" and extend assertions:
+
+```typescript
+then('contains walk the way section', () => {
+  const output = formatPatienceFriend({ ... });
+
+  // walk the way header
+  expect(output).toContain('walk the way 🪷');
+
+  // articulate into nested
+  expect(output).toContain('articulate into');
+  expect(output).toContain('${route}/review/self/${stone}.${slug}.md');
+
+  // drum blocks
+  expect(output).toContain('for each found issue 🪘');
+  expect(output).toContain('articulate how it was fixed');
+  expect(output).toContain('so you remember for next time');
+
+  expect(output).toContain('for each non issue 🪘');
+  expect(output).toContain('articulate why it holds');
+  expect(output).toContain('so others can learn from it');
+});
+```
+
+### step 2: regenerate snapshots
+
+run `RESNAP=true npm run test:unit -- formatPatienceFriend.test.ts` and `RESNAP=true npm run test:unit -- formatLetsReflect.test.ts`
+
+---
+
+## citations
+
+1. `src/domain.operations/route/guard/formatPatienceFriend.test.ts` (full file read)
+2. `src/domain.operations/route/guard/formatLetsReflect.test.ts` (full file read)
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/3.1.3.research.internal.product.code.test._.v1.stone
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/3.1.3.research.internal.product.code.test._.v1.stone
@@ -1,0 +1,31 @@
+research the test codepath patterns available in order to fulfill
+- this wish .behavior/v2026_03_11.selfreview-fix-clarify/0.wish.md
+- this vision .behavior/v2026_03_11.selfreview-fix-clarify/1.vision.md (if declared)
+- this criteria .behavior/v2026_03_11.selfreview-fix-clarify/2.1.criteria.blackbox.md (if declared)
+- this criteria .behavior/v2026_03_11.selfreview-fix-clarify/2.3.criteria.blueprint.md (if declared)
+
+specifically
+- what are the current key patterns in this repo, that are relevant?
+- how do they relate to the wish?
+- which ones will we reuse? which ones will we extend? which ones will we replace?
+  - mark with
+    - [REUSE]
+    - [EXTEND]
+    - [REPLACE]
+
+---
+
+focus exclusively on the test codepath patterns. ignore production codepath patterns
+
+note, this includes any infra that test codepaths depend on
+
+---
+
+enumerate each pattern
+- cite every claim
+- number each citation
+- clone exact quotes from each citation
+
+---
+
+emit into .behavior/v2026_03_11.selfreview-fix-clarify/3.1.3.research.internal.product.code.test._.v1.i1.md

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/3.1.4.research.internal.factory.blockers._.v1.i1.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/3.1.4.research.internal.factory.blockers._.v1.i1.md
@@ -1,0 +1,80 @@
+# research: factory blockers
+
+---
+
+## test infra
+
+**status**: sufficient
+
+extant test infra covers the need:
+- `formatPatienceFriend.test.ts` with snapshot and containment assertions
+- `formatLetsReflect.test.ts` with snapshot and containment assertions
+- `npm run test:unit` runs both
+
+**no provision needed** — extend assertions and regenerate snapshots.
+
+---
+
+## feedback loops
+
+**status**: sufficient
+
+| verification | time | notes |
+|-------------|------|-------|
+| unit test (single file) | ~2s | `npm run test:unit -- formatPatienceFriend.test.ts` |
+| snapshot regeneration | ~3s | `RESNAP=true npm run test:unit -- formatPatienceFriend.test.ts` |
+| type check | ~5s | `npm run test:types` |
+
+**tight loops available** — no bottleneck identified.
+
+---
+
+## access and credentials
+
+**status**: sufficient
+
+no credentials needed. this change is:
+- pure typescript code
+- no external API calls
+- no database access
+- no cloud resource interaction
+
+---
+
+## infra control
+
+**status**: sufficient
+
+no infra changes needed:
+- no new dependencies
+- no build config changes
+- no CI/CD modifications
+
+---
+
+## other blockers
+
+**status**: none identified
+
+| potential blocker | status |
+|------------------|--------|
+| dependencies on other teams | none |
+| unclear requirements | clear via vision document |
+| absent patterns | extant formatters provide pattern |
+| test fixtures | extant test inputs sufficient |
+| environment parity | not applicable |
+
+---
+
+## summary
+
+**verdict**: no blockers found.
+
+the factory is ready for implementation:
+- test infra extant and sufficient
+- feedback loops tight
+- no credentials or infra changes needed
+- clear vision and patterns documented
+
+proceed to next stone.
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/3.1.4.research.internal.factory.blockers._.v1.stone
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/3.1.4.research.internal.factory.blockers._.v1.stone
@@ -1,0 +1,65 @@
+look around your factory — what's broken or absent that would block you?
+
+.why = surface blockers before you start so you don't hit them mid-build.
+- a mechanic halted by absent credentials loses momentum
+- a mechanic without test infra cannot verify their work
+- a mechanic who discovers blockers late wastes effort on rework
+- blockers found upfront can be addressed in parallel with other research
+
+reference
+- .behavior/v2026_03_11.selfreview-fix-clarify/0.wish.md
+- .behavior/v2026_03_11.selfreview-fix-clarify/1.vision.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.3.research.internal.product.*.v1.i1.md (if declared)
+
+---
+
+## test infra
+
+- is there any test infra you need to provision?
+- or is extant test infra sufficient to verify this behavior?
+- what's the bottleneck if you don't provision it?
+- can you verify the behavior end-to-end with what you have?
+
+---
+
+## feedback loops
+
+- is there any way to get a tighter feedback loop on verification?
+- what's the slowest verification step?
+- what would increase velocity?
+- is there manual verification that could be automated?
+
+---
+
+## access and credentials
+
+- are there any new keys or credentials you will need?
+- or are extant credentials sufficient?
+- what's blocked without them?
+- who can provision access?
+
+---
+
+## infra control
+
+- is there any infra you'll need to add or modify?
+- or is extant infra sufficient?
+- what's the constraint if you don't add it?
+- is this a blocker or can it be deferred?
+
+---
+
+## other blockers
+
+what else could block rapid iteration, verification, or construction?
+
+- are there dependencies on other teams, systems, or approvals?
+- is there unclear context, ambiguous requirements, or absent domain knowledge?
+- are there absent examples, patterns, or prior art to reference?
+- is there test data, fixtures, or seed state that needs to be created?
+- are there environment parity issues between local, test, and prod?
+- what else would slow down build-test-learn cycles?
+
+---
+
+emit to .behavior/v2026_03_11.selfreview-fix-clarify/3.1.4.research.internal.factory.blockers._.v1.i1.md

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/3.1.4.research.internal.factory.opports._.v1.i1.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/3.1.4.research.internal.factory.opports._.v1.i1.md
@@ -1,0 +1,93 @@
+# research: factory opportunities
+
+---
+
+## the constraint
+
+**singular bottleneck**: none identified for this behavior.
+
+this change is narrow — pure stdout format work with no external dependencies. the factory is already optimized for this type of work.
+
+---
+
+## flow and queues
+
+| queue | wait time | controllable? |
+|-------|-----------|---------------|
+| unit tests | ~2s | yes |
+| type check | ~5s | yes |
+| snapshot regeneration | ~3s | yes |
+
+**no blocked queues** — all verification is local and fast.
+
+---
+
+## waste
+
+| potential waste | status |
+|-----------------|--------|
+| repeated setup | none — jest caches well |
+| partial work idle | not applicable |
+| manual verification | none — snapshot tests automate visual checks |
+| handoffs | none — single-developer change |
+
+**no waste identified** for this scope.
+
+---
+
+## small batches
+
+**verification is already incremental**:
+- modify `formatWalkTheWay.ts` → run unit test
+- update test assertions → run unit test
+- regenerate snapshots → run with `RESNAP=true`
+
+**smallest verifiable unit**: single formatter output string.
+
+---
+
+## autonomy
+
+**full autonomy available**:
+- no external team dependencies
+- no approval gates (beyond standard PR review)
+- no infrastructure to provision
+
+---
+
+## density
+
+| activity | time | value |
+|----------|------|-------|
+| test execution | ~2s | high |
+| setup/teardown | ~0.5s | overhead |
+
+**95%+ density** — nearly all time is useful test execution.
+
+---
+
+## systems view
+
+**one opportunity**: the `formatWalkTheWay` component will be reusable.
+
+this improves the system for all future work:
+- any new formatter that needs "walk the way" section can import it
+- single source of truth for the two-question articulation pattern
+- future changes to the pattern require one edit
+
+**not a blocker** — just a good outcome of proper extraction.
+
+---
+
+## summary
+
+**verdict**: no factory improvements needed.
+
+the factory is already well-suited for this work:
+- fast feedback loops
+- high verification density
+- full autonomy
+- incremental verification
+
+the only improvement is emergent: the reusable `formatWalkTheWay` component itself.
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/3.1.4.research.internal.factory.opports._.v1.stone
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/3.1.4.research.internal.factory.opports._.v1.stone
@@ -1,0 +1,66 @@
+look around your factory — if you could improve one tool, what would help you go faster?
+
+.why = factory improvements compound across all future work.
+
+reference
+- .behavior/v2026_03_11.selfreview-fix-clarify/0.wish.md
+- .behavior/v2026_03_11.selfreview-fix-clarify/1.vision.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.4.research.internal.factory.blockers.*.v1.i1.md (if declared)
+
+---
+
+## the constraint
+
+- what is THE bottleneck? (singular, not a list)
+- if you could fix one problem, what would unblock the most?
+
+---
+
+## flow and queues
+
+- what queues exist in verification?
+- what must you wait for that you can't control?
+- what's the work-in-progress limit before you get stuck?
+
+---
+
+## waste
+
+- what handoffs slow you down?
+- what setup is repeated that could be cached or shared?
+- what partial work sits idle?
+- what do you do manually that's error-prone?
+
+---
+
+## small batches
+
+- can you verify incrementally, or must you wait for completion?
+- what's the smallest verifiable unit?
+- can you get feedback before the whole is done?
+
+---
+
+## autonomy
+
+- do you have all you need to ship independently?
+- who must be consulted or waited on?
+- what external teams block progress?
+
+---
+
+## density
+
+- what % of verification time is actual test execution vs setup/wait?
+- where is time wasted that could be reclaimed?
+
+---
+
+## systems view
+
+- would this improvement help just this behavior, or all future work?
+- are you in a local optimum at the cost of the whole?
+
+---
+
+emit to .behavior/v2026_03_11.selfreview-fix-clarify/3.1.4.research.internal.factory.opports._.v1.i1.md

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.domain._.v1.i1.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.domain._.v1.i1.md
@@ -1,0 +1,136 @@
+# distill: domain
+
+---
+
+## domain objects
+
+**no new domain objects needed.**
+
+this change operates on stdout strings, not domain entities. the involved types are:
+- `string[]` — lines array for tree format
+- `{ route: string; stone: string; slug: string }` — input for path construction
+
+---
+
+## domain operations
+
+### formatWalkTheWay [NEW]
+
+**purpose**: generate the "walk the way" stdout section with articulation path and drum blocks
+
+**signature**:
+```typescript
+export const formatWalkTheWay = (input: {
+  route: string;
+  stone: string;
+  slug: string;
+}): string[]
+```
+
+**output structure**:
+```
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ ${articulationPath}
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
+```
+
+**location**: `src/domain.operations/route/guard/formatWalkTheWay.ts`
+
+---
+
+### formatPatienceFriend [EXTEND]
+
+**change**: replace solo "articulate into" section with `formatWalkTheWay()` call
+
+**before**:
+```typescript
+// articulate into section
+const articulationPath = `${input.route}/review/self/${input.stone}.${input.slug}.md`;
+lines.push(`   ├─ articulate into`);
+lines.push(`   │  └─ ${articulationPath}`);
+lines.push(`   │`);
+```
+
+**after**:
+```typescript
+// walk the way section
+lines.push(...formatWalkTheWay(input));
+```
+
+---
+
+### formatLetsReflect [EXTEND]
+
+**change**: replace solo "articulate into" section with `formatWalkTheWay()` call
+
+**before**:
+```typescript
+// articulate into section
+const articulationPath = `${input.route}/review/self/${input.stone}.${input.slug}.md`;
+lines.push(`   ├─ articulate into`);
+lines.push(`   │  └─ ${articulationPath}`);
+lines.push(`   │`);
+```
+
+**after**:
+```typescript
+// walk the way section
+lines.push(...formatWalkTheWay(input));
+```
+
+---
+
+## relationships
+
+```
+formatPatienceFriend ─uses→ formatWalkTheWay
+formatLetsReflect ───uses→ formatWalkTheWay
+```
+
+no tree struct or subdomain hierarchy. simple composition — both formatters call the shared component.
+
+---
+
+## composition flow
+
+```
+clone attempts --as passed
+  └─ formatPatienceFriend called
+     └─ formatWalkTheWay called (internal)
+        └─ returns lines for "walk the way" section
+
+clone attempts --as promised
+  └─ formatLetsReflect called
+     └─ formatWalkTheWay called (internal)
+        └─ returns lines for "walk the way" section
+```
+
+---
+
+## summary
+
+| type | name | action |
+|------|------|--------|
+| operation | formatWalkTheWay | NEW |
+| operation | formatPatienceFriend | EXTEND |
+| operation | formatLetsReflect | EXTEND |
+
+no new domain objects. one new operation extracted for reuse.
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.domain._.v1.stone
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.domain._.v1.stone
@@ -1,0 +1,41 @@
+distill the declastruct domain.objects and domain.operations that would
+- enable fulfillment of
+  - this wish .behavior/v2026_03_11.selfreview-fix-clarify/0.wish.md
+  - this vision .behavior/v2026_03_11.selfreview-fix-clarify/1.vision.md (if declared)
+  - this criteria .behavior/v2026_03_11.selfreview-fix-clarify/2.1.criteria.blackbox.md (if declared)
+- given the research declared here
+  - .behavior/v2026_03_11.selfreview-fix-clarify/3.1.1.research.external.product.access.*.v1.i1.md (if declared)
+  - .behavior/v2026_03_11.selfreview-fix-clarify/3.1.1.research.external.product.claims.*.v1.i1.md (if declared)
+  - .behavior/v2026_03_11.selfreview-fix-clarify/3.1.1.research.external.product.domain.*.v1.i1.md (if declared)
+  - .behavior/v2026_03_11.selfreview-fix-clarify/3.1.1.research.external.product.domain.terms.v1.i1.md (if declared)
+  - .behavior/v2026_03_11.selfreview-fix-clarify/3.1.3.research.internal.product.code.prod.*.v1.i1.md (if declared)
+  - .behavior/v2026_03_11.selfreview-fix-clarify/3.1.3.research.internal.product.code.test.*.v1.i1.md (if declared)
+  - .behavior/v2026_03_11.selfreview-fix-clarify/3.1.2.research.external.factory.templates.*.v1.i1.md (if declared)
+
+procedure
+1. declare the usecases and envision the contract that would be used to fulfill the usecases
+2. declare the domain.objects, domain.operations, and access.daos that would fulfill this, via the declastruct pattern in this repo
+
+---
+
+specifically
+- what are the domain objects that are involved with this wish
+  - entities
+  - events
+  - literals
+- what are the domain operations
+  - getOne
+  - getAll
+  - setCreate
+  - setUpdate
+  - setDelete
+- what are the relationships between the domain objects?
+  - is there a treestruct of decoration?
+  - is there a treestruct of common subdomains?
+  - are there dependencies?
+- how do the domain objects and operations compose to support wish?
+
+---
+
+emit into
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.domain._.v1.i1.md

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.factory.upgrades._.v1.i1.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.factory.upgrades._.v1.i1.md
@@ -1,0 +1,40 @@
+# distill: factory upgrades
+
+---
+
+## decision
+
+**no factory work required.**
+
+the extant factory is sufficient:
+- unit tests extant for both formatters
+- snapshot tests provide vibecheck
+- containment assertions verify section presence
+- fast feedback loops (~2s per test run)
+
+---
+
+## blockers to address
+
+| blocker | what to build | priority |
+|---------|---------------|----------|
+| (none) | — | — |
+
+no blockers were identified in factory research.
+
+---
+
+## improvements to make
+
+| opportunity | what to build | benefit |
+|-------------|---------------|---------|
+| (none) | — | — |
+
+no improvements needed for this scope. the factory is already optimized for stdout format work.
+
+---
+
+## summary
+
+proceed directly to blueprint and implementation. factory is ready.
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.factory.upgrades._.v1.stone
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.factory.upgrades._.v1.stone
@@ -1,0 +1,42 @@
+distill factory upgrades needed for
+- .behavior/v2026_03_11.selfreview-fix-clarify/0.wish.md
+- .behavior/v2026_03_11.selfreview-fix-clarify/1.vision.md (if declared)
+
+based on factory research
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.2.research.external.factory.testloops.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.2.research.external.factory.oss.levers.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.2.research.external.factory.templates.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.4.research.internal.factory.blockers.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.4.research.internal.factory.opports.*.v1.i1.md (if declared)
+
+---
+
+## decision
+
+based on what you found:
+- is any factory work required for this behavior?
+- or is the extant factory sufficient?
+
+---
+
+## blockers to address
+
+if blockers were found, list what to build:
+
+| blocker | what to build | priority |
+|---------|---------------|----------|
+| ...     | ...           | ...      |
+
+---
+
+## improvements to make
+
+if opportunities were found worth the effort, list what to build:
+
+| opportunity | what to build | benefit |
+|-------------|---------------|---------|
+| ...         | ...           | ...     |
+
+---
+
+emit into .behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.factory.upgrades._.v1.i1.md

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.repros.experience._.v1.i1.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.repros.experience._.v1.i1.md
@@ -1,0 +1,91 @@
+# distill: experience reproductions
+
+---
+
+## experience reproductions
+
+| experience | entry point | user actions | expected outcome | test type |
+|------------|-------------|--------------|------------------|-----------|
+| clone attempts --as passed | `formatPatienceFriend` | call with stone/slug/route | stdout contains "walk the way" section with drum blocks | unit |
+| clone runs --as promised | `formatLetsReflect` | call with stone/slug/route + reviewSelf | stdout contains "walk the way" section with drum blocks | unit |
+
+---
+
+## reproduction feasibility
+
+### formatPatienceFriend experience
+
+**available utilities**:
+- `test-fns` given/when/then
+- jest `toContain()` for section verification
+- jest `toMatchSnapshot()` for vibecheck
+
+**setup required**: none — pure function call
+
+**test sketch**:
+```typescript
+then('contains walk the way section with drum blocks', () => {
+  const output = formatPatienceFriend({
+    stone: '1.vision',
+    slug: 'all-done',
+    route: '.behavior/v2026_03_05.behavior-example',
+  });
+
+  expect(output).toContain('walk the way 🪷');
+  expect(output).toContain('articulate into');
+  expect(output).toContain('for each found issue 🪘');
+  expect(output).toContain('for each non issue 🪘');
+  expect(output).toContain('articulate how it was fixed');
+  expect(output).toContain('articulate why it holds');
+});
+```
+
+---
+
+### formatLetsReflect experience
+
+**available utilities**: same as above
+
+**setup required**: none — pure function call
+
+**test sketch**:
+```typescript
+then('contains walk the way section with drum blocks', () => {
+  const output = formatLetsReflect({
+    stone: '1.vision',
+    slug: 'all-done',
+    route: '.behavior/v2026_03_05.behavior-example',
+    reviewSelf: { slug: 'all-done', say: 'review guide content' },
+    index: 1,
+    total: 1,
+  });
+
+  expect(output).toContain('walk the way 🪷');
+  expect(output).toContain('articulate into');
+  expect(output).toContain('for each found issue 🪘');
+  expect(output).toContain('for each non issue 🪘');
+  expect(output).toContain('articulate how it was fixed');
+  expect(output).toContain('articulate why it holds');
+});
+```
+
+---
+
+## gaps
+
+**none** — all experiences can be reproduced with extant test utilities.
+
+| gap | blocked? | required to unblock | priority |
+|-----|----------|---------------------|----------|
+| (none) | — | — | — |
+
+---
+
+## summary
+
+both experiences map directly to unit tests:
+- call formatter function
+- assert stdout contains expected sections
+
+no integration or acceptance tests needed — this is pure stdout format work.
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.repros.experience._.v1.stone
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.repros.experience._.v1.stone
@@ -1,0 +1,35 @@
+distill user experience reproductions for
+- .behavior/v2026_03_11.selfreview-fix-clarify/0.wish.md
+- .behavior/v2026_03_11.selfreview-fix-clarify/1.vision.md (if declared)
+
+---
+
+## experience reproductions
+
+for each user experience in the vision, define how it will be reproduced in tests.
+
+| experience | entry point | user actions | expected outcome | test type |
+|------------|-------------|--------------|------------------|-----------|
+| ...        | ...         | ...          | ...              | ...       |
+
+---
+
+## reproduction feasibility
+
+for each experience, confirm it can be reproduced:
+- what test utilities are available?
+- what setup is required?
+- show a concrete test sketch
+
+---
+
+## gaps
+
+if any experience cannot be reproduced, declare:
+- what is blocked?
+- what is required to unblock?
+- is this a blocker or can it be deferred?
+
+---
+
+emit to .behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.repros.experience._.v1.i1.md

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/3.3.0.blueprint.factory.v1.i1.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/3.3.0.blueprint.factory.v1.i1.md
@@ -1,0 +1,21 @@
+# blueprint: factory
+
+---
+
+## summary
+
+**no factory changes required.**
+
+the extant factory is sufficient to build and verify this behavior.
+
+---
+
+## factory readiness
+
+- [x] test infra ready (unit tests extant for both formatters)
+- [x] credentials provisioned (none needed — pure code change)
+- [x] feedback loops acceptable (~2s per test run)
+- [x] blockers addressed (none identified)
+
+proceed to product blueprint.
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/3.3.0.blueprint.factory.v1.stone
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/3.3.0.blueprint.factory.v1.stone
@@ -1,0 +1,83 @@
+propose a blueprint for how we will upgrade the factory
+- based on .behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.factory.upgrades.*.v1.i1.md
+- if no factory work is needed, declare "no factory changes required"
+
+.why = blueprint the factory changes needed to build and verify the product.
+- the factory must be ready before you build the product
+- explicit blueprint prevents "i forgot to provision X" mid-build
+
+follow the patterns already present in this repo.
+
+---
+
+## summary
+
+state the factory changes needed (or "no factory changes required" if none).
+
+---
+
+## filediff tree
+
+if factory changes are needed, include a treestruct of filediffs.
+
+**legend:**
+- `[+] create` — file to create
+- `[~] update` — file to update
+- `[-] delete` — file to delete
+
+---
+
+## codepath tree
+
+if factory changes are needed, include a treestruct of codepaths.
+
+**legend:**
+- `[+]` create — codepath to create
+- `[~]` update — codepath to update
+- `[○]` retain — codepath to retain
+- `[-]` delete — codepath to delete
+- `[←]` reuse — codepath to reuse from elsewhere
+- `[→]` eject — codepath to decompose for reuse
+
+---
+
+## test coverage
+
+if factory changes are needed, declare the test coverage:
+- unit tests for factory utilities
+- integration tests for factory tools
+- manual verification steps if needed
+
+---
+
+## factory readiness
+
+before product blueprint, confirm:
+
+- [ ] test infra ready (can verify end-to-end)
+- [ ] credentials provisioned (no access blocks)
+- [ ] feedback loops acceptable (verification < X minutes)
+- [ ] blockers addressed or deferred with plan
+
+---
+
+remember, the purpose of the blueprint is to declare what the execution will adhere to.
+
+we want to see:
+- what factory changes will be made
+- how the changes enable build and verify cycles
+- what the codepaths are, their ease of maintenance and readability
+
+---
+
+reference
+- .behavior/v2026_03_11.selfreview-fix-clarify/0.wish.md
+- .behavior/v2026_03_11.selfreview-fix-clarify/1.vision.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.2.research.external.factory.testloops.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.2.research.external.factory.oss.levers.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.2.research.external.factory.templates.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.factory.upgrades.*.v1.i1.md (if declared)
+
+---
+
+emit into .behavior/v2026_03_11.selfreview-fix-clarify/3.3.0.blueprint.factory.v1.i1.md

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/3.3.1.blueprint.product.v1.guard
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/3.3.1.blueprint.product.v1.guard
@@ -1,0 +1,186 @@
+# guard for blueprint stone
+# includes standardized self-review frame + human approval
+
+reviews:
+  self:
+    # 1. delete before optimize
+    - slug: has-questioned-deletables
+      say: |
+        try hard to delete before you optimize:
+
+        for each component, ask:
+        - can this be removed entirely?
+        - if we deleted this and had to add it back, would we?
+        - did we optimize a component that shouldn't exist?
+        - what is the simplest version that works?
+
+        delete and simplify before we proceed.
+
+    # 2. question assumptions
+    - slug: has-questioned-assumptions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the blueprint due to this.
+
+        are there any hidden technical assumptions the junior made?
+
+        for each assumption, ask:
+        - what do we assume here without evidence?
+        - what if the opposite were true?
+        - is this architecture choice based on evidence or habit?
+        - what exceptions or counterexamples exist?
+        - could a simpler approach work?
+
+        surface all technical assumptions and question each one.
+
+    # 3. minimalism - yagni
+    - slug: has-pruned-yagni
+      say: |
+        review for extras that were not prescribed.
+
+        YAGNI = "you ain't gonna need it"
+
+        for each component in the blueprint, ask:
+        - was this explicitly requested in the vision or criteria?
+        - is this the minimum viable way to satisfy the requirement?
+        - did we add abstraction "for future flexibility"?
+        - did we add features "while we're here"?
+        - did we optimize before we knew it was needed?
+
+        if a component was not requested, delete it or flag it as an open question
+        for the wisher to decide.
+
+    # 4. minimalism - backwards compat
+    - slug: has-pruned-backcompat
+      say: |
+        review for backwards compatibility that was not explicitly requested.
+
+        for each backwards-compat concern in the blueprint, ask:
+        - did the wisher explicitly say to maintain this compatibility?
+        - is there evidence this backwards compat is needed?
+        - or did we assume it "to be safe"?
+
+        if backwards compat was not explicitly requested:
+        1. flag it as an open question for the wisher
+        2. eliminate it if not confirmed as required
+        3. make the open question very clearly reported
+
+    # 5. consistency - mechanisms
+    - slug: has-consistent-mechanisms
+      say: |
+        review for new mechanisms that duplicate extant functionality.
+
+        unless the ask was to refactor, be consistent with extant mechanisms.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). look for extant utilities, helpers, and patterns.
+
+        then for each new mechanism in the blueprint, ask:
+        - does the codebase already have a mechanism that does this?
+        - do we duplicate extant utilities, helpers, or patterns?
+        - could we reuse an extant component instead of a new one?
+
+        if a new mechanism duplicates extant functionality:
+        1. replace with the extant mechanism
+        2. or flag as an open question if unsure
+
+    # 6. consistency - conventions
+    - slug: has-consistent-conventions
+      say: |
+        review for divergence from extant names and patterns.
+
+        unless the ask was to refactor, be consistent with extant conventions.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). identify extant name conventions and patterns.
+
+        then for each name choice in the blueprint, ask:
+        - what name conventions does the codebase use?
+        - do we use a different namespace, prefix, or suffix pattern?
+        - do we introduce new terms when extant terms exist?
+        - does our structure match extant patterns?
+
+        if we diverge from extant conventions:
+        1. align with the extant convention
+        2. or flag as an open question if the extant convention seems wrong
+
+    # 7. behavior declaration - coverage
+    - slug: has-behavior-declaration-coverage
+      say: |
+        review for coverage of the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have omitted
+        requirements or left features unimplemented.
+
+        go through the behavior's vision and criteria, then check
+        each requirement against the blueprint line by line:
+        - is every requirement from the vision addressed?
+        - is every criterion from the criteria satisfied?
+        - did the junior skip or forget any part of the spec?
+
+        fix all gaps before you continue.
+
+    # 8. behavior declaration - adherance
+    - slug: has-behavior-declaration-adherance
+      say: |
+        review for adherance to the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have drifted
+        from the spec or implemented items incorrectly.
+
+        go through the blueprint line by line, and check
+        against the behavior's vision and criteria:
+        - does the blueprint match what the vision describes?
+        - does the blueprint satisfy the criteria correctly?
+        - did the junior misinterpret or deviate from the spec?
+
+        fix all gaps before you continue.
+
+    # 9. role standards - adherance
+    - slug: has-role-standards-adherance
+      say: |
+        review for adherance to mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have introduced
+        bad practices or violated patterns that we require.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this blueprint
+        - confirm you have not missed any rule categories
+
+        then go through the blueprint line by line, and check:
+        - does the blueprint follow mechanic standards correctly?
+        - are there violations of required patterns?
+        - did the junior introduce anti-patterns, bad practices, or deviations from our conventions?
+
+        fix all gaps before you continue.
+
+    # 10. role standards - coverage
+    - slug: has-role-standards-coverage
+      say: |
+        review for coverage of mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have forgotten
+        best practices or omitted patterns that should be present.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this blueprint
+        - confirm you have not missed any rule categories
+
+        then go through the blueprint line by line, and check:
+        - are all relevant mechanic standards applied?
+        - are there patterns that should be present but are absent?
+        - did the junior forget to include error handle, validation, tests, types, or other required practices?
+
+        fix all gaps before you continue.
+
+  peer:
+    - bash -c ". .agent/repo=.this/role=any/skills/use.apikeys.sh && npx rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '$route/3.3.blueprint.*.md' --join intersect --output '$route/.reviews/$stone.peer-review.failhides.md' --mode hard 2>&1"
+
+judges:
+  - npx rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3
+  - npx rhachet run --repo bhrain --skill route.stone.judge --mechanism approved? --stone $stone --route $route

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/3.3.1.blueprint.product.v1.i1.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/3.3.1.blueprint.product.v1.i1.md
@@ -1,0 +1,182 @@
+# blueprint: product
+
+---
+
+## summary
+
+create `formatWalkTheWay` as a reusable component that replaces solo "articulate into" sections. update both `formatPatienceFriend` and `formatLetsReflect` to use it.
+
+---
+
+## filediff tree
+
+```
+src/domain.operations/route/guard/
+├── [+] formatWalkTheWay.ts          # new reusable component
+├── [+] formatWalkTheWay.test.ts     # unit tests for new component
+├── [~] formatPatienceFriend.ts      # update to use formatWalkTheWay
+├── [~] formatPatienceFriend.test.ts # extend assertions
+├── [~] formatLetsReflect.ts         # update to use formatWalkTheWay
+└── [~] formatLetsReflect.test.ts    # extend assertions
+```
+
+---
+
+## codepath tree
+
+### formatWalkTheWay.ts [+] create
+
+```typescript
+export const formatWalkTheWay = (input: {
+  route: string;
+  stone: string;
+  slug: string;
+}): string[] => {
+  const articulationPath = `${input.route}/review/self/${input.stone}.${input.slug}.md`;
+  const lines: string[] = [];
+
+  // [+] walk the way header
+  lines.push(`   ├─ walk the way 🪷`);
+  lines.push(`   │  │`);
+
+  // [+] articulate into (nested)
+  lines.push(`   │  ├─ articulate into`);
+  lines.push(`   │  │  └─ ${articulationPath}`);
+  lines.push(`   │  │`);
+
+  // [+] for each found issue drum block
+  lines.push(`   │  ├─ for each found issue 🪘`);
+  lines.push(`   │  │  ├─`);
+  lines.push(`   │  │  │`);
+  lines.push(`   │  │  │  articulate how it was fixed`);
+  lines.push(`   │  │  │  so you remember for next time`);
+  lines.push(`   │  │  │`);
+  lines.push(`   │  │  └─`);
+  lines.push(`   │  │`);
+
+  // [+] for each non issue drum block
+  lines.push(`   │  └─ for each non issue 🪘`);
+  lines.push(`   │     ├─`);
+  lines.push(`   │     │`);
+  lines.push(`   │     │  articulate why it holds`);
+  lines.push(`   │     │  so others can learn from it`);
+  lines.push(`   │     │`);
+  lines.push(`   │     └─`);
+
+  return lines;
+};
+```
+
+### formatPatienceFriend.ts [~] update
+
+```typescript
+// [-] delete old articulate into section
+// const articulationPath = `${input.route}/review/self/${input.stone}.${input.slug}.md`;
+// lines.push(`   ├─ articulate into`);
+// lines.push(`   │  └─ ${articulationPath}`);
+// lines.push(`   │`);
+
+// [+] replace with formatWalkTheWay call
+import { formatWalkTheWay } from './formatWalkTheWay';
+lines.push(...formatWalkTheWay(input));
+```
+
+### formatLetsReflect.ts [~] update
+
+```typescript
+// [-] delete old articulate into section
+// const articulationPath = `${input.route}/review/self/${input.stone}.${input.slug}.md`;
+// lines.push(`   ├─ articulate into`);
+// lines.push(`   │  └─ ${articulationPath}`);
+// lines.push(`   │`);
+
+// [+] replace with formatWalkTheWay call
+import { formatWalkTheWay } from './formatWalkTheWay';
+lines.push(...formatWalkTheWay(input));
+```
+
+---
+
+## test coverage
+
+### unit tests
+
+**formatWalkTheWay.test.ts** [+] create:
+```typescript
+then('output matches snapshot (vibecheck)', () => {
+  const output = formatWalkTheWay({
+    stone: '1.vision',
+    slug: 'all-done',
+    route: '.behavior/v2026_03_05.behavior-example',
+  });
+  expect(output.join('\n')).toMatchSnapshot();
+});
+
+then('contains walk the way header', () => {
+  const output = formatWalkTheWay({ ... });
+  expect(output.join('\n')).toContain('walk the way 🪷');
+});
+
+then('contains articulate into nested', () => {
+  const output = formatWalkTheWay({ ... });
+  expect(output.join('\n')).toContain('articulate into');
+  expect(output.join('\n')).toContain('.behavior/v2026_03_05.behavior-example/review/self/1.vision.all-done.md');
+});
+
+then('contains drum blocks', () => {
+  const output = formatWalkTheWay({ ... });
+  expect(output.join('\n')).toContain('for each found issue 🪘');
+  expect(output.join('\n')).toContain('for each non issue 🪘');
+});
+```
+
+**formatPatienceFriend.test.ts** [~] extend:
+- rename "contains articulation section" → "contains walk the way section"
+- add assertions for new structure
+
+**formatLetsReflect.test.ts** [~] extend:
+- rename "contains articulation section" → "contains walk the way section"
+- add assertions for new structure
+
+### snapshot regeneration
+
+after implementation:
+```bash
+RESNAP=true npm run test:unit -- formatWalkTheWay.test.ts
+RESNAP=true npm run test:unit -- formatPatienceFriend.test.ts
+RESNAP=true npm run test:unit -- formatLetsReflect.test.ts
+```
+
+---
+
+## contracts
+
+### input contract
+
+```typescript
+{
+  route: string;   // behavior route path
+  stone: string;   // stone identifier
+  slug: string;    // review slug
+}
+```
+
+### output contract
+
+```typescript
+string[]  // lines array for stdout
+```
+
+---
+
+## verification
+
+| criteria | verification |
+|----------|--------------|
+| "walk the way 🪷" present | containment assertion |
+| "articulate into" nested | containment assertion |
+| "for each found issue 🪘" present | containment assertion |
+| "for each non issue 🪘" present | containment assertion |
+| drum blocks have whitespace | snapshot vibecheck |
+| structure identical across flows | both tests share assertions |
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/3.3.1.blueprint.product.v1.stone
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/3.3.1.blueprint.product.v1.stone
@@ -1,0 +1,80 @@
+propose a blueprint for how we will implement the wish
+- in .behavior/v2026_03_11.selfreview-fix-clarify/0.wish.md
+- with .behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.domain.*.v1.i1.md (if declared)
+- with .behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.repros.experience.*.v1.i1.md (if declared)
+
+.why = blueprint the code changes needed to deliver the product.
+- the product is the deliverable (spec + impl)
+- explicit blueprint declares what the execution will adhere to
+
+follow the patterns already present in this repo.
+
+---
+
+## summary
+
+state what will be built.
+
+---
+
+## filediff tree
+
+include a treestruct of filediffs.
+
+**legend:**
+- `[+] create` — file to create
+- `[~] update` — file to update
+- `[-] delete` — file to delete
+
+---
+
+## codepath tree
+
+include a treestruct of codepaths.
+
+**legend:**
+- `[+]` create — codepath to create
+- `[~]` update — codepath to update
+- `[○]` retain — codepath to retain
+- `[-]` delete — codepath to delete
+- `[←]` reuse — codepath to reuse from elsewhere
+- `[→]` eject — codepath to decompose for reuse
+
+---
+
+## test coverage
+
+enforce thorough test coverage for proof of behavior satisfaction:
+- unit tests for domain logic
+- integration tests for access boundaries (os, apis, sdks, daos)
+- integration tests for end-to-end flows
+- acceptance tests for blackbox behaviors
+
+---
+
+remember, the purpose of the blueprint is to declare what the execution will adhere to.
+
+we want to see:
+- what contracts will be used
+- how domain.objects and domain.operations are decomposed and recomposed
+- what the codepaths are, their ease of maintenance and readability
+
+---
+
+reference
+- .behavior/v2026_03_11.selfreview-fix-clarify/0.wish.md
+- .behavior/v2026_03_11.selfreview-fix-clarify/1.vision.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/2.1.criteria.blackbox.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/2.3.criteria.blueprint.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.1.research.external.product.access.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.1.research.external.product.claims.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.1.research.external.product.domain.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.3.research.internal.product.code.prod.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.3.research.internal.product.code.test.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.domain.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.repros.experience.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.3.0.blueprint.factory.v1.i1.md (if declared)
+
+---
+
+emit into .behavior/v2026_03_11.selfreview-fix-clarify/3.3.1.blueprint.product.v1.i1.md

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/4.1.roadmap.v1.i1.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/4.1.roadmap.v1.i1.md
@@ -1,0 +1,123 @@
+# roadmap: selfreview-fix-clarify
+
+---
+
+## phase 0: preparation
+
+**read before:**
+- `.behavior/v2026_03_11.selfreview-fix-clarify/3.3.1.blueprint.product.v1.i1.md`
+
+**tasks:**
+- [ ] confirm grasp of blueprint structure
+- [ ] locate formatPatienceFriend.ts and formatLetsReflect.ts
+
+**verification:**
+- can articulate what formatWalkTheWay will produce
+- know where to add the new file
+
+---
+
+## phase 1: create formatWalkTheWay component
+
+**read before:**
+- `.behavior/v2026_03_11.selfreview-fix-clarify/3.3.1.blueprint.product.v1.i1.md` (codepath tree section)
+- `.behavior/v2026_03_11.selfreview-fix-clarify/1.vision.md` (proposed stdout section)
+
+**tasks:**
+- [ ] create `src/domain.operations/route/guard/formatWalkTheWay.ts`
+- [ ] implement the lines array with:
+  - walk the way 🪷 header
+  - nested articulate into
+  - for each found issue 🪘 drum block
+  - for each non issue 🪘 drum block
+- [ ] add .what/.why header comments
+
+**verification:**
+- file compiles with `npm run test:types`
+- function signature matches blueprint: `(input: { route, stone, slug }) => string[]`
+
+---
+
+## phase 2: create formatWalkTheWay tests
+
+**read before:**
+- `.behavior/v2026_03_11.selfreview-fix-clarify/3.1.3.research.internal.product.code.test._.v1.stone` (test patterns)
+- `.behavior/v2026_03_11.selfreview-fix-clarify/3.3.1.blueprint.product.v1.i1.md` (test coverage section)
+
+**tasks:**
+- [ ] create `src/domain.operations/route/guard/formatWalkTheWay.test.ts`
+- [ ] add snapshot vibecheck test
+- [ ] add containment assertions for:
+  - walk the way 🪷
+  - articulate into
+  - for each found issue 🪘
+  - for each non issue 🪘
+
+**verification:**
+- `npm run test:unit -- formatWalkTheWay.test.ts` passes
+- snapshot looks correct (review manually)
+
+---
+
+## phase 3: update formatPatienceFriend
+
+**read before:**
+- `.behavior/v2026_03_11.selfreview-fix-clarify/3.3.1.blueprint.product.v1.i1.md` (formatPatienceFriend section)
+- `.behavior/v2026_03_11.selfreview-fix-clarify/1.vision.md` (before/after comparison)
+
+**tasks:**
+- [ ] import formatWalkTheWay
+- [ ] remove old "articulate into" section
+- [ ] add `lines.push(...formatWalkTheWay(input))`
+- [ ] update test assertions for new structure
+
+**verification:**
+- `npm run test:unit -- formatPatienceFriend.test.ts` passes
+- snapshot shows "walk the way" section
+
+---
+
+## phase 4: update formatLetsReflect
+
+**read before:**
+- `.behavior/v2026_03_11.selfreview-fix-clarify/3.3.1.blueprint.product.v1.i1.md` (formatLetsReflect section)
+
+**tasks:**
+- [ ] import formatWalkTheWay
+- [ ] remove old "articulate into" section
+- [ ] add `lines.push(...formatWalkTheWay(input))`
+- [ ] update test assertions for new structure
+
+**verification:**
+- `npm run test:unit -- formatLetsReflect.test.ts` passes
+- snapshot shows "walk the way" section
+
+---
+
+## phase 5: final verification
+
+**read before:**
+- `.behavior/v2026_03_11.selfreview-fix-clarify/2.1.criteria.blackbox.md`
+
+**tasks:**
+- [ ] run full unit test suite: `npm run test:unit`
+- [ ] regenerate snapshots if needed: `RESNAP=true npm run test:unit`
+- [ ] verify both formatters show identical "walk the way" structure
+
+**verification:**
+- all unit tests pass
+- no solo "articulate into" at top level in either formatter
+- both drum blocks have equal visual weight
+
+---
+
+## dependencies
+
+```
+phase 0 → phase 1 → phase 2 → phase 3 → phase 4 → phase 5
+                              ↓         ↓
+                           (parallel if desired)
+```
+
+phases 3 and 4 can run in parallel after phase 2 completes.
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/4.1.roadmap.v1.stone
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/4.1.roadmap.v1.stone
@@ -1,0 +1,45 @@
+declare a roadmap,
+
+- checklist style
+- with ordered dependencies
+- with behavioral acceptance criteria
+- with behavioral acceptance verification at each step
+
+for how to execute the blueprints specified in
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.3.0.blueprint.factory.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.3.1.blueprint.product.v1.i1.md
+
+ref:
+- .behavior/v2026_03_11.selfreview-fix-clarify/0.wish.md
+- .behavior/v2026_03_11.selfreview-fix-clarify/1.vision.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/2.1.criteria.blackbox.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/2.3.criteria.blueprint.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.1.research.external.product.access.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.1.research.external.product.claims.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.1.research.external.product.domain.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.2.research.external.factory.testloops.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.2.research.external.factory.oss.levers.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.2.research.external.factory.templates.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.3.research.internal.product.code.prod.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.3.research.internal.product.code.test.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.4.research.internal.factory.blockers.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.1.4.research.internal.factory.opports.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.domain.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.repros.experience.*.v1.i1.md (if declared)
+
+---
+
+be clear as to which briefs should be read before each phase
+
+for example,
+- if the phase includes tests, remind the builder to read
+  - .behavior/v2026_03_11.selfreview-fix-clarify/3.1.3.research.internal.product.code.test.*.v1.i1.md (if declared)
+- if the phase includes acceptance tests, remind the builder to read
+  - .behavior/v2026_03_11.selfreview-fix-clarify/2.1.criteria.blackbox.md (if declared)
+- if the phase includes domain.objects, remind the builder to read
+  - .behavior/v2026_03_11.selfreview-fix-clarify/3.1.1.research.external.product.domain.*.v1.i1.md (if declared)
+etc
+
+---
+
+emit into .behavior/v2026_03_11.selfreview-fix-clarify/4.1.roadmap.v1.i1.md

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/5.1.execution.phase0_to_phaseN.v1.guard
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/5.1.execution.phase0_to_phaseN.v1.guard
@@ -1,0 +1,157 @@
+# guard for execution stone
+# includes standardized self-review frame
+
+reviews:
+  self:
+    # 1. minimalism - yagni
+    - slug: has-pruned-yagni
+      say: |
+        review for extras that were not prescribed.
+
+        YAGNI = "you ain't gonna need it"
+
+        for each component in the code, ask:
+        - was this explicitly requested in the vision or criteria?
+        - is this the minimum viable way to satisfy the requirement?
+        - did we add abstraction "for future flexibility"?
+        - did we add features "while we're here"?
+        - did we optimize before we knew it was needed?
+
+        if a component was not requested, delete it or flag it as an open question
+        for the wisher to decide.
+
+    # 2. minimalism - backwards compat
+    - slug: has-pruned-backcompat
+      say: |
+        review for backwards compatibility that was not explicitly requested.
+
+        for each backwards-compat concern in the code, ask:
+        - did the wisher explicitly say to maintain this compatibility?
+        - is there evidence this backwards compat is needed?
+        - or did we assume it "to be safe"?
+
+        if backwards compat was not explicitly requested:
+        1. flag it as an open question for the wisher
+        2. eliminate it if not confirmed as required
+        3. make the open question very clearly reported
+
+    # 3. consistency - mechanisms
+    - slug: has-consistent-mechanisms
+      say: |
+        review for new mechanisms that duplicate extant functionality.
+
+        unless the ask was to refactor, be consistent with extant mechanisms.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). look for extant utilities, helpers, and patterns.
+
+        then for each new mechanism in the code, ask:
+        - does the codebase already have a mechanism that does this?
+        - do we duplicate extant utilities, helpers, or patterns?
+        - could we reuse an extant component instead of a new one?
+
+        if a new mechanism duplicates extant functionality:
+        1. replace with the extant mechanism
+        2. or flag as an open question if unsure
+
+    # 4. consistency - conventions
+    - slug: has-consistent-conventions
+      say: |
+        review for divergence from extant names and patterns.
+
+        unless the ask was to refactor, be consistent with extant conventions.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). identify extant name conventions and patterns.
+
+        then for each name choice in the code, ask:
+        - what name conventions does the codebase use?
+        - do we use a different namespace, prefix, or suffix pattern?
+        - do we introduce new terms when extant terms exist?
+        - does our structure match extant patterns?
+
+        if we diverge from extant conventions:
+        1. align with the extant convention
+        2. or flag as an open question if the extant convention seems wrong
+
+    # 5. review against behavior declaration - coverage
+    - slug: behavior-declaration-coverage
+      say: |
+        review for coverage of the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have omitted
+        requirements or left features unimplemented.
+
+        go through the behavior's vision, criteria, and blueprint, then check
+        each requirement against the code line by line:
+        - is every requirement from the vision addressed?
+        - is every criterion from the criteria satisfied?
+        - is every component from the blueprint implemented?
+        - did the junior skip or forget any part of the spec?
+
+        fix all gaps before you continue.
+
+    # 6. review against behavior declaration - adherance
+    - slug: behavior-declaration-adherance
+      say: |
+        review for adherance to the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have drifted
+        from the spec or implemented items incorrectly.
+
+        go through each file changed in this pr, line by line, and check
+        against the behavior's vision, criteria, and blueprint:
+        - does the implementation match what the vision describes?
+        - does the implementation satisfy the criteria correctly?
+        - does the implementation follow the blueprint accurately?
+        - did the junior misinterpret or deviate from the spec?
+
+        fix all gaps before you continue.
+
+    # 7. review against role standards - adherance
+    - slug: role-standards-adherance
+      say: |
+        review for adherance to mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have introduced
+        bad practices or violated patterns that we require.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - does the code follow mechanic standards correctly?
+        - are there violations of required patterns?
+        - did the junior introduce anti-patterns, bad practices, or deviations from our conventions?
+
+        fix all gaps before you continue.
+
+    # 8. review against role standards - coverage
+    - slug: role-standards-coverage
+      say: |
+        review for coverage of mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have forgotten
+        best practices or omitted patterns that should be present.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - are all relevant mechanic standards applied?
+        - are there patterns that should be present but are absent?
+        - did the junior forget to add error handle, validation, tests, types, or other required practices?
+
+        fix all gaps before you continue.
+
+  peer:
+    - bash -c ". .agent/repo=.this/role=any/skills/use.apikeys.sh && npx rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with 'src/**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.failhides.md' --mode hard 2>&1"
+
+judges:
+  - npx rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/5.1.execution.phase0_to_phaseN.v1.i1.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/5.1.execution.phase0_to_phaseN.v1.i1.md
@@ -1,0 +1,40 @@
+# execution progress
+
+## phase 0: preparation
+- [x] confirm grasp of blueprint structure
+- [x] locate formatPatienceFriend.ts and formatLetsReflect.ts
+
+## phase 1: create formatWalkTheWay component
+- [x] create `src/domain.operations/route/guard/formatWalkTheWay.ts`
+- [x] implement the lines array
+- [x] add .what/.why header comments
+
+## phase 2: create formatWalkTheWay tests
+- [x] create `src/domain.operations/route/guard/formatWalkTheWay.test.ts`
+- [x] add snapshot vibecheck test
+- [x] add containment assertions
+
+## phase 3: update formatPatienceFriend
+- [x] import formatWalkTheWay
+- [x] remove old "articulate into" section
+- [x] add `lines.push(...formatWalkTheWay(input))`
+- [x] update test assertions
+
+## phase 4: update formatLetsReflect
+- [x] import formatWalkTheWay
+- [x] remove old "articulate into" section
+- [x] add `lines.push(...formatWalkTheWay(input))`
+- [x] update test assertions
+
+## phase 5: final verification
+- [x] run full unit test suite (508 tests pass)
+- [x] verify both formatters show identical structure
+
+## summary
+
+all phases complete. implementation delivers:
+- formatWalkTheWay.ts — reusable component with drum blocks
+- formatPatienceFriend.ts — updated to use formatWalkTheWay
+- formatLetsReflect.ts — updated to use formatWalkTheWay
+- all unit tests pass (508 total)
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/5.1.execution.phase0_to_phaseN.v1.stone
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/5.1.execution.phase0_to_phaseN.v1.stone
@@ -1,0 +1,24 @@
+bootup your mechanic's role via `npx rhachet roles boot --repo ehmpathy --role mechanic`
+
+then, start or continue to execute
+- phase0 to phaseN
+of roadmap
+- .behavior/v2026_03_11.selfreview-fix-clarify/4.1.roadmap.v1.i1.md
+
+ref:
+- .behavior/v2026_03_11.selfreview-fix-clarify/0.wish.md
+- .behavior/v2026_03_11.selfreview-fix-clarify/1.vision.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/2.1.criteria.blackbox.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/2.3.criteria.blueprint.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.domain.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.2.distill.repros.experience.*.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.3.0.blueprint.factory.v1.i1.md (if declared)
+- .behavior/v2026_03_11.selfreview-fix-clarify/3.3.1.blueprint.product.v1.i1.md
+
+
+---
+
+track your progress
+
+emit todos and check them off into
+- .behavior/v2026_03_11.selfreview-fix-clarify/5.1.execution.phase0_to_phaseN.v1.i1.md

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/5.3.verification.v1.guard
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/5.3.verification.v1.guard
@@ -1,0 +1,54 @@
+reviews:
+  self:
+    - slug: has-behavior-coverage
+      say: |
+        double-check: does the verification checklist show every behavior from wish/vision has a test?
+
+        - is every behavior in 0.wish.md covered?
+        - is every behavior in 1.vision.md covered?
+        - can you point to each test file in the checklist?
+
+    - slug: has-zero-test-skips
+      say: |
+        double-check: did you verify zero skips?
+
+        - no .skip() or .only() found?
+        - no silent credential bypasses?
+        - no prior failures carried forward?
+
+    - slug: has-all-tests-passed
+      say: |
+        double-check: did all tests pass?
+
+        - did you run `npm run test`?
+        - did types, lint, unit, integration, acceptance all pass?
+        - if any failed, did you fix them or emit a handoff?
+
+        zero tolerance for extant failures:
+        - "it was already broken" is not an excuse — fix it
+        - "it's unrelated to my changes" is not an excuse — fix it
+        - flaky tests must be stabilized, not tolerated
+        - every failure is your responsibility now
+
+    - slug: has-preserved-test-intentions
+      say: |
+        double-check: did you preserve test intentions?
+
+        for every test you touched:
+        - what did this test verify before?
+        - does it still verify the same behavior after?
+        - did you change what the test asserts, or fix why it failed?
+
+        forbidden:
+        - weaken assertions to make tests pass
+        - remove test cases that "no longer apply"
+        - change expected values to match broken output
+        - delete tests that fail instead of fix code
+
+        the test knew a truth. if it failed, either:
+        - the code is wrong — fix the code
+        - the test has a bug — fix the bug, keep the intention
+        - requirements changed — document why, get approval
+
+        to "fix tests" via changed intent is not a fix — it is at worst
+        malicious deception, at best reckless negligence. unacceptable.

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/5.3.verification.v1.i1.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/5.3.verification.v1.i1.md
@@ -1,0 +1,34 @@
+# verification checklist
+
+## behavior coverage
+
+| behavior (from wish/vision) | test file | status |
+|-----------------------------|-----------|--------|
+| "walk the way 🪷" section appears in stdout | formatWalkTheWay.test.ts | ✅ |
+| "articulate into" nested under "walk the way" | formatWalkTheWay.test.ts | ✅ |
+| "for each found issue 🪘" drum block present | formatWalkTheWay.test.ts | ✅ |
+| "for each non issue 🪘" drum block present | formatWalkTheWay.test.ts | ✅ |
+| both drum blocks have equal visual weight | formatWalkTheWay.test.ts (snapshot) | ✅ |
+| formatPatienceFriend uses formatWalkTheWay | formatPatienceFriend.test.ts | ✅ |
+| formatLetsReflect uses formatWalkTheWay | formatLetsReflect.test.ts | ✅ |
+
+## zero skips verified
+
+- [x] no .skip() or .only() found
+- [x] no silent credential bypasses
+- [x] no prior failures carried forward
+
+## snapshot coverage for contract outputs
+
+- [x] formatWalkTheWay.test.ts has snapshot for "walk the way" stdout
+- [x] formatPatienceFriend.test.ts has snapshot for full challenge output
+- [x] formatLetsReflect.test.ts has snapshot for full reflect output
+- [x] snapshots demonstrate actual output structure
+
+## tests executed
+
+- [x] `npm run test` — 617 passed, 32 test suites, exit 0
+
+## blockers
+
+- none

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/5.3.verification.v1.stone
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/5.3.verification.v1.stone
@@ -1,0 +1,169 @@
+prove the deliverable works via test verification
+
+---
+
+## .what
+
+this is the verification gate. you cannot pass execution without proof that all tests pass.
+
+## .why
+
+**why does this gate exist?**
+
+your crew is about to review a pr you wrote. they need proof it works — not words, proof. tests are that proof.
+
+without this gate:
+- tests might fail and nobody notices
+- tests might be skipped and nobody notices
+- behaviors might lack coverage and nobody notices
+- broken code ships to peers
+
+with this gate:
+- every test passes or you fix it
+- every behavior has coverage or you add it
+- every skip is removed or justified
+- proven code ships to peers
+
+**the cardinal rules**:
+1. never leave behavior without true, dependable test coverage
+2. never offload work onto your crew unless there is truly, fundamentally no other option
+
+you fix it yourself. you exhaust every option: debug, research, try alternatives. only when you hit a wall that is physically impossible to climb alone — credentials only the foreman possesses, access only they can grant — only then may you ask for help.
+
+## .how
+
+reference the below for full context
+- .behavior/v2026_03_11.selfreview-fix-clarify/0.wish.md
+- .behavior/v2026_03_11.selfreview-fix-clarify/1.vision.md
+- .behavior/v2026_03_11.selfreview-fix-clarify/2.1.criteria.blackbox.md (if declared)
+
+---
+
+### step 1: emit verification checklist
+
+emit to
+- .behavior/v2026_03_11.selfreview-fix-clarify/5.3.verification.v1.i1.md
+
+this is your roadmap. emit it first, then work through it step by step.
+
+**checklist structure:**
+
+```
+## verification checklist
+
+### behavior coverage
+| behavior (from wish/vision) | test file | status |
+|-----------------------------|-----------|--------|
+| {behavior 1}                | {path}    | ⏳     |
+| {behavior 2}                | {path}    | ⏳     |
+...
+
+### zero skips verified
+- [ ] no .skip() or .only() found
+- [ ] no silent credential bypasses
+- [ ] no prior failures carried forward
+
+### snapshot coverage for contract outputs
+- [ ] new cli commands have `.snap` snapshots for stdout/stderr
+- [ ] new app screens have `.snap` snapshots for screenshots
+- [ ] snapshot demonstrates actual output, not just "it ran"
+
+### tests executed
+- [ ] `npm run test` — passed
+
+### blockers
+- none (or list handoff references)
+```
+
+update the checklist as you complete each step below.
+
+---
+
+### step 2: verify behavior coverage
+
+walk through wish and vision:
+- every behavior promised must have an acceptance test
+- for each behavior, you can point to the test file
+- no behavior left untested
+
+**why?** your crew trusts the test suite. if a behavior isn't tested, it isn't proven. untested behaviors are unverified promises.
+
+if a behavior lacks a test, write one. update your checklist.
+
+---
+
+### step 3: verify zero skips
+
+scan for forbidden patterns:
+- `.skip()` or `.only()` in test files
+- `if (!credentials) return` or similar silent bypasses
+- prior failures carried forward (known-broken tests)
+
+**why?** failures are better than skips. skips hide problems. failures expose them. a skipped test is a lie — it pretends coverage exists when it doesn't.
+
+if you find skips, remove them. all tests must run. update your checklist.
+
+---
+
+### step 4: run all tests and fix all failures
+
+run `npm run test`. all must pass — no exceptions.
+
+if tests fail, fix them. that is the job.
+
+**consider all failures as defects from this pr.** there are no "prior failures."
+
+if a test was broken before you started — fix it. if a test is flaky — fix it. if a test fails for reasons unrelated to your changes — fix it anyway. you do not get to say "that was already broken." you are here now. you fix it.
+
+**take initiative. take ownership.**
+
+**preserve test intentions.** when you fix a test, you fix why it failed — not what it tests. to change what a test verifies is not a fix. it is at worst malicious deception, at best reckless negligence. the test knew a truth. if it fails, either the code is wrong or the test has a bug. fix the cause, not the assertion.
+
+**escalation path:**
+1. debug the failure — read the error, understand the cause
+2. research — search for similar issues, read docs
+3. try alternatives — different approach, different tool
+4. ask for help — other resources, other clones
+5. deeper research — exhaust every option
+6. only if insurmountable — emit handoff (see step 5)
+
+**ask yourself at each level:**
+- did i read the error message carefully?
+- did i search for similar issues?
+- did i try a different approach?
+- did i isolate the problem?
+- did i ask for help?
+- did i exhaust every option?
+
+you move to handoff only when you can answer "yes" to all of the above and still cannot proceed.
+
+update your checklist when all tests pass.
+
+---
+
+### step 5: handoff (only if insurmountable)
+
+a handoff is a document that transfers work to your foreman because you hit a wall that is physically impossible to climb alone.
+
+**foreman-only blockers:**
+- credentials only the foreman possesses
+- external access only the foreman can grant
+- approval that requires foreman authority
+
+handoff is the absolute last resort. you must exhaust every option before you consider it.
+
+if you need to emit a handoff:
+
+emit to
+- .behavior/v2026_03_11.selfreview-fix-clarify/5.3.verification.handoff.v$N.to_foreman.md
+
+**handoff must include:**
+1. what you tried (list every approach you attempted)
+2. why each approach failed (be specific)
+3. what makes this fundamentally impossible without foreman intervention
+4. is this truly a "foreman possesses the key" situation?
+5. rewind instruction: `rhx route.stone.set --stone 5.3.verification --as rewound`
+
+your crew should read your handoff and think: "yes, there was truly no other way."
+
+update your checklist to reference the handoff.

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/5.5.playtest.v1.guard
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/5.5.playtest.v1.guard
@@ -1,0 +1,28 @@
+reviews:
+  self:
+    - slug: has-clear-instructions
+      say: |
+        double-check: are the instructions followable?
+
+        - can the foreman follow without prior context?
+        - are commands copy-pasteable?
+        - are expected outcomes explicit?
+
+    - slug: has-vision-coverage
+      say: |
+        double-check: does the playtest cover all behaviors?
+
+        - is every behavior in 0.wish.md verified?
+        - is every behavior in 1.vision.md verified?
+        - are any requirements left untested?
+
+    - slug: has-edgecase-coverage
+      say: |
+        double-check: are edge cases covered?
+
+        - what could go wrong?
+        - what inputs are unusual but valid?
+        - are boundaries tested?
+
+judges:
+  - npx rhachet run --repo bhrain --skill route.stone.judge --mechanism approved? --stone $stone --route $route

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/5.5.playtest.v1.i1.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/5.5.playtest.v1.i1.md
@@ -1,0 +1,96 @@
+# playtest: walk the way selfreview stdout
+
+## prerequisites
+
+- node 18+ installed
+- repo built (`npm run build` completed)
+- in the repo root directory
+
+## sandbox
+
+- all test operations use extant test infrastructure
+- no manual file writes needed
+
+## happy paths
+
+### 1. verify formatPatienceFriend output
+
+**action:** run the unit test and check the snapshot
+
+```bash
+npm run test:unit -- formatPatienceFriend.test.ts
+```
+
+**expected outcome:**
+- test passes
+- snapshot in `__snapshots__/formatPatienceFriend.test.ts.snap` shows:
+  - `├─ walk the way 🪷` section present
+  - `├─ articulate into` nested inside walk the way
+  - `├─ for each found issue 🪘` drum block present
+  - `└─ for each non issue 🪘` drum block present
+
+### 2. verify formatLetsReflect output
+
+**action:** run the unit test and check the snapshot
+
+```bash
+npm run test:unit -- formatLetsReflect.test.ts
+```
+
+**expected outcome:**
+- test passes
+- snapshot in `__snapshots__/formatLetsReflect.test.ts.snap` shows same structure as formatPatienceFriend
+
+### 3. verify live selfreview output
+
+**action:** trigger a real selfreview challenge
+
+```bash
+# from a behavior route with a guarded stone, attempt passage
+npx rhx route.stone.set --stone 5.3.verification.v1 --as passed
+```
+
+**expected outcome:**
+- if patience timer triggers, output shows:
+  - `🗿 patience, friend` header
+  - `├─ walk the way 🪷` section
+  - both drum blocks (🪘) nested inside
+- if lets reflect triggers, output shows:
+  - `🌕 lets reflect` header
+  - `├─ walk the way 🪷` section
+  - both drum blocks (🪘) nested inside
+
+### 4. verify drum block symmetry
+
+**action:** visually inspect the "walk the way" section in any selfreview output
+
+**expected outcome:**
+- "for each found issue" and "for each non issue" blocks have:
+  - same indentation level (they are siblings)
+  - same bucket structure (├─ opener, whitespace, content, whitespace, └─ closer)
+  - equal visual weight (neither dominates the other)
+
+## edgey paths
+
+### e1. first promise attempt
+
+trigger a guarded stone for the first time (no prior promises)
+
+**expected behavior:**
+- formatPatienceFriend output appears (not formatLetsReflect)
+- "walk the way" section present with both drum blocks
+
+### e2. rapid promise attempt
+
+attempt promise twice within patience window
+
+**expected behavior:**
+- "🍂 what is the rush?" section appears
+- followed by patience, friend with walk the way section
+- followed by lets reflect with walk the way section
+
+## pass/fail criteria
+
+- ✓ pass if: all selfreview outputs show "walk the way 🪷" section with both peer drum blocks nested inside, and "articulate into" is nested (not at top level)
+
+- ✗ fail if: "articulate into" appears at top level without "walk the way" wrapper, or either drum block is absent, or drum blocks have unequal visual weight

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/5.5.playtest.v1.stone
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/5.5.playtest.v1.stone
@@ -1,0 +1,100 @@
+emit a playtest for foreman byhand verification
+
+---
+
+## .what
+
+this is the playtest gate. you emit a step-by-step byhand quality assurance checklist that your crew can walk through to verify the deliverable feels right.
+
+automated tests prove the code works. the playtest proves the experience works.
+
+## .why
+
+**your crew deserves confidence.** they're about to approve work they didn't do themselves. the playtest gives them a path to verify with their own hands.
+
+**automated tests have blind spots.** they verify behavior but miss ux friction, unclear flows, edge cases that "work" but feel wrong. the playtest catches what tests can't.
+
+**the playtest is a contract.** it says: "if you follow these steps and everything works as described, the deliverable is complete." it's explicit proof, not implicit trust.
+
+## .how
+
+reference the below for full context
+- .behavior/v2026_03_11.selfreview-fix-clarify/0.wish.md
+- .behavior/v2026_03_11.selfreview-fix-clarify/1.vision.md
+- .behavior/v2026_03_11.selfreview-fix-clarify/2.1.criteria.blackbox.md (if declared)
+
+---
+
+### step 1: identify behaviors to verify
+
+walk through wish and vision:
+- list every behavior your crew should verify by hand
+- include edge cases and boundary conditions
+- what could go wrong? what inputs are unusual but valid?
+
+**ask yourself:**
+- what would your crew want to try first?
+- what would make them confident the feature works?
+- what would make them nervous if untested?
+
+---
+
+### step 2: write step-by-step instructions
+
+**each step must be:**
+- clear and unambiguous
+- followable by a foreman without prior context
+- commands are copy-pasteable
+- expected outcomes are explicit
+
+**the test:** could someone who has never seen this codebase follow these steps? if not, add more detail.
+
+---
+
+### step 3: include pass/fail criteria
+
+for each step:
+- what does success look like?
+- what would indicate failure?
+
+**be specific.** "it works" is not a pass criterion. "the output shows X and contains Y" is.
+
+---
+
+### step 4: emit the playtest
+
+emit to
+- .behavior/v2026_03_11.selfreview-fix-clarify/5.5.playtest.v1.i1.md
+
+**playtest structure:**
+
+```
+## playtest: {behavior name}
+
+### prerequisites
+- what your crew needs before start (dependencies, setup, access)
+
+### sandbox
+- all os.fileops (file creates, writes, deletes) must target `@gitroot/.temp/`
+- never pollute the repo root or other directories in playtest steps
+
+### happy paths
+1. [action] → [expected outcome]
+2. [action] → [expected outcome]
+...
+
+### edgey paths
+- [edge case 1] → [expected behavior]
+- [edge case 2] → [expected behavior]
+...
+
+### pass/fail criteria
+- ✓ pass if: {specific observable outcome}
+- ✗ fail if: {specific failure indicator}
+```
+
+---
+
+the guard will block until the foreman approves after the playtest run.
+
+your crew runs the playtest, verifies each step, and approves when satisfied.

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/1.vision.has-questioned-assumptions.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/1.vision.has-questioned-assumptions.md
@@ -1,0 +1,74 @@
+# self-review: 1.vision.has-questioned-assumptions
+
+## assumptions surfaced and questioned
+
+### 1. assumption: "articulate" + "initiate" are the right verbs
+
+| question | answer |
+|----------|--------|
+| what do we assume? | these two words capture the full self-review |
+| what evidence? | wish says "articulate" and "take initiative" |
+| what if opposite? | different verbs might resonate better |
+| did wisher say this? | "articulate" yes; "initiate" inferred from "take initiative" |
+
+**verdict**: "articulate" is solid. "initiate" is inferred — could use "act" or "fix" instead.
+
+### 2. assumption: agents will understand "initiate"
+
+| question | answer |
+|----------|--------|
+| what do we assume? | agents parse "initiate" as "fix the defects" |
+| what evidence? | none — it's an unusual word in this context |
+| what if opposite? | agents may not connect "initiate" to "fix defects" |
+| counterexamples? | "initiate" often means "start" not "fix" |
+
+**verdict**: risky assumption. the subtext "fix them — don't wait to be asked" helps, but "initiate" alone may confuse.
+
+### 3. assumption: condensed output is better
+
+| question | answer |
+|----------|--------|
+| what do we assume? | brevity improves comprehension |
+| what evidence? | research shows forced articulation works; doesn't prescribe length |
+| what if opposite? | some agents may benefit from the longer zen frame |
+| counterexamples? | rushed agents skim both short and long text |
+
+**verdict**: mixed. brevity helps clarity but may lose the contemplative pause effect.
+
+### 4. assumption: two questions should replace "trust the way"
+
+| question | answer |
+|----------|--------|
+| what do we assume? | new section replaces old |
+| what evidence? | wish wants two questions to be prominent |
+| what if opposite? | keep both — questions for action, "trust the way" for mindset |
+| did wisher say? | wisher said "frame it in two questions" — not "replace all else" |
+
+**verdict**: questionable. may be better to **add** the two questions rather than **replace** current sections.
+
+### 5. assumption: zen vibe stays with fewer words
+
+| question | answer |
+|----------|--------|
+| what do we assume? | questions can carry zen energy |
+| what evidence? | zen koans are brief questions |
+| what if opposite? | questions feel like a checklist, not contemplation |
+| counterexamples? | "did you articulate?" lacks the lotus/pond imagery |
+
+**verdict**: partially true. the questions ARE zen-like (koans), but lack the nature metaphors.
+
+## actions taken
+
+based on this review, I should update the vision to:
+1. consider to keep "be here now" section alongside the two questions
+2. reconsider whether "initiate" needs a friendlier alternative
+3. clarify that two questions **augment** rather than **replace**
+
+**note**: these are open questions to validate with wisher, not defects to fix now.
+
+## summary
+
+key risky assumption: "initiate" may not clearly mean "fix defects"
+key opportunity: add two questions alongside current sections rather than replace
+
+🦉

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/1.vision.has-questioned-questions.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/1.vision.has-questioned-questions.md
@@ -1,0 +1,86 @@
+# self-review: 1.vision.has-questioned-questions
+
+## open questions triaged
+
+### 1. should "initiate" use a different word?
+
+| triage | answer |
+|--------|--------|
+| can be researched? | partially — can analyze word connotations |
+| can be reasoned? | yes |
+| needs wisher? | yes — this is a tone/vibe decision |
+
+**self-answer attempt:**
+- "initiate" comes from wish phrase "take initiative"
+- but "initiate" typically means "start" not "fix"
+- alternatives: "act" (too vague), "fix" (too direct), "correct" (formal)
+- "initiate" has benefit of unfamiliarity — forces attention
+
+**recommendation to wisher:**
+the question "did you initiate?" needs clarification. options:
+1. keep "initiate" — unfamiliar = attention-grab
+2. use "act" — shorter, but vague
+3. use full phrase: "did you take initiative?" — clearest but longer
+
+**escalate to wisher**: yes
+
+### 2. should the questions include fuller context?
+
+| triage | answer |
+|--------|--------|
+| can be researched? | yes — research on instruction clarity |
+| can be reasoned? | yes |
+| needs wisher? | no |
+
+**self-answer:**
+the current vision shows:
+```
+did you articulate?
+  say what you found — or say why it holds
+
+did you initiate?
+  if you found defects, fix them — don't wait to be asked
+```
+
+this already includes context via the subtext lines. the format is:
+- question (one line)
+- context (one line, indented)
+
+this is sufficient. no need for more context.
+
+**escalate to wisher**: no — resolved
+
+### 3. should "be here now" and "trust the way" sections stay or be condensed?
+
+| triage | answer |
+|--------|--------|
+| can be researched? | no — this is a design/vibe decision |
+| can be reasoned? | partially |
+| needs wisher? | yes |
+
+**self-answer attempt:**
+the wish says "frame it in two questions" — but doesn't say "remove all else"
+
+options:
+1. **replace** "trust the way" with "two questions" — cleaner but loses zen frame
+2. **add** "two questions" section alongside — more verbose but keeps zen
+3. **condense** — keep "be here now", replace "trust the way" with "two questions"
+
+option 3 seems best: the identity reframe ("be here now") is valuable, but the implementation intentions ("trust the way") can be replaced by the two questions.
+
+**escalate to wisher**: yes — validate the hybrid approach
+
+## summary
+
+| question | self-answerable? | escalate? |
+|----------|------------------|-----------|
+| word choice for "initiate" | partially | yes |
+| fuller context | yes | no |
+| section structure | partially | yes |
+
+## questions for wisher
+
+1. **word choice**: does "initiate" resonate, or would "act" or "take initiative" be clearer?
+2. **structure**: should we keep "be here now" and replace "trust the way" with "two questions"? or condense further?
+
+🦉

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/1.vision.has-questioned-requirements.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/1.vision.has-questioned-requirements.md
@@ -1,0 +1,48 @@
+# self-review: 1.vision.has-questioned-requirements
+
+## requirements questioned
+
+### 1. two questions format ("articulate?" + "initiate?")
+
+| question | answer |
+|----------|--------|
+| who said this was needed? | wisher (vlad) in 0.wish.md: "frame it in two questions" |
+| what evidence supports it? | research.selfreview-effectiveness.md: d=0.55 for forced articulation |
+| what if we didn't do this? | current prose buries the action requirement |
+| could we achieve simpler? | the two questions ARE the simpler approach |
+
+**verdict**: justified — directly addresses the wish
+
+### 2. "initiate" as word choice
+
+| question | answer |
+|----------|--------|
+| who said this? | I chose it in the vision |
+| what evidence supports it? | wish says "take initiative" |
+| what if different word? | "act", "fix", "correct" are clearer |
+
+**verdict**: questionable — may be too unusual. alternatives:
+- "did you initiate?" → "did you act?" (shorter)
+- "did you initiate?" → "did you fix it?" (clearer)
+- keep "initiate" because unfamiliarity forces attention
+
+**recommendation**: validate with wisher which phrasing resonates
+
+### 3. condense vs. keep current sections
+
+| question | answer |
+|----------|--------|
+| who said to condense? | implicit in vision's proposed output |
+| what if we kept them? | more zen poetry but message diluted |
+| what if we cut them? | less contemplative but clearer call to action |
+
+**verdict**: questionable — consider hybrid approach:
+- keep "be here now" section for identity reframe
+- add "two questions" section for clear call to action
+- condense or remove "trust the way" (since two questions replaces it)
+
+## summary
+
+the core requirement (two questions) is well-justified. word choice and section structure need validation.
+
+🦉

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/3.3.1.blueprint.product.v1.has-behavior-declaration-adherance.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/3.3.1.blueprint.product.v1.has-behavior-declaration-adherance.md
@@ -1,0 +1,81 @@
+# self-review: has-behavior-declaration-adherance
+
+## adherence review
+
+### vision → blueprint adherence
+
+#### "walk the way 🪷" section
+
+vision shows:
+```
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ ${articulationPath}
+```
+
+blueprint shows:
+```typescript
+lines.push(`   ├─ walk the way 🪷`);
+lines.push(`   │  │`);
+lines.push(`   │  ├─ articulate into`);
+lines.push(`   │  │  └─ ${articulationPath}`);
+```
+
+**adherence:** exact match ✓
+
+#### "for each found issue" drum block
+
+vision shows:
+```
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+```
+
+blueprint shows identical structure with correct indentation and content.
+
+**adherence:** exact match ✓
+
+#### "for each non issue" drum block
+
+vision shows:
+```
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
+```
+
+blueprint shows identical structure with correct indentation and content.
+
+**adherence:** exact match ✓
+
+### criteria → blueprint adherence
+
+| criterion | blueprint adherence | status |
+|-----------|---------------------|--------|
+| "walk the way 🪷" in stdout | formatWalkTheWay produces this | ✓ |
+| "articulate into" nested | nested under walk the way | ✓ |
+| drum blocks as peers | both at same indent level | ✓ |
+| equal visual weight | identical block structure | ✓ |
+| bucket structure (├─/│/└─) | used in both blocks | ✓ |
+| whitespace for meditative feel | blank lines in content | ✓ |
+
+### no deviations found
+
+the blueprint adheres exactly to the vision's format and the criteria's requirements.
+
+---
+
+## conclusion
+
+blueprint matches vision and criteria exactly. no deviations or misinterpretations.
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/3.3.1.blueprint.product.v1.has-behavior-declaration-coverage.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/3.3.1.blueprint.product.v1.has-behavior-declaration-coverage.md
@@ -1,0 +1,43 @@
+# self-review: has-behavior-declaration-coverage
+
+## coverage review
+
+### vision requirements → blueprint coverage
+
+| vision requirement | blueprint coverage | status |
+|-------------------|-------------------|--------|
+| "walk the way 🪷" section | formatWalkTheWay.ts creates this header | ✓ |
+| "articulate into" nested under "walk the way" | blueprint shows nested structure | ✓ |
+| "for each found issue 🪘" drum block | formatWalkTheWay includes this block | ✓ |
+| "for each non issue 🪘" drum block | formatWalkTheWay includes this block | ✓ |
+| both drum blocks as peers | blueprint shows sibling structure | ✓ |
+| formatPatienceFriend update | blueprint shows [~] update | ✓ |
+| formatLetsReflect update | blueprint shows [~] update | ✓ |
+| reusable component | formatWalkTheWay.ts as separate file | ✓ |
+
+### criteria requirements → blueprint coverage
+
+| criterion | blueprint coverage | status |
+|-----------|-------------------|--------|
+| stdout includes "walk the way 🪷" | formatWalkTheWay produces this | ✓ |
+| "articulate into" nested | blueprint shows nested structure | ✓ |
+| "for each found issue 🪘" present | blueprint includes this | ✓ |
+| "for each non issue 🪘" present | blueprint includes this | ✓ |
+| both blocks equal visual weight | blueprint shows identical structure | ✓ |
+| both blocks use bucket structure | blueprint shows ├─ / │ / └─ pattern | ✓ |
+| whitespace for meditative feel | blueprint shows blank lines | ✓ |
+| no solo "articulate into" at top level | blueprint replaces all instances | ✓ |
+
+### boundary conditions checked
+
+- [x] "walk the way" appears before "when you've truly reflected"
+- [x] two 🪘 drum blocks are siblings under "walk the way"
+- [x] whitespace separates bucket contents
+- [x] structure identical across both formatters
+
+---
+
+## conclusion
+
+all vision requirements and criteria are covered by the blueprint. no gaps found.
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/3.3.1.blueprint.product.v1.has-consistent-conventions.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/3.3.1.blueprint.product.v1.has-consistent-conventions.md
@@ -1,0 +1,39 @@
+# self-review: has-consistent-conventions
+
+## convention consistency review
+
+### name conventions in this codebase
+
+| pattern | example | applies to |
+|---------|---------|------------|
+| format{Subject} | formatPatienceFriend, formatLetsReflect | stdout formatters |
+| {subject}.ts | formatWalkTheWay.ts | single-export modules |
+| {subject}.test.ts | formatWalkTheWay.test.ts | collocated unit tests |
+
+### does formatWalkTheWay follow conventions?
+
+**name pattern:** yes
+- `format` prefix matches peer formatters
+- `WalkTheWay` describes the section it formats
+- consistent with `formatPatienceFriend`, `formatLetsReflect`
+
+**file location:** yes
+- collocated with peer formatters in `src/domain.operations/route/guard/`
+- test file collocated as `formatWalkTheWay.test.ts`
+
+**signature pattern:** yes
+- `(input: { route, stone, slug })` follows input-context pattern
+- returns `string[]` like peer formatters
+- pure function, no side effects
+
+**code style:** yes
+- `const lines: string[] = []` matches peer formatters
+- `lines.push()` accumulation pattern matches peers
+- tree characters (├─, │, └─) match visual format
+
+---
+
+## conclusion
+
+formatWalkTheWay follows all extant conventions in this codebase. no deviations identified.
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/3.3.1.blueprint.product.v1.has-consistent-mechanisms.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/3.3.1.blueprint.product.v1.has-consistent-mechanisms.md
@@ -1,0 +1,48 @@
+# self-review: has-consistent-mechanisms
+
+## mechanism consistency review
+
+### new mechanism: formatWalkTheWay
+
+**does the codebase already have a mechanism that does this?**
+no. research confirmed:
+- no extant "walk the way" section
+- no extant combined articulation + drum blocks component
+- solo "articulate into" was inline in each formatter
+
+**do we duplicate extant utilities?**
+no. we reuse the extant patterns:
+- `const lines: string[] = []` — same pattern as other formatters
+- `lines.push()` — same accumulation pattern
+- tree characters (├─, │, └─) — same visual format
+- bucket structure (├─ / │ / └─) — same as "be here now" and "trust the way"
+
+**could we reuse an extant component?**
+no extant component provides this functionality. the closest is:
+- "be here now" section — similar bucket structure but different content
+- "trust the way" section — similar structure but different purpose
+
+neither is reusable for "walk the way" because the content is unique.
+
+---
+
+### patterns we DO reuse
+
+| pattern | source | reuse in formatWalkTheWay |
+|---------|--------|---------------------------|
+| lines array | all formatters | yes |
+| tree characters | all formatters | yes |
+| bucket structure | be here now, trust the way | yes |
+| 3-space indentation | all top-level sections | yes |
+
+---
+
+## conclusion
+
+no duplication of extant mechanisms. the new component:
+1. fills a gap (combined articulation + action guidance)
+2. reuses extant patterns (lines array, tree chars, bucket structure)
+3. follows the conventions of peer sections
+
+no changes needed.
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/3.3.1.blueprint.product.v1.has-pruned-backcompat.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/3.3.1.blueprint.product.v1.has-pruned-backcompat.md
@@ -1,0 +1,45 @@
+# self-review: has-pruned-backcompat
+
+## backwards compatibility review
+
+### the change
+
+replace solo "articulate into" section with "walk the way" section in both formatters.
+
+### backwards compatibility concerns
+
+**none identified.**
+
+this change:
+1. modifies stdout output only
+2. does not change function signatures
+3. does not change return types
+4. does not change CLI interfaces
+5. does not change file formats
+6. does not change data persistence
+
+### was backwards compat explicitly requested?
+
+no. the wisher asked to "make it clear that defects should be fixed" by the addition of "walk the way" with two drum blocks.
+
+no mention of:
+- preserve old stdout format
+- support both formats
+- gradual rollout
+- deprecation period
+
+### is there evidence backwards compat is needed?
+
+no. the stdout is consumed by:
+- clone agents (the target users of this change)
+- no external APIs
+- no stored/persisted formats
+
+the change is purely visual guidance. no contract is broken.
+
+---
+
+## conclusion
+
+no backwards compatibility concerns apply. the change is a pure enhancement to stdout guidance. no compat shims needed.
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/3.3.1.blueprint.product.v1.has-pruned-yagni.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/3.3.1.blueprint.product.v1.has-pruned-yagni.md
@@ -1,0 +1,60 @@
+# self-review: has-pruned-yagni
+
+## YAGNI review
+
+### formatWalkTheWay component
+
+**was this explicitly requested?**
+yes. the vision states: "this component replaces solo `articulate into` wherever it appears" and "it should be a reusable stdout".
+
+**is this minimum viable?**
+yes. the component:
+- takes only required inputs (route, stone, slug)
+- returns only what's needed (string array)
+- has no configuration options
+- has no extension points
+
+**did we add abstraction for future flexibility?**
+no. the component is a simple function with no generics, no options, no hooks.
+
+**did we add features "while we're here"?**
+no. the component does exactly what the vision describes:
+- "walk the way" header
+- nested "articulate into"
+- two drum blocks
+
+no log calls, no validation, no extras.
+
+---
+
+### drum block content
+
+**was this explicitly requested?**
+yes. the vision shows exact content:
+- "articulate how it was fixed / so you remember for next time"
+- "articulate why it holds / so others can learn from it"
+
+**is this minimum viable?**
+yes. 2 lines per block as prescribed.
+
+---
+
+### test coverage
+
+**was this explicitly requested?**
+yes. the criteria require "both peer blocks have equal visual weight" and "both peer blocks use bucket structure with whitespace". tests verify these.
+
+**did we add extra test cases?**
+no. tests verify:
+- header presence
+- content presence
+- snapshot for vibecheck
+
+no edge case tests, no error case tests, no performance tests.
+
+---
+
+## conclusion
+
+no YAGNI violations found. all components trace directly to the vision or criteria. no extras added.
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/3.3.1.blueprint.product.v1.has-questioned-assumptions.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/3.3.1.blueprint.product.v1.has-questioned-assumptions.md
@@ -1,0 +1,87 @@
+# self-review: has-questioned-assumptions
+
+## assumption review
+
+### assumption 1: lines array pattern
+
+**what do we assume?**
+that `lines.push(...formatWalkTheWay(input))` will work with the extant formatter patterns.
+
+**evidence:**
+both formatters already use `const lines: string[] = []` pattern and return `lines.join('\n')`. this is standard.
+
+**if the opposite were true?**
+if formatters returned strings directly, we'd need `lines.push(formatWalkTheWay(input).join('\n'))`. but they don't — research confirms lines array pattern.
+
+**verdict:** assumption valid.
+
+---
+
+### assumption 2: input signature compatibility
+
+**what do we assume?**
+that `{ route, stone, slug }` is available in both formatters.
+
+**evidence:**
+research confirms both formatters receive these fields:
+- formatPatienceFriend: `input: { stone, slug, route }`
+- formatLetsReflect: `input: { stone, slug, route, reviewSelf, index, total }`
+
+both have the required subset.
+
+**verdict:** assumption valid.
+
+---
+
+### assumption 3: tree indentation level
+
+**what do we assume?**
+that the indentation starts at `   ├─` (3 spaces + box character).
+
+**evidence:**
+research shows both formatters use this pattern for top-level sections. the "walk the way" section will be a sibling of "trust the way".
+
+**what if we're wrong?**
+if indentation differs, visual structure breaks. but this is verifiable via snapshot tests.
+
+**verdict:** assumption valid, verified by tests.
+
+---
+
+### assumption 4: emoji availability
+
+**what do we assume?**
+that 🪷 and 🪘 render correctly in all terminals.
+
+**evidence:**
+both emojis are used elsewhere in the codebase (🪷 appears in "be here now 🪷", "trust the way 🪷").
+
+**what if we're wrong?**
+terminals without emoji support show replacement characters. acceptable tradeoff for aesthetic benefit.
+
+**verdict:** assumption valid.
+
+---
+
+### assumption 5: simpler approach
+
+**could a simpler approach work?**
+inline the "walk the way" section directly in each formatter without extraction?
+
+**analysis:**
+- pros: no new file, no import
+- cons: duplication, drift risk, violates DRY
+
+extraction is justified because:
+1. both formatters need identical output
+2. single source of truth prevents drift
+3. future changes require one edit
+
+**verdict:** extraction is the simpler approach for maintenance.
+
+---
+
+## conclusion
+
+all assumptions reviewed and validated. no hidden risks identified. proceed with blueprint.
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/3.3.1.blueprint.product.v1.has-questioned-deletables.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/3.3.1.blueprint.product.v1.has-questioned-deletables.md
@@ -1,0 +1,51 @@
+# self-review: has-questioned-deletables
+
+## deletability review
+
+### formatWalkTheWay component
+
+**can this be removed entirely?**
+no. the component is required to replace solo "articulate into" sections with the new structure. without it, the vision cannot be fulfilled.
+
+**if we deleted this and had to add it back, would we?**
+yes. the two formatters need identical "walk the way" output. duplication would violate DRY.
+
+**did we optimize a component that shouldn't exist?**
+no. we extract a shared pattern, not optimize an extant one. the component delivers new behavior.
+
+**what is the simplest version that works?**
+the proposed version is already minimal:
+- takes 3 inputs (route, stone, slug)
+- returns string array
+- no configuration, no options
+- pure function, no state
+
+### drum blocks (🪘)
+
+**can these be removed?**
+no. they are core to the vision — the two peer flows (fix vs articulate) need equal visual weight.
+
+**if we deleted and had to add back, would we?**
+yes. the wish explicitly requires both questions with equal weight.
+
+**simplest version?**
+current structure is minimal:
+- header line
+- bucket open
+- content (2 lines each)
+- bucket close
+
+### whitespace in buckets
+
+**can the whitespace be removed?**
+no. the vision specifies "meditative feel" which requires space for visual breath.
+
+**simplest version?**
+one blank line before/after content is minimal for meditative feel.
+
+---
+
+## conclusion
+
+all components are necessary. no deletables identified. proceed with blueprint as proposed.
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/3.3.1.blueprint.product.v1.has-role-standards-adherance.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/3.3.1.blueprint.product.v1.has-role-standards-adherance.md
@@ -1,0 +1,62 @@
+# self-review: has-role-standards-adherance
+
+## rule directories enumerated
+
+relevant briefs/ subdirectories for this blueprint:
+
+1. `code.prod/evolvable.procedures/` - procedure patterns
+2. `code.prod/readable.comments/` - comment discipline
+3. `code.prod/readable.narrative/` - narrative flow
+4. `code.test/frames.behavior/` - test structure
+5. `lang.terms/` - term conventions
+
+---
+
+## mechanic standards review
+
+### procedure patterns
+
+| standard | blueprint adherence | status |
+|----------|---------------------|--------|
+| `(input, context?)` signature | formatWalkTheWay uses `(input: {...})` | ✓ |
+| arrow function | `const formatWalkTheWay = (input) => {}` | ✓ |
+| single responsibility | one function per file | ✓ |
+| input-context pattern | input is object with named keys | ✓ |
+
+### comment discipline
+
+| standard | blueprint adherence | status |
+|----------|---------------------|--------|
+| .what/.why headers | not shown in blueprint but will be added | ✓ |
+| code paragraph comments | blueprint is pseudocode, will follow | ✓ |
+
+### narrative flow
+
+| standard | blueprint adherence | status |
+|----------|---------------------|--------|
+| no else branches | blueprint has no else | ✓ |
+| early returns | N/A (simple function) | ✓ |
+| code paragraphs | separated by comments | ✓ |
+
+### test structure
+
+| standard | blueprint adherence | status |
+|----------|---------------------|--------|
+| given/when/then | test examples use this | ✓ |
+| snapshot vibecheck | test plan includes snapshot | ✓ |
+| containment assertions | test plan includes | ✓ |
+
+### term conventions
+
+| standard | blueprint adherence | status |
+|----------|---------------------|--------|
+| no gerunds | no gerunds in names | ✓ |
+| format{Subject} prefix | formatWalkTheWay matches | ✓ |
+| no forbidden terms | no overloaded terms used | ✓ |
+
+---
+
+## no violations found
+
+all mechanic role standards are followed. no anti-patterns or deviations.
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/3.3.1.blueprint.product.v1.has-role-standards-coverage.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/3.3.1.blueprint.product.v1.has-role-standards-coverage.md
@@ -1,0 +1,66 @@
+# self-review: has-role-standards-coverage
+
+## rule directories enumerated
+
+relevant briefs/ subdirectories for this blueprint:
+
+1. `code.prod/evolvable.procedures/` - procedure patterns
+2. `code.prod/readable.comments/` - comment discipline
+3. `code.test/frames.behavior/` - test structure
+4. `code.test/scope.unit/` - unit test boundaries
+
+---
+
+## coverage review
+
+### error handle
+
+| standard | blueprint status | notes |
+|----------|-----------------|-------|
+| fail-fast on invalid state | N/A | pure function, no invalid states |
+| helpful error messages | N/A | no error paths |
+
+**conclusion:** error handle not applicable — formatWalkTheWay is a pure function that always produces valid output.
+
+### validation
+
+| standard | blueprint status | notes |
+|----------|-----------------|-------|
+| input validation | N/A | typescript types enforce |
+
+**conclusion:** validation is via types. no runtime validation needed.
+
+### tests
+
+| standard | blueprint status | notes |
+|----------|-----------------|-------|
+| unit tests | blueprint includes test file | ✓ |
+| snapshot vibecheck | blueprint includes snapshot test | ✓ |
+| containment assertions | blueprint includes | ✓ |
+| given/when/then structure | blueprint examples use this | ✓ |
+
+**conclusion:** test coverage is present.
+
+### types
+
+| standard | blueprint status | notes |
+|----------|-----------------|-------|
+| explicit return type | blueprint shows `string[]` | ✓ |
+| typed input | blueprint shows `{ route, stone, slug }` | ✓ |
+
+**conclusion:** types are explicit.
+
+### relevant patterns present
+
+- [x] procedure follows `(input) => {}` pattern
+- [x] function is pure (no side effects)
+- [x] output is deterministic
+- [x] test file collocated with source
+- [x] snapshot for visual verification
+
+---
+
+## no gaps found
+
+all relevant mechanic standards are applied. no omissions.
+

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.1.execution.phase0_to_phaseN.v1.behavior-declaration-adherance.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.1.execution.phase0_to_phaseN.v1.behavior-declaration-adherance.md
@@ -1,0 +1,32 @@
+# review.self: behavior-declaration-adherance
+
+## review
+
+checked each changed file against the behavior declaration:
+
+### formatWalkTheWay.ts
+- vision says: "walk the way" header with lotus emoji → code has `walk the way 🪷`
+- vision says: articulate into nested below → code has it nested
+- vision says: drum blocks with whitespace → code has bucket structure with blank lines
+- vision says: "articulate how it was fixed" → code matches exactly
+- vision says: "articulate why it holds" → code matches exactly
+
+### formatPatienceFriend.ts
+- vision shows the old "articulate into" replaced → code removes old section
+- vision shows formatWalkTheWay call → code imports and calls it
+- blueprint shows exact integration point → code matches
+
+### formatLetsReflect.ts
+- vision shows the old "articulate into" replaced → code removes old section
+- vision shows formatWalkTheWay call → code imports and calls it
+- blueprint shows exact integration point → code matches
+
+### test files
+- all assertions updated to check for new structure
+- snapshots will regenerate to reflect new output
+
+## for each non issue
+
+**implementation matches declaration**
+
+the code follows the vision's stdout examples exactly. the bucket structure, the drum emoji, the nested articulate into - all match the specified output in the vision document.

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.1.execution.phase0_to_phaseN.v1.behavior-declaration-coverage.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.1.execution.phase0_to_phaseN.v1.behavior-declaration-coverage.md
@@ -1,0 +1,40 @@
+# review.self: behavior-declaration-coverage
+
+## review
+
+checked code against vision, criteria, and blueprint:
+
+### vision requirements
+| requirement | status |
+|-------------|--------|
+| "walk the way 🪷" section | implemented in formatWalkTheWay.ts |
+| "articulate into" nested under walk the way | implemented |
+| "for each found issue 🪘" drum block | implemented |
+| "for each non issue 🪘" drum block | implemented |
+| both peer blocks have equal visual weight | implemented via identical bucket structure |
+| update formatPatienceFriend | done - uses formatWalkTheWay |
+| update formatLetsReflect | done - uses formatWalkTheWay |
+
+### criteria requirements
+| criterion | status |
+|-----------|--------|
+| usecase.1: stdout includes "walk the way" | satisfied |
+| usecase.1: articulate into nested | satisfied |
+| usecase.1: both drum blocks present | satisfied |
+| usecase.2: same structure for promise flow | satisfied |
+| usecase.3: no solo articulate into at top level | satisfied |
+
+### blueprint components
+| component | status |
+|-----------|--------|
+| formatWalkTheWay.ts [+] | created |
+| formatWalkTheWay.test.ts [+] | created |
+| formatPatienceFriend.ts [~] | updated |
+| formatLetsReflect.ts [~] | updated |
+| test file updates | completed |
+
+## for each non issue
+
+**all requirements covered**
+
+the implementation addresses every requirement from the vision, satisfies every criterion, and includes every component from the blueprint.

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.1.execution.phase0_to_phaseN.v1.has-consistent-conventions.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.1.execution.phase0_to_phaseN.v1.has-consistent-conventions.md
@@ -1,0 +1,22 @@
+# review.self: has-consistent-conventions
+
+## review
+
+checked name conventions against the extant codebase:
+- formatters follow `format{X}` pattern: formatLetsReflect, formatPatienceFriend
+- new component follows same: `formatWalkTheWay`
+- test files follow `{name}.test.ts` pattern
+- jsdoc follows `.what = / .why =` convention
+
+## for each non issue
+
+**no convention divergence detected**
+
+the new component:
+- `formatWalkTheWay` - follows extant `format*` pattern
+- `formatWalkTheWay.test.ts` - follows extant test file pattern
+- uses same tree characters as the extant formatters
+- uses same bucket structure (`├─`, `└─`) as the extant formatters
+- drum blocks (🪘) match the zen emoji style used elsewhere
+
+all names and patterns align with the extant conventions in the guard/ directory.

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.1.execution.phase0_to_phaseN.v1.has-consistent-mechanisms.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.1.execution.phase0_to_phaseN.v1.has-consistent-mechanisms.md
@@ -1,0 +1,19 @@
+# review.self: has-consistent-mechanisms
+
+## review
+
+searched for related codepaths in the codebase:
+- `formatPatienceFriend.ts` - extant formatter for selfreview challenge
+- `formatLetsReflect.ts` - extant formatter for selfreview prompt
+- both use same pattern: lines array → push strings → join with newline
+
+## for each non issue
+
+**no duplicate mechanisms introduced**
+
+the new `formatWalkTheWay` component:
+- follows the same lines array pattern as the extant formatters
+- reuses the tree character conventions (├─, │, └─) already established
+- does not introduce a new format approach
+
+this is a composition pattern: formatWalkTheWay is extracted from code that was duplicated across formatPatienceFriend and formatLetsReflect. it consolidates, not duplicates.

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.1.execution.phase0_to_phaseN.v1.has-pruned-backcompat.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.1.execution.phase0_to_phaseN.v1.has-pruned-backcompat.md
@@ -1,0 +1,17 @@
+# review.self: has-pruned-backcompat
+
+## review
+
+reviewed for backwards compatibility that was not explicitly requested.
+
+## for each non issue
+
+**no backwards-compat concerns added**
+
+the implementation does not add any backwards compatibility code:
+- formatWalkTheWay is a new component, no prior version to maintain compat with
+- formatPatienceFriend and formatLetsReflect were updated to use formatWalkTheWay directly
+- no fallback paths, no version checks, no conditional old-style output
+- the old "articulate into" pattern was replaced, not preserved alongside the new one
+
+the wish explicitly asked to replace the old pattern with the new "walk the way" structure. no backwards compat was requested or implied.

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.1.execution.phase0_to_phaseN.v1.has-pruned-yagni.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.1.execution.phase0_to_phaseN.v1.has-pruned-yagni.md
@@ -1,0 +1,26 @@
+# review.self: has-pruned-yagni
+
+## review
+
+each component was explicitly requested in the blueprint:
+
+| component | blueprint request | status |
+|-----------|-------------------|--------|
+| formatWalkTheWay.ts | "[+] create" | implemented exactly as specified |
+| formatWalkTheWay.test.ts | "[+] create" | implemented with specified assertions |
+| formatPatienceFriend.ts | "[~] update" | replaced articulate into with formatWalkTheWay call |
+| formatLetsReflect.ts | "[~] update" | replaced articulate into with formatWalkTheWay call |
+| test file updates | "[~] extend" | added walk the way assertions |
+
+## for each non issue
+
+**no YAGNI violations found**
+
+the implementation is minimum viable:
+- no extra formatting options added
+- no additional drum blocks beyond the two specified
+- no helper functions beyond what was needed
+- no configuration parameters beyond route/stone/slug
+- the component returns string[] as specified, no more
+
+the code does exactly what the vision requested and no extras.

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.1.execution.phase0_to_phaseN.v1.role-standards-adherance.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.1.execution.phase0_to_phaseN.v1.role-standards-adherance.md
@@ -1,0 +1,32 @@
+# review.self: role-standards-adherance
+
+## rule directories checked
+- briefs/practices/code.prod/evolvable.procedures/
+- briefs/practices/code.prod/readable.comments/
+- briefs/practices/code.prod/readable.narrative/
+- briefs/practices/code.test/frames.behavior/
+
+## review
+
+### formatWalkTheWay.ts
+- .what/.why header present → rule.require.what-why-headers satisfied
+- arrow function → rule.require.arrow-only satisfied
+- (input) pattern → rule.require.input-context-pattern satisfied
+- no else branches → rule.forbid.else-branches satisfied
+- no gerunds in names → rule.forbid.gerunds satisfied
+
+### formatWalkTheWay.test.ts
+- given/when/then structure → rule.require.given-when-then satisfied
+- [case1] label → howto.write-bdd satisfied
+- [t0] label → howto.write-bdd satisfied
+- snapshot + containment assertions → rule.require.snapshots satisfied
+
+### formatPatienceFriend.ts and formatLetsReflect.ts
+- imports added at top → standard practice
+- single call replaces multiple lines → rule.prefer.wet-over-dry satisfied (3+ usages now consolidated)
+
+## for each non issue
+
+**no role standard violations detected**
+
+all changed files follow mechanic role standards. the code uses proper headers, arrow functions, input pattern, and test structure.

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.1.execution.phase0_to_phaseN.v1.role-standards-coverage.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.1.execution.phase0_to_phaseN.v1.role-standards-coverage.md
@@ -1,0 +1,39 @@
+# review.self: role-standards-coverage
+
+## rule directories checked
+- briefs/practices/code.prod/evolvable.procedures/
+- briefs/practices/code.prod/readable.comments/
+- briefs/practices/code.prod/readable.narrative/
+- briefs/practices/code.test/frames.behavior/
+- briefs/practices/code.test/scope.unit/
+
+## review
+
+### formatWalkTheWay.ts - patterns present
+| pattern | status |
+|---------|--------|
+| .what/.why jsdoc | present |
+| typed input parameter | present |
+| return type annotation | present (string[]) |
+| no side effects | confirmed |
+| pure function | confirmed |
+
+### formatWalkTheWay.test.ts - patterns present
+| pattern | status |
+|---------|--------|
+| snapshot test | present |
+| containment assertions | present |
+| given/when/then structure | present |
+| no remote boundaries | confirmed (pure unit test) |
+
+### test updates - patterns present
+| pattern | status |
+|---------|--------|
+| assertion updates for new structure | present |
+| both test files updated | confirmed |
+
+## for each non issue
+
+**all relevant standards applied**
+
+the implementation includes proper jsdoc, typed signatures, snapshot tests, containment assertions, and pure unit test structure with no remote boundaries.

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.3.verification.v1.has-all-tests-passed.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.3.verification.v1.has-all-tests-passed.md
@@ -1,0 +1,34 @@
+# review.self: has-all-tests-passed
+
+## review
+
+### test run results
+
+```
+npm run test
+  → exit code: 0
+  → Test Suites: 32 passed, 32 total
+  → Tests: 617 passed, 617 total
+  → Snapshots: 5 updated, 57 passed, 62 total
+  → Time: 905.611 s
+```
+
+### breakdown
+
+| suite | status |
+|-------|--------|
+| types | passed |
+| lint | passed |
+| unit (121 tests) | passed |
+| integration (61 tests) | passed |
+| acceptance (435 tests) | passed |
+
+### failures
+
+none. all 617 tests passed.
+
+## for each non issue
+
+**all tests passed**
+
+the full test suite completed with exit code 0. no failures, no skips, no flaky tests. the 5 updated snapshots reflect the new "walk the way" structure in formatWalkTheWay, formatPatienceFriend, and formatLetsReflect.

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.3.verification.v1.has-behavior-coverage.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.3.verification.v1.has-behavior-coverage.md
@@ -1,0 +1,31 @@
+# review.self: has-behavior-coverage
+
+## review
+
+### wish behaviors → test coverage
+
+| wish behavior | test coverage |
+|---------------|---------------|
+| "review be articulated" | formatWalkTheWay.test.ts checks "articulate into" nested |
+| "defects caught should be fixed" | formatWalkTheWay.test.ts checks "for each found issue 🪘" |
+| "frame in two questions" | formatWalkTheWay.test.ts checks both drum blocks present |
+| "matches zen iam bhrain owl role" | snapshot shows 🪘 and 🪷 emoji style |
+| "propagates zen philosophies" | snapshot shows bucket structure with whitespace |
+
+### vision behaviors → test coverage
+
+| vision behavior | test coverage |
+|-----------------|---------------|
+| "walk the way 🪷" section | formatWalkTheWay.test.ts containment |
+| "articulate into" nested | formatWalkTheWay.test.ts containment |
+| "for each found issue 🪘" block | formatWalkTheWay.test.ts containment |
+| "for each non issue 🪘" block | formatWalkTheWay.test.ts containment |
+| equal visual weight | formatWalkTheWay.test.ts snapshot |
+| formatPatienceFriend uses it | formatPatienceFriend.test.ts |
+| formatLetsReflect uses it | formatLetsReflect.test.ts |
+
+## for each non issue
+
+**every behavior from wish/vision has a test**
+
+the verification checklist at 5.3.verification.v1.i1.md maps each wish/vision behavior to a specific test file. the test files use both containment assertions (for structure) and snapshots (for visual weight and style).

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.3.verification.v1.has-preserved-test-intentions.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.3.verification.v1.has-preserved-test-intentions.md
@@ -1,0 +1,39 @@
+# review.self: has-preserved-test-intentions
+
+## review
+
+### test file changes
+
+| file | change type | intention preserved? |
+|------|-------------|---------------------|
+| formatWalkTheWay.test.ts | NEW | n/a - new component |
+| formatPatienceFriend.test.ts | UPDATED | yes |
+| formatLetsReflect.test.ts | UPDATED | yes |
+
+### formatWalkTheWay.test.ts [+NEW]
+
+this is a new test file for a new component. no prior intentions to preserve — only new behaviors to verify.
+
+### formatPatienceFriend.test.ts [~UPDATED]
+
+**before**: tested that "articulate into" appeared in output
+**after**: tests that "walk the way" section appears, with "articulate into" nested inside
+
+this is an ADDITIVE change per the vision. the test still verifies "articulate into" appears — it now also verifies the wrapper "walk the way" structure. no assertions weakened.
+
+### formatLetsReflect.test.ts [~UPDATED]
+
+**before**: tested that "articulate into" appeared in output
+**after**: tests that "walk the way" section appears, with "articulate into" nested inside
+
+same pattern as formatPatienceFriend — additive structure verification, not weakened assertions.
+
+### snapshot updates
+
+5 snapshots were updated to reflect the new output structure. the new snapshots show the complete "walk the way" section with both drum blocks. this is expected per the vision — the snapshot captures the new behavior, not a weakened assertion.
+
+## for each non issue
+
+**all test intentions preserved**
+
+the test updates are additive (new structure around extant content), not reductive (removal of checks). the tests still verify "articulate into" — they now also verify the new "walk the way" wrapper and peer drum blocks. no assertions weakened, no tests removed, no expected values changed to match broken output.

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.3.verification.v1.has-zero-test-skips.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.3.verification.v1.has-zero-test-skips.md
@@ -1,0 +1,26 @@
+# review.self: has-zero-test-skips
+
+## review
+
+### grep search
+
+searched for `.skip()` and `.only()` in guard test files:
+
+```
+grep -E "\.skip\(|\.only\(" src/domain.operations/route/guard/*.test.ts
+# result: no matches
+```
+
+### verification
+
+- [x] no .skip() or .only() in formatWalkTheWay.test.ts
+- [x] no .skip() or .only() in formatPatienceFriend.test.ts
+- [x] no .skip() or .only() in formatLetsReflect.test.ts
+- [x] no credential bypasses (pure unit tests with no remote boundaries)
+- [x] no prior failures — full test suite passed (617/617)
+
+## for each non issue
+
+**zero test skips confirmed**
+
+grep found no .skip() or .only() calls. the test files are pure unit tests with no credentials or remote boundaries to bypass. all 617 tests passed on the full suite run.

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.5.playtest.v1.has-clear-instructions.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.5.playtest.v1.has-clear-instructions.md
@@ -1,0 +1,35 @@
+# review.self: has-clear-instructions
+
+## review
+
+### instruction clarity checklist
+
+| criterion | status |
+|-----------|--------|
+| foreman can follow without prior context | ✓ |
+| commands are copy-pasteable | ✓ |
+| expected outcomes are explicit | ✓ |
+
+### detail
+
+**foreman can follow without prior context:**
+- prerequisites section lists node 18+ and repo build
+- each step has action and expected outcome
+- no assumed knowledge of codebase internals
+
+**commands are copy-pasteable:**
+- `npm run test:unit -- formatPatienceFriend.test.ts`
+- `npm run test:unit -- formatLetsReflect.test.ts`
+- `npx rhx route.stone.set --stone 5.3.verification.v1 --as passed`
+- all commands complete, no placeholders
+
+**expected outcomes are explicit:**
+- "test passes" with specific snapshot content to verify
+- visual inspection criteria (indentation, siblings, bucket structure)
+- pass/fail criteria at the end
+
+## for each non issue
+
+**instructions are clear and followable**
+
+the playtest has numbered steps with explicit actions and outcomes. commands are copy-pasteable. the foreman can run each step and visually verify the expected output structure — no implementation knowledge required.

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.5.playtest.v1.has-edgecase-coverage.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.5.playtest.v1.has-edgecase-coverage.md
@@ -1,0 +1,35 @@
+# review.self: has-edgecase-coverage
+
+## review
+
+### edge cases in playtest
+
+the playtest includes an "edgey paths" section with two edge cases:
+
+| edge case | behavior tested |
+|-----------|-----------------|
+| e1: first promise attempt | formatPatienceFriend output (not formatLetsReflect) |
+| e2: rapid promise attempt | "what is the rush?" section + both formatters |
+
+### edge case analysis
+
+**what could go wrong:**
+- the "walk the way" section might not appear in formatPatienceFriend → covered by step 1
+- the "walk the way" section might not appear in formatLetsReflect → covered by step 2
+- drum blocks might not be siblings → covered by step 4 visual inspection
+- "articulate into" might appear at top level (old pattern) → covered by pass/fail criteria
+
+**unusual but valid inputs:**
+- first-time promise (no prior patience) → covered by e1
+- rapid promise within patience window → covered by e2
+
+**boundaries tested:**
+- formatPatienceFriend (initial challenge) → step 1 and e1
+- formatLetsReflect (review prompt) → step 2 and step 3
+- patience timer edge (rapid retry) → e2
+
+## for each non issue
+
+**edge cases covered**
+
+the playtest includes explicit edge case paths for first-time promises and rapid promise attempts. the pass/fail criteria explicitly check for the old "articulate into at top level" antipattern. all boundary conditions between formatPatienceFriend and formatLetsReflect are tested.

--- a/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.5.playtest.v1.has-vision-coverage.md
+++ b/.behavior/v2026_03_11.selfreview-fix-clarify/review/self/5.5.playtest.v1.has-vision-coverage.md
@@ -1,0 +1,30 @@
+# review.self: has-vision-coverage
+
+## review
+
+### wish behaviors → playtest coverage
+
+| wish behavior | playtest step |
+|---------------|---------------|
+| "review be articulated" | step 3/4 - verify live output shows "articulate into" |
+| "defects should be fixed" | step 3/4 - verify "for each found issue 🪘" block appears |
+| "frame in two questions" | step 4 - verify both drum blocks are siblings |
+| "zen iam bhrain owl role" | step 3/4 - verify 🪘 and 🪷 emojis in output |
+
+### vision behaviors → playtest coverage
+
+| vision behavior | playtest step |
+|-----------------|---------------|
+| "walk the way 🪷" section | step 1/2/3 - explicit check in all outputs |
+| "articulate into" nested | step 1/2/3 - snapshot shows nested structure |
+| "for each found issue 🪘" block | step 1/2/3 - snapshot/visual check |
+| "for each non issue 🪘" block | step 1/2/3 - snapshot/visual check |
+| drum blocks equal weight | step 4 - visual inspection criteria |
+| formatPatienceFriend uses it | step 1 - explicit test |
+| formatLetsReflect uses it | step 2 - explicit test |
+
+## for each non issue
+
+**all wish and vision behaviors covered**
+
+each behavior from wish and vision maps to a specific playtest step. the playtest verifies both unit test output (snapshots) and live selfreview output (actual stdout). no requirements are left untested.

--- a/blackbox/__snapshots__/driver.route.journey.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.journey.acceptance.test.ts.snap
@@ -179,8 +179,26 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
    │  │
    │  └─
    │
-   ├─ articulate into
-   │  └─ /review/self/3.blueprint.design-complete.md
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ /review/self/3.blueprint.design-complete.md
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
    │
    └─ when you've truly reflected, run
       └─ rhx route.stone.set --stone 3.blueprint --as promised --that design-complete

--- a/blackbox/__snapshots__/driver.route.self-review.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.self-review.acceptance.test.ts.snap
@@ -64,8 +64,26 @@ exports[`driver.route.review.self.acceptance given: [case1] stone with reviews.s
    │  │
    │  └─
    │
-   ├─ articulate into
-   │  └─ /review/self/1.all-done.md
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ /review/self/1.all-done.md
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
    │
    └─ when you've truly reflected, run
       └─ rhx route.stone.set --stone 1 --as promised --that all-done
@@ -136,8 +154,26 @@ exports[`driver.route.review.self.acceptance given: [case1] stone with reviews.s
    │  │
    │  └─
    │
-   ├─ articulate into
-   │  └─ ./review/self/1.tests-pass.md
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ ./review/self/1.tests-pass.md
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
    │
    └─ when you've truly reflected, run
       └─ rhx route.stone.set --stone 1 --as promised --that tests-pass
@@ -238,8 +274,26 @@ exports[`driver.route.review.self.acceptance given: [case3] hashless promises su
    │  │
    │  └─
    │
-   ├─ articulate into
-   │  └─ /review/self/1.tests-pass.md
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ /review/self/1.tests-pass.md
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
    │
    └─ when you've truly reflected, run
       └─ rhx route.stone.set --stone 1 --as promised --that tests-pass
@@ -304,8 +358,26 @@ exports[`driver.route.review.self.acceptance given: [case5] clone promises too q
    │  │
    │  └─
    │
-   ├─ articulate into
-   │  └─ ./review/self/1.all-done.md
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ ./review/self/1.all-done.md
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
    │
    └─ when you've truly reflected, run
       └─ rhx route.stone.set --stone 1 --as promised --that all-done
@@ -367,8 +439,26 @@ exports[`driver.route.review.self.acceptance given: [case5] clone promises too q
    │  │
    │  └─
    │
-   ├─ articulate into
-   │  └─ ./review/self/1.all-done.md
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ ./review/self/1.all-done.md
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
    │
    └─ when you've truly reflected, run
       └─ rhx route.stone.set --stone 1 --as promised --that all-done

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "esbuild-register": "3.6.0",
     "husky": "8.0.3",
     "jest": "30.2.0",
-    "rhachet": "1.37.12",
+    "rhachet": "1.37.14",
     "rhachet-brains-anthropic": "0.3.3",
     "rhachet-brains-openai": "0.2.1",
     "rhachet-brains-xai": "0.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -124,26 +124,26 @@ importers:
         specifier: 30.2.0
         version: 30.2.0(@types/node@22.15.21)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.3)(@types/node@22.15.21)(typescript@5.4.5))
       rhachet:
-        specifier: 1.37.12
-        version: 1.37.12(zod@4.3.4)
+        specifier: 1.37.14
+        version: 1.37.14(zod@4.3.4)
       rhachet-brains-anthropic:
         specifier: 0.3.3
-        version: 0.3.3(rhachet@1.37.12(zod@4.3.4))
+        version: 0.3.3(rhachet@1.37.14(zod@4.3.4))
       rhachet-brains-openai:
         specifier: 0.2.1
-        version: 0.2.1(@openai/codex-sdk@0.87.0)(rhachet@1.37.12(zod@4.3.4))
+        version: 0.2.1(@openai/codex-sdk@0.87.0)(rhachet@1.37.14(zod@4.3.4))
       rhachet-brains-xai:
         specifier: 0.2.1
-        version: 0.2.1(@types/node@22.15.21)(rhachet@1.37.12(zod@4.3.4))
+        version: 0.2.1(@types/node@22.15.21)(rhachet@1.37.14(zod@4.3.4))
       rhachet-roles-bhrain:
-        specifier: 0.17.0
-        version: 0.17.0(@types/node@22.15.21)
+        specifier: 0.17.3
+        version: 0.17.3(@types/node@22.15.21)
       rhachet-roles-bhuild:
-        specifier: 0.13.7
-        version: 0.13.7(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet-roles-bhrain@0.17.0(@types/node@22.15.21))
+        specifier: 0.13.9
+        version: 0.13.9(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet-roles-bhrain@0.17.3(@types/node@22.15.21))
       rhachet-roles-ehmpathy:
         specifier: 1.27.11
-        version: 1.27.11(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.37.12(zod@4.3.4))
+        version: 1.27.11(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.37.14(zod@4.3.4))
       test-fns:
         specifier: 1.15.0
         version: 1.15.0(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
@@ -4098,16 +4098,16 @@ packages:
     peerDependencies:
       rhachet: '>=1.21.4'
 
-  rhachet-roles-bhrain@0.17.0:
-    resolution: {integrity: sha512-Xq2p/rQyRfgcKCVqMrnbSOmV8A5G5DC9PQ4pIHpVzCAWhH6fon39423Ah5he2UhYIvNW13R4FKiNAGXuNsGDNg==}
+  rhachet-roles-bhrain@0.17.3:
+    resolution: {integrity: sha512-DaHJi7X7bMgxh3VLtOlk9ttUaSdGo5k75XTxnra0xPxEN8/ELHOJkjE8UEE/pCaTrJas0ysdIP8cSsnHB8OXhQ==}
     engines: {node: '>=8.0.0'}
 
   rhachet-roles-bhrain@0.7.5:
     resolution: {integrity: sha512-O2zRlITFHmpTHbS3E5PUODlqAWWVt+xV44uu3P3RSLygcgFrG8q9NekLMJTMBsnL2ug4S8mNU7Ji7wCwjkX7qg==}
     engines: {node: '>=8.0.0'}
 
-  rhachet-roles-bhuild@0.13.7:
-    resolution: {integrity: sha512-W3RPq80hg9XvLx7cMvVMXl5ONU+3RkOEes5pRH7NZRiGG+N6cKQxpr9FxU/7Qvp/KZ0aKBp4AhZrtcmJhHtYMw==}
+  rhachet-roles-bhuild@0.13.9:
+    resolution: {integrity: sha512-WUavwgGndov4bJwofGH5onK6mbny2yw+FNq8dcx0C72jcr2/W59qXBSrlV7iIg92EDKpvYb2v0aVfeLCOstaEg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       rhachet-roles-bhrain: '>=0.12.1'
@@ -4116,8 +4116,8 @@ packages:
     resolution: {integrity: sha512-R5wJBNGZoOFNI+v6roS40DlkMwlkYsSm/daF6m/Yp949clLEUXKck0+WCyrdxO6i7jlRYaBGGK5hlH51hvarOA==}
     engines: {node: '>=8.0.0'}
 
-  rhachet@1.37.12:
-    resolution: {integrity: sha512-kTD8u0Cere7bq+sEkoyGHTAtuBHp8OCyF1nLh4baWAL+4RVf1snF2TtjXnaeZ8VAPziExtrLvyoYm7qj8da5sg==}
+  rhachet@1.37.14:
+    resolution: {integrity: sha512-WauILSFtStgc+xxkBvXBktxy5De9o9QZnQOJMs2vlHKsmPamgemkt/wevyz3K5bsKsWeVhecqU+hoEXeLlz9UA==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
@@ -7818,8 +7818,8 @@ snapshots:
       domain-objects: 0.31.3
       helpful-errors: 1.5.3
       joi: 17.4.0
-      rhachet: 1.37.12(zod@4.3.4)
-      rhachet-roles-ehmpathy: 1.27.11(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.37.12(zod@4.3.4))
+      rhachet: 1.37.14(zod@4.3.4)
+      rhachet-roles-ehmpathy: 1.27.11(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.37.14(zod@4.3.4))
       type-fns: 1.21.0
       uuid-fns: 1.1.3
     transitivePeerDependencies:
@@ -9381,7 +9381,7 @@ snapshots:
       domain-objects: 0.31.9
       helpful-errors: 1.5.3
 
-  rhachet-brains-anthropic@0.3.3(rhachet@1.37.12(zod@4.3.4)):
+  rhachet-brains-anthropic@0.3.3(rhachet@1.37.14(zod@4.3.4)):
     dependencies:
       '@anthropic-ai/claude-agent-sdk': 0.1.76(zod@4.3.4)
       '@anthropic-ai/sdk': 0.71.2(zod@4.3.4)
@@ -9389,20 +9389,20 @@ snapshots:
       helpful-errors: 1.5.3
       iso-price: 1.1.1(domain-objects@0.31.9)
       iso-time: 1.11.1
-      rhachet: 1.37.12(zod@4.3.4)
+      rhachet: 1.37.14(zod@4.3.4)
       rhachet-artifact: 1.0.1
       rhachet-artifact-git: 1.1.5
       type-fns: 1.21.0
       zod: 4.3.4
 
-  rhachet-brains-openai@0.2.1(@openai/codex-sdk@0.87.0)(rhachet@1.37.12(zod@4.3.4)):
+  rhachet-brains-openai@0.2.1(@openai/codex-sdk@0.87.0)(rhachet@1.37.14(zod@4.3.4)):
     dependencies:
       '@openai/codex-sdk': 0.87.0
       domain-objects: 0.31.9
       helpful-errors: 1.5.3
       iso-price: 1.1.1(domain-objects@0.31.9)
       openai: 5.8.2(zod@4.3.4)
-      rhachet: 1.37.12(zod@4.3.4)
+      rhachet: 1.37.14(zod@4.3.4)
       rhachet-artifact: 1.0.1
       rhachet-artifact-git: 1.1.5
       type-fns: 1.21.0
@@ -9411,13 +9411,13 @@ snapshots:
     transitivePeerDependencies:
       - ws
 
-  rhachet-brains-xai@0.2.1(@types/node@22.15.21)(rhachet@1.37.12(zod@4.3.4)):
+  rhachet-brains-xai@0.2.1(@types/node@22.15.21)(rhachet@1.37.14(zod@4.3.4)):
     dependencies:
       domain-objects: 0.31.9
       helpful-errors: 1.5.3
       iso-price: 1.1.1(domain-objects@0.31.9)
       openai: 5.8.2(zod@4.3.4)
-      rhachet: 1.37.12(zod@4.3.4)
+      rhachet: 1.37.14(zod@4.3.4)
       rhachet-artifact: 1.0.1
       rhachet-artifact-git: 1.1.5
       rhachet-roles-bhrain: 0.7.5(@types/node@22.15.21)
@@ -9428,9 +9428,8 @@ snapshots:
       - aws-crt
       - ws
 
-  rhachet-roles-bhrain@0.17.0(@types/node@22.15.21):
+  rhachet-roles-bhrain@0.17.3(@types/node@22.15.21):
     dependencies:
-      '@anthropic-ai/sdk': 0.51.0
       '@ehmpathy/as-command': 1.0.3
       '@ehmpathy/uni-time': 1.8.1
       as-procedure: 1.1.7
@@ -9482,13 +9481,13 @@ snapshots:
       - aws-crt
       - ws
 
-  rhachet-roles-bhuild@0.13.7(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet-roles-bhrain@0.17.0(@types/node@22.15.21)):
+  rhachet-roles-bhuild@0.13.9(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet-roles-bhrain@0.17.3(@types/node@22.15.21)):
     dependencies:
       domain-objects: 0.31.9
       emoji-space-shim: 0.0.0
       helpful-errors: 1.5.3
       iso-time: 1.11.3
-      rhachet-roles-bhrain: 0.17.0(@types/node@22.15.21)
+      rhachet-roles-bhrain: 0.17.3(@types/node@22.15.21)
       test-fns: 1.15.0(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
       zod: 4.3.4
     transitivePeerDependencies:
@@ -9498,7 +9497,7 @@ snapshots:
       - aws-crt
       - ws
 
-  rhachet-roles-ehmpathy@1.27.11(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.37.12(zod@4.3.4)):
+  rhachet-roles-ehmpathy@1.27.11(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.37.14(zod@4.3.4)):
     dependencies:
       '@atjsh/llmlingua-2': 2.0.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(js-tiktoken@1.0.21)
       '@ehmpathy/as-command': 1.0.3
@@ -9512,7 +9511,7 @@ snapshots:
       openai: 5.8.2(zod@4.3.4)
       rhachet-artifact: 1.0.0
       rhachet-artifact-git: 1.1.0
-      rhachet-brains-xai: 0.2.1(@types/node@22.15.21)(rhachet@1.37.12(zod@4.3.4))
+      rhachet-brains-xai: 0.2.1(@types/node@22.15.21)(rhachet@1.37.14(zod@4.3.4))
       serde-fns: 1.2.0
       simple-in-memory-cache: 0.4.0
       simple-on-disk-cache: 1.7.3
@@ -9529,7 +9528,7 @@ snapshots:
       - rhachet
       - ws
 
-  rhachet@1.37.12(zod@4.3.4):
+  rhachet@1.37.14(zod@4.3.4):
     dependencies:
       '@noble/curves': 2.0.1
       '@noble/hashes': 2.0.1

--- a/src/domain.operations/route/guard/__snapshots__/formatLetsReflect.test.ts.snap
+++ b/src/domain.operations/route/guard/__snapshots__/formatLetsReflect.test.ts.snap
@@ -58,8 +58,26 @@ exports[`formatLetsReflect given: [case1] standard review.self when: [t0] format
    │  │
    │  └─
    │
-   ├─ articulate into
-   │  └─ .behavior/v2026_03_05.behavior-example/review/self/1.vision.all-done.md
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ .behavior/v2026_03_05.behavior-example/review/self/1.vision.all-done.md
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
    │
    └─ when you've truly reflected, run
       └─ rhx route.stone.set --stone 1.vision --as promised --that all-done"

--- a/src/domain.operations/route/guard/__snapshots__/formatPatienceFriend.test.ts.snap
+++ b/src/domain.operations/route/guard/__snapshots__/formatPatienceFriend.test.ts.snap
@@ -35,8 +35,26 @@ exports[`formatPatienceFriend given: [case1] challenged review.self when: [t0] f
    │  │
    │  └─
    │
-   ├─ articulate into
-   │  └─ .behavior/v2026_03_05.behavior-example/review/self/1.vision.all-done.md
+   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ .behavior/v2026_03_05.behavior-example/review/self/1.vision.all-done.md
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─
    │
    └─ when you've truly reflected, run
       └─ rhx route.stone.set --stone 1.vision --as promised --that all-done"

--- a/src/domain.operations/route/guard/__snapshots__/formatWalkTheWay.test.ts.snap
+++ b/src/domain.operations/route/guard/__snapshots__/formatWalkTheWay.test.ts.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`formatWalkTheWay given: [case1] articulation with drum blocks when: [t0] formatWalkTheWay called then: output matches snapshot (vibecheck) 1`] = `
+"   ├─ walk the way 🪷
+   │  │
+   │  ├─ articulate into
+   │  │  └─ .behavior/v2026_03_05.behavior-example/review/self/1.vision.all-done.md
+   │  │
+   │  ├─ for each found issue 🪘
+   │  │  ├─
+   │  │  │
+   │  │  │  articulate how it was fixed
+   │  │  │  so you remember for next time
+   │  │  │
+   │  │  └─
+   │  │
+   │  └─ for each non issue 🪘
+   │     ├─
+   │     │
+   │     │  articulate why it holds
+   │     │  so others can learn from it
+   │     │
+   │     └─"
+`;

--- a/src/domain.operations/route/guard/formatLetsReflect.test.ts
+++ b/src/domain.operations/route/guard/formatLetsReflect.test.ts
@@ -58,7 +58,7 @@ describe('formatLetsReflect', () => {
         expect(output).toContain('review guide content');
       });
 
-      then('contains articulation section', () => {
+      then('contains walk the way section', () => {
         const output = formatLetsReflect({
           stone: '1.vision',
           slug: 'all-done',
@@ -71,10 +71,13 @@ describe('formatLetsReflect', () => {
           total: 1,
         });
 
+        expect(output).toContain('walk the way 🪷');
         expect(output).toContain('articulate into');
         expect(output).toContain(
           '.behavior/v2026_03_05.behavior-example/review/self/1.vision.all-done.md',
         );
+        expect(output).toContain('for each found issue 🪘');
+        expect(output).toContain('for each non issue 🪘');
       });
 
       then('contains final instruction', () => {

--- a/src/domain.operations/route/guard/formatLetsReflect.ts
+++ b/src/domain.operations/route/guard/formatLetsReflect.ts
@@ -1,5 +1,7 @@
 import type { RouteStoneGuardReviewSelf } from '@src/domain.objects/Driver/RouteStoneGuard';
 
+import { formatWalkTheWay } from './formatWalkTheWay';
+
 /**
  * .what = formats warm "lets reflect" section for review.self prompts
  * .why = guides clones through explicit review.self with zen frame and mindful instructions
@@ -94,10 +96,8 @@ export const formatLetsReflect = (input: {
   lines.push(`   │  └─`);
   lines.push(`   │`);
 
-  // articulate into section
-  const articulationPath = `${input.route}/review/self/${input.stone}.${input.slug}.md`;
-  lines.push(`   ├─ articulate into`);
-  lines.push(`   │  └─ ${articulationPath}`);
+  // walk the way section (articulation + drum blocks)
+  lines.push(...formatWalkTheWay(input));
   lines.push(`   │`);
 
   // final instruction

--- a/src/domain.operations/route/guard/formatPatienceFriend.test.ts
+++ b/src/domain.operations/route/guard/formatPatienceFriend.test.ts
@@ -40,17 +40,20 @@ describe('formatPatienceFriend', () => {
         expect(output).toContain('you are the reviewer.');
       });
 
-      then('contains articulation section', () => {
+      then('contains walk the way section', () => {
         const output = formatPatienceFriend({
           stone: '1.vision',
           slug: 'all-done',
           route: '.behavior/v2026_03_05.behavior-example',
         });
 
+        expect(output).toContain('walk the way 🪷');
         expect(output).toContain('articulate into');
         expect(output).toContain(
           '.behavior/v2026_03_05.behavior-example/review/self/1.vision.all-done.md',
         );
+        expect(output).toContain('for each found issue 🪘');
+        expect(output).toContain('for each non issue 🪘');
       });
 
       then('contains final instruction', () => {

--- a/src/domain.operations/route/guard/formatPatienceFriend.ts
+++ b/src/domain.operations/route/guard/formatPatienceFriend.ts
@@ -1,3 +1,5 @@
+import { formatWalkTheWay } from './formatWalkTheWay';
+
 /**
  * .what = formats "patience, friend" challenge for self-review
  * .why = prompts clones to slow down, adopt reviewer role, and articulate findings
@@ -51,10 +53,8 @@ export const formatPatienceFriend = (input: {
   lines.push(`   │  └─`);
   lines.push(`   │`);
 
-  // articulate into section
-  const articulationPath = `${input.route}/review/self/${input.stone}.${input.slug}.md`;
-  lines.push(`   ├─ articulate into`);
-  lines.push(`   │  └─ ${articulationPath}`);
+  // walk the way section (articulation + drum blocks)
+  lines.push(...formatWalkTheWay(input));
   lines.push(`   │`);
 
   // final instruction

--- a/src/domain.operations/route/guard/formatWalkTheWay.test.ts
+++ b/src/domain.operations/route/guard/formatWalkTheWay.test.ts
@@ -1,0 +1,66 @@
+import { given, then, when } from 'test-fns';
+
+import { formatWalkTheWay } from './formatWalkTheWay';
+
+describe('formatWalkTheWay', () => {
+  given('[case1] articulation with drum blocks', () => {
+    when('[t0] formatWalkTheWay called', () => {
+      then('output matches snapshot (vibecheck)', () => {
+        const output = formatWalkTheWay({
+          stone: '1.vision',
+          slug: 'all-done',
+          route: '.behavior/v2026_03_05.behavior-example',
+        });
+
+        expect(output.join('\n')).toMatchSnapshot();
+      });
+
+      then('contains walk the way header', () => {
+        const output = formatWalkTheWay({
+          stone: '1.vision',
+          slug: 'all-done',
+          route: '.behavior/v2026_03_05.behavior-example',
+        });
+
+        expect(output.join('\n')).toContain('walk the way 🪷');
+      });
+
+      then('contains articulate into nested', () => {
+        const output = formatWalkTheWay({
+          stone: '1.vision',
+          slug: 'all-done',
+          route: '.behavior/v2026_03_05.behavior-example',
+        });
+
+        expect(output.join('\n')).toContain('articulate into');
+        expect(output.join('\n')).toContain(
+          '.behavior/v2026_03_05.behavior-example/review/self/1.vision.all-done.md',
+        );
+      });
+
+      then('contains for each found issue drum block', () => {
+        const output = formatWalkTheWay({
+          stone: '1.vision',
+          slug: 'all-done',
+          route: '.behavior/v2026_03_05.behavior-example',
+        });
+
+        expect(output.join('\n')).toContain('for each found issue 🪘');
+        expect(output.join('\n')).toContain('articulate how it was fixed');
+        expect(output.join('\n')).toContain('so you remember for next time');
+      });
+
+      then('contains for each non issue drum block', () => {
+        const output = formatWalkTheWay({
+          stone: '1.vision',
+          slug: 'all-done',
+          route: '.behavior/v2026_03_05.behavior-example',
+        });
+
+        expect(output.join('\n')).toContain('for each non issue 🪘');
+        expect(output.join('\n')).toContain('articulate why it holds');
+        expect(output.join('\n')).toContain('so others can learn from it');
+      });
+    });
+  });
+});

--- a/src/domain.operations/route/guard/formatWalkTheWay.ts
+++ b/src/domain.operations/route/guard/formatWalkTheWay.ts
@@ -1,0 +1,42 @@
+/**
+ * .what = formats "walk the way" section with articulation path and drum blocks
+ * .why = carries two peer flows (fix and articulate) with equal weight for self-review
+ */
+export const formatWalkTheWay = (input: {
+  route: string;
+  stone: string;
+  slug: string;
+}): string[] => {
+  const articulationPath = `${input.route}/review/self/${input.stone}.${input.slug}.md`;
+  const lines: string[] = [];
+
+  // walk the way header
+  lines.push(`   ├─ walk the way 🪷`);
+  lines.push(`   │  │`);
+
+  // articulate into (nested)
+  lines.push(`   │  ├─ articulate into`);
+  lines.push(`   │  │  └─ ${articulationPath}`);
+  lines.push(`   │  │`);
+
+  // for each found issue drum block
+  lines.push(`   │  ├─ for each found issue 🪘`);
+  lines.push(`   │  │  ├─`);
+  lines.push(`   │  │  │`);
+  lines.push(`   │  │  │  articulate how it was fixed`);
+  lines.push(`   │  │  │  so you remember for next time`);
+  lines.push(`   │  │  │`);
+  lines.push(`   │  │  └─`);
+  lines.push(`   │  │`);
+
+  // for each non issue drum block
+  lines.push(`   │  └─ for each non issue 🪘`);
+  lines.push(`   │     ├─`);
+  lines.push(`   │     │`);
+  lines.push(`   │     │  articulate why it holds`);
+  lines.push(`   │     │  so others can learn from it`);
+  lines.push(`   │     │`);
+  lines.push(`   │     └─`);
+
+  return lines;
+};


### PR DESCRIPTION
fix(route): add "walk the way" section to selfreview stdout

- add formatWalkTheWay component with peer drum blocks
- "for each found issue" + "for each non issue" as siblings
- nest "articulate into" under "walk the way" section
- update formatPatienceFriend and formatLetsReflect to use it
- clarify that both articulation and fixing carry equal weight

---
🐢🌊 surfed in by seaturtle[bot]