### PR TITLE
fix(route): move cross-stone invalidation into getAllPassageReports

### DIFF
--- a/src/domain.operations/route/judges/getOneStoneGuardApproval.ts
+++ b/src/domain.operations/route/judges/getOneStoneGuardApproval.ts
@@ -1,82 +1,33 @@
-import * as fs from 'fs/promises';
 import * as path from 'path';
 
 import type { RouteStone } from '@src/domain.objects/Driver/RouteStone';
 import { RouteStoneGuardApproveArtifact } from '@src/domain.objects/Driver/RouteStoneGuardApproveArtifact';
 
-import { compareStonePrefix } from '../stones/compareStonePrefix';
-import {
-  computeStoneOrderPrefix,
-  getStoneOrderPrefixFromName,
-} from '../stones/computeStoneOrderPrefix';
+import { getAllPassageReports } from '../passage/getAllPassageReports';
 
 /**
  * .what = retrieves approval artifact for a stone if present and valid
  * .why = enables guard to check if human approval has been granted
  *
- * .note = approvals are invalidated by subsequent rewinds per log order:
- *         if a rewind entry for stone M appears AFTER an approval for stone N,
- *         and M <= N (rewind target is at or before approved stone),
- *         then the approval is stale
- *
- * .note = reads raw passage.jsonl to preserve log order for invalidation checks
+ * .note = delegates to getAllPassageReports which handles cross-stone invalidation:
+ *         rewind of stone M invalidates approvals for all stones >= M
  */
 export const getOneStoneGuardApproval = async (input: {
   stone: RouteStone;
   route: string;
 }): Promise<RouteStoneGuardApproveArtifact | null> => {
-  const passagePath = path.join(input.route, '.route', 'passage.jsonl');
+  // get passage reports with cross-stone invalidation applied
+  const reports = await getAllPassageReports({ route: input.route });
 
-  // check if file exists
-  const fileFound = await fs
-    .access(passagePath)
-    .then(() => true)
-    .catch(() => false);
-  if (!fileFound) return null;
-
-  // read raw log to preserve chronological order for invalidation checks
-  const content = await fs.readFile(passagePath, 'utf-8');
-  const allReports = content
-    .split('\n')
-    .filter(Boolean)
-    .map((line) => JSON.parse(line) as { stone: string; status: string });
-
-  // find latest approval for this stone (with index in raw log)
-  let approvalIndex = -1;
-  for (let i = allReports.length - 1; i >= 0; i--) {
-    const report = allReports[i]!;
-    if (report.stone === input.stone.name && report.status === 'approved') {
-      approvalIndex = i;
-      break;
-    }
-  }
-
-  // no approval found
-  if (approvalIndex === -1) {
-    return null;
-  }
-
-  // check if any rewind invalidates this approval
-  // a rewind invalidates if: it appears AFTER the approval in log,
-  // AND the rewound stone prefix <= this stone's prefix
-  const thisPrefix = computeStoneOrderPrefix({ stone: input.stone });
-
-  for (let i = approvalIndex + 1; i < allReports.length; i++) {
-    const report = allReports[i]!;
-    if (report.status === 'rewound') {
-      // extract prefix from rewound stone name
-      const rewoundPrefix = getStoneOrderPrefixFromName(report.stone);
-
-      // if rewound stone is at or before this stone, approval is invalid
-      if (compareStonePrefix({ a: rewoundPrefix, b: thisPrefix }) <= 0) {
-        return null;
-      }
-    }
-  }
+  // find approval for this stone
+  const approval = reports.find(
+    (r) => r.stone === input.stone.name && r.status === 'approved',
+  );
+  if (!approval) return null;
 
   // approval is valid
   return new RouteStoneGuardApproveArtifact({
     stone: { path: input.stone.path },
-    path: passagePath,
+    path: path.join(input.route, '.route', 'passage.jsonl'),
   });
 };

--- a/src/domain.operations/route/passage/getAllPassageReports.test.ts
+++ b/src/domain.operations/route/passage/getAllPassageReports.test.ts
@@ -332,138 +332,153 @@ describe('getAllPassageReports', () => {
     });
   });
 
-  given('[case11] cross-stone invalidation: rewind earlier clears later approval', () => {
-    const tempDir = path.join(
-      os.tmpdir(),
-      `test-passage-crossstone-clears-${Date.now()}`,
-    );
-
-    beforeEach(async () => {
-      await fs.mkdir(path.join(tempDir, '.route'), { recursive: true });
-      const content =
-        [
-          JSON.stringify({ stone: '1.vision', status: 'passed' }),
-          JSON.stringify({ stone: '2.plan', status: 'approved' }),
-          JSON.stringify({ stone: '2.plan', status: 'passed' }),
-          JSON.stringify({ stone: '1.vision', status: 'rewound' }), // rewind to 1 should clear 2's approval
-        ].join('\n') + '\n';
-      await fs.writeFile(
-        path.join(tempDir, '.route', 'passage.jsonl'),
-        content,
+  given(
+    '[case11] cross-stone invalidation: rewind earlier clears later approval',
+    () => {
+      const tempDir = path.join(
+        os.tmpdir(),
+        `test-passage-crossstone-clears-${Date.now()}`,
       );
-    });
 
-    afterEach(async () => {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    });
-
-    when('[t0] stone 1 rewound after stone 2 approved', () => {
-      then('stone 2 approval is cleared (cross-stone invalidation)', async () => {
-        const reports = await getAllPassageReports({ route: tempDir });
-
-        // should have: 1.vision rewound, 2.plan passed (no approval)
-        const approvals = reports.filter((r) => r.status === 'approved');
-        expect(approvals).toHaveLength(0);
-
-        const stone2Reports = reports.filter((r) => r.stone === '2.plan');
-        expect(stone2Reports).toHaveLength(1);
-        expect(stone2Reports[0]!.status).toEqual('passed');
+      beforeEach(async () => {
+        await fs.mkdir(path.join(tempDir, '.route'), { recursive: true });
+        const content =
+          [
+            JSON.stringify({ stone: '1.vision', status: 'passed' }),
+            JSON.stringify({ stone: '2.plan', status: 'approved' }),
+            JSON.stringify({ stone: '2.plan', status: 'passed' }),
+            JSON.stringify({ stone: '1.vision', status: 'rewound' }), // rewind to 1 should clear 2's approval
+          ].join('\n') + '\n';
+        await fs.writeFile(
+          path.join(tempDir, '.route', 'passage.jsonl'),
+          content,
+        );
       });
-    });
-  });
 
-  given('[case12] cross-stone invalidation: rewind later does NOT clear earlier approval', () => {
-    const tempDir = path.join(
-      os.tmpdir(),
-      `test-passage-crossstone-keeps-${Date.now()}`,
-    );
+      afterEach(async () => {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      });
 
-    beforeEach(async () => {
-      await fs.mkdir(path.join(tempDir, '.route'), { recursive: true });
-      const content =
-        [
-          JSON.stringify({ stone: '1.vision', status: 'approved' }),
-          JSON.stringify({ stone: '1.vision', status: 'passed' }),
-          JSON.stringify({ stone: '2.plan', status: 'approved' }),
-          JSON.stringify({ stone: '2.plan', status: 'passed' }),
-          JSON.stringify({ stone: '2.plan', status: 'rewound' }), // rewind to 2 should NOT clear 1's approval
-        ].join('\n') + '\n';
-      await fs.writeFile(
-        path.join(tempDir, '.route', 'passage.jsonl'),
-        content,
+      when('[t0] stone 1 rewound after stone 2 approved', () => {
+        then(
+          'stone 2 approval is cleared (cross-stone invalidation)',
+          async () => {
+            const reports = await getAllPassageReports({ route: tempDir });
+
+            // should have: 1.vision rewound, 2.plan passed (no approval)
+            const approvals = reports.filter((r) => r.status === 'approved');
+            expect(approvals).toHaveLength(0);
+
+            const stone2Reports = reports.filter((r) => r.stone === '2.plan');
+            expect(stone2Reports).toHaveLength(1);
+            expect(stone2Reports[0]!.status).toEqual('passed');
+          },
+        );
+      });
+    },
+  );
+
+  given(
+    '[case12] cross-stone invalidation: rewind later does NOT clear earlier approval',
+    () => {
+      const tempDir = path.join(
+        os.tmpdir(),
+        `test-passage-crossstone-keeps-${Date.now()}`,
       );
-    });
 
-    afterEach(async () => {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    });
-
-    when('[t0] stone 2 rewound after both stones approved', () => {
-      then('stone 1 approval is preserved (not invalidated by later rewind)', async () => {
-        const reports = await getAllPassageReports({ route: tempDir });
-
-        // stone 1 should still have approval
-        const stone1Reports = reports.filter((r) => r.stone === '1.vision');
-        const stone1Statuses = stone1Reports.map((r) => r.status).sort();
-        expect(stone1Statuses).toEqual(['approved', 'passed']);
-
-        // stone 2 should have no approval (rewound clears same-stone)
-        const stone2Reports = reports.filter((r) => r.stone === '2.plan');
-        expect(stone2Reports).toHaveLength(1);
-        expect(stone2Reports[0]!.status).toEqual('rewound');
+      beforeEach(async () => {
+        await fs.mkdir(path.join(tempDir, '.route'), { recursive: true });
+        const content =
+          [
+            JSON.stringify({ stone: '1.vision', status: 'approved' }),
+            JSON.stringify({ stone: '1.vision', status: 'passed' }),
+            JSON.stringify({ stone: '2.plan', status: 'approved' }),
+            JSON.stringify({ stone: '2.plan', status: 'passed' }),
+            JSON.stringify({ stone: '2.plan', status: 'rewound' }), // rewind to 2 should NOT clear 1's approval
+          ].join('\n') + '\n';
+        await fs.writeFile(
+          path.join(tempDir, '.route', 'passage.jsonl'),
+          content,
+        );
       });
-    });
-  });
 
-  given('[case13] cross-stone invalidation: cascade through multiple stones', () => {
-    const tempDir = path.join(
-      os.tmpdir(),
-      `test-passage-crossstone-cascade-${Date.now()}`,
-    );
+      afterEach(async () => {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      });
 
-    beforeEach(async () => {
-      await fs.mkdir(path.join(tempDir, '.route'), { recursive: true });
-      const content =
-        [
-          JSON.stringify({ stone: '1.vision', status: 'approved' }),
-          JSON.stringify({ stone: '1.vision', status: 'passed' }),
-          JSON.stringify({ stone: '2.plan', status: 'approved' }),
-          JSON.stringify({ stone: '2.plan', status: 'passed' }),
-          JSON.stringify({ stone: '3.execute', status: 'approved' }),
-          JSON.stringify({ stone: '3.execute', status: 'blocked' }),
-          JSON.stringify({ stone: '1.vision', status: 'rewound' }), // cascade: clears 1, 2, and 3 approvals
-        ].join('\n') + '\n';
-      await fs.writeFile(
-        path.join(tempDir, '.route', 'passage.jsonl'),
-        content,
+      when('[t0] stone 2 rewound after both stones approved', () => {
+        then(
+          'stone 1 approval is preserved (not invalidated by later rewind)',
+          async () => {
+            const reports = await getAllPassageReports({ route: tempDir });
+
+            // stone 1 should still have approval
+            const stone1Reports = reports.filter((r) => r.stone === '1.vision');
+            const stone1Statuses = stone1Reports.map((r) => r.status).sort();
+            expect(stone1Statuses).toEqual(['approved', 'passed']);
+
+            // stone 2 should have no approval (rewound clears same-stone)
+            const stone2Reports = reports.filter((r) => r.stone === '2.plan');
+            expect(stone2Reports).toHaveLength(1);
+            expect(stone2Reports[0]!.status).toEqual('rewound');
+          },
+        );
+      });
+    },
+  );
+
+  given(
+    '[case13] cross-stone invalidation: cascade through multiple stones',
+    () => {
+      const tempDir = path.join(
+        os.tmpdir(),
+        `test-passage-crossstone-cascade-${Date.now()}`,
       );
-    });
 
-    afterEach(async () => {
-      await fs.rm(tempDir, { recursive: true, force: true });
-    });
-
-    when('[t0] stone 1 rewound after all three stones approved', () => {
-      then('all approvals are cleared (cascade invalidation)', async () => {
-        const reports = await getAllPassageReports({ route: tempDir });
-
-        // no approvals should remain
-        const approvals = reports.filter((r) => r.status === 'approved');
-        expect(approvals).toHaveLength(0);
-
-        // check each stone has correct passage state
-        const stone1 = reports.filter((r) => r.stone === '1.vision');
-        expect(stone1).toHaveLength(1);
-        expect(stone1[0]!.status).toEqual('rewound');
-
-        const stone2 = reports.filter((r) => r.stone === '2.plan');
-        expect(stone2).toHaveLength(1);
-        expect(stone2[0]!.status).toEqual('passed');
-
-        const stone3 = reports.filter((r) => r.stone === '3.execute');
-        expect(stone3).toHaveLength(1);
-        expect(stone3[0]!.status).toEqual('blocked');
+      beforeEach(async () => {
+        await fs.mkdir(path.join(tempDir, '.route'), { recursive: true });
+        const content =
+          [
+            JSON.stringify({ stone: '1.vision', status: 'approved' }),
+            JSON.stringify({ stone: '1.vision', status: 'passed' }),
+            JSON.stringify({ stone: '2.plan', status: 'approved' }),
+            JSON.stringify({ stone: '2.plan', status: 'passed' }),
+            JSON.stringify({ stone: '3.execute', status: 'approved' }),
+            JSON.stringify({ stone: '3.execute', status: 'blocked' }),
+            JSON.stringify({ stone: '1.vision', status: 'rewound' }), // cascade: clears 1, 2, and 3 approvals
+          ].join('\n') + '\n';
+        await fs.writeFile(
+          path.join(tempDir, '.route', 'passage.jsonl'),
+          content,
+        );
       });
-    });
-  });
+
+      afterEach(async () => {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      });
+
+      when('[t0] stone 1 rewound after all three stones approved', () => {
+        then('all approvals are cleared (cascade invalidation)', async () => {
+          const reports = await getAllPassageReports({ route: tempDir });
+
+          // no approvals should remain
+          const approvals = reports.filter((r) => r.status === 'approved');
+          expect(approvals).toHaveLength(0);
+
+          // check each stone has correct passage state
+          const stone1 = reports.filter((r) => r.stone === '1.vision');
+          expect(stone1).toHaveLength(1);
+          expect(stone1[0]!.status).toEqual('rewound');
+
+          const stone2 = reports.filter((r) => r.stone === '2.plan');
+          expect(stone2).toHaveLength(1);
+          expect(stone2[0]!.status).toEqual('passed');
+
+          const stone3 = reports.filter((r) => r.stone === '3.execute');
+          expect(stone3).toHaveLength(1);
+          expect(stone3[0]!.status).toEqual('blocked');
+        });
+      });
+    },
+  );
 });

--- a/src/domain.operations/route/passage/getAllPassageReports.test.ts
+++ b/src/domain.operations/route/passage/getAllPassageReports.test.ts
@@ -331,4 +331,139 @@ describe('getAllPassageReports', () => {
       );
     });
   });
+
+  given('[case11] cross-stone invalidation: rewind earlier clears later approval', () => {
+    const tempDir = path.join(
+      os.tmpdir(),
+      `test-passage-crossstone-clears-${Date.now()}`,
+    );
+
+    beforeEach(async () => {
+      await fs.mkdir(path.join(tempDir, '.route'), { recursive: true });
+      const content =
+        [
+          JSON.stringify({ stone: '1.vision', status: 'passed' }),
+          JSON.stringify({ stone: '2.plan', status: 'approved' }),
+          JSON.stringify({ stone: '2.plan', status: 'passed' }),
+          JSON.stringify({ stone: '1.vision', status: 'rewound' }), // rewind to 1 should clear 2's approval
+        ].join('\n') + '\n';
+      await fs.writeFile(
+        path.join(tempDir, '.route', 'passage.jsonl'),
+        content,
+      );
+    });
+
+    afterEach(async () => {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    });
+
+    when('[t0] stone 1 rewound after stone 2 approved', () => {
+      then('stone 2 approval is cleared (cross-stone invalidation)', async () => {
+        const reports = await getAllPassageReports({ route: tempDir });
+
+        // should have: 1.vision rewound, 2.plan passed (no approval)
+        const approvals = reports.filter((r) => r.status === 'approved');
+        expect(approvals).toHaveLength(0);
+
+        const stone2Reports = reports.filter((r) => r.stone === '2.plan');
+        expect(stone2Reports).toHaveLength(1);
+        expect(stone2Reports[0]!.status).toEqual('passed');
+      });
+    });
+  });
+
+  given('[case12] cross-stone invalidation: rewind later does NOT clear earlier approval', () => {
+    const tempDir = path.join(
+      os.tmpdir(),
+      `test-passage-crossstone-keeps-${Date.now()}`,
+    );
+
+    beforeEach(async () => {
+      await fs.mkdir(path.join(tempDir, '.route'), { recursive: true });
+      const content =
+        [
+          JSON.stringify({ stone: '1.vision', status: 'approved' }),
+          JSON.stringify({ stone: '1.vision', status: 'passed' }),
+          JSON.stringify({ stone: '2.plan', status: 'approved' }),
+          JSON.stringify({ stone: '2.plan', status: 'passed' }),
+          JSON.stringify({ stone: '2.plan', status: 'rewound' }), // rewind to 2 should NOT clear 1's approval
+        ].join('\n') + '\n';
+      await fs.writeFile(
+        path.join(tempDir, '.route', 'passage.jsonl'),
+        content,
+      );
+    });
+
+    afterEach(async () => {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    });
+
+    when('[t0] stone 2 rewound after both stones approved', () => {
+      then('stone 1 approval is preserved (not invalidated by later rewind)', async () => {
+        const reports = await getAllPassageReports({ route: tempDir });
+
+        // stone 1 should still have approval
+        const stone1Reports = reports.filter((r) => r.stone === '1.vision');
+        const stone1Statuses = stone1Reports.map((r) => r.status).sort();
+        expect(stone1Statuses).toEqual(['approved', 'passed']);
+
+        // stone 2 should have no approval (rewound clears same-stone)
+        const stone2Reports = reports.filter((r) => r.stone === '2.plan');
+        expect(stone2Reports).toHaveLength(1);
+        expect(stone2Reports[0]!.status).toEqual('rewound');
+      });
+    });
+  });
+
+  given('[case13] cross-stone invalidation: cascade through multiple stones', () => {
+    const tempDir = path.join(
+      os.tmpdir(),
+      `test-passage-crossstone-cascade-${Date.now()}`,
+    );
+
+    beforeEach(async () => {
+      await fs.mkdir(path.join(tempDir, '.route'), { recursive: true });
+      const content =
+        [
+          JSON.stringify({ stone: '1.vision', status: 'approved' }),
+          JSON.stringify({ stone: '1.vision', status: 'passed' }),
+          JSON.stringify({ stone: '2.plan', status: 'approved' }),
+          JSON.stringify({ stone: '2.plan', status: 'passed' }),
+          JSON.stringify({ stone: '3.execute', status: 'approved' }),
+          JSON.stringify({ stone: '3.execute', status: 'blocked' }),
+          JSON.stringify({ stone: '1.vision', status: 'rewound' }), // cascade: clears 1, 2, and 3 approvals
+        ].join('\n') + '\n';
+      await fs.writeFile(
+        path.join(tempDir, '.route', 'passage.jsonl'),
+        content,
+      );
+    });
+
+    afterEach(async () => {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    });
+
+    when('[t0] stone 1 rewound after all three stones approved', () => {
+      then('all approvals are cleared (cascade invalidation)', async () => {
+        const reports = await getAllPassageReports({ route: tempDir });
+
+        // no approvals should remain
+        const approvals = reports.filter((r) => r.status === 'approved');
+        expect(approvals).toHaveLength(0);
+
+        // check each stone has correct passage state
+        const stone1 = reports.filter((r) => r.stone === '1.vision');
+        expect(stone1).toHaveLength(1);
+        expect(stone1[0]!.status).toEqual('rewound');
+
+        const stone2 = reports.filter((r) => r.stone === '2.plan');
+        expect(stone2).toHaveLength(1);
+        expect(stone2[0]!.status).toEqual('passed');
+
+        const stone3 = reports.filter((r) => r.stone === '3.execute');
+        expect(stone3).toHaveLength(1);
+        expect(stone3[0]!.status).toEqual('blocked');
+      });
+    });
+  });
 });

--- a/src/domain.operations/route/passage/getAllPassageReports.ts
+++ b/src/domain.operations/route/passage/getAllPassageReports.ts
@@ -3,6 +3,9 @@ import * as path from 'path';
 
 import { PassageReport } from '@src/domain.objects/Driver/PassageReport';
 
+import { compareStonePrefix } from '../stones/compareStonePrefix';
+import { getStoneOrderPrefixFromName } from '../stones/computeStoneOrderPrefix';
+
 /**
  * .what = reads current passage state per stone from passage.jsonl
  * .why = enables current passage state lookup
@@ -10,7 +13,7 @@ import { PassageReport } from '@src/domain.objects/Driver/PassageReport';
  * .note = passage.jsonl is append-only with specific deduplication rules:
  *         - passage states (passed/blocked/malfunction): last entry wins
  *         - approved: sticky (persists) unless rewound after it
- *         - rewound: clears both passage state AND approval
+ *         - rewound: clears approval for this stone AND all later stones (cross-stone invalidation)
  */
 export const getAllPassageReports = async (input: {
   route: string;
@@ -40,8 +43,14 @@ export const getAllPassageReports = async (input: {
       // approved is sticky until rewound
       approvedByStone.set(report.stone, report);
     } else if (report.status === 'rewound') {
-      // rewound clears approval
-      approvedByStone.delete(report.stone);
+      // rewound clears approval for this stone AND all later stones (cross-stone invalidation)
+      const rewoundPrefix = getStoneOrderPrefixFromName(report.stone);
+      for (const [stoneName] of approvedByStone) {
+        const stonePrefix = getStoneOrderPrefixFromName(stoneName);
+        if (compareStonePrefix({ a: rewoundPrefix, b: stonePrefix }) <= 0) {
+          approvedByStone.delete(stoneName);
+        }
+      }
       latestByStone.set(report.stone, report);
     } else {
       // other statuses: last entry wins


### PR DESCRIPTION
fix(route): move cross-stone invalidation into getAllPassageReports

- rewind of stone M now clears approvals for all stones >= M
- simplifies getOneStoneGuardApproval to just use getAllPassageReports
- adds 3 test cases for cross-stone invalidation behavior

---
🐢🌊 surfed in by seaturtle[bot]