### PR TITLE
fix(route): disambiguate self-review articulation path format

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,15 +24,15 @@
           },
           {
             "type": "command",
-            "command": "./node_modules/.bin/rhachet run --repo bhuild --role behaver --init claude.hooks/sessionstart.boot-behavior",
-            "timeout": 10,
-            "author": "repo=bhuild/role=behaver"
-          },
-          {
-            "type": "command",
             "command": "./node_modules/.bin/rhx route.drive --mode hook",
             "timeout": 5,
             "author": "repo=bhrain/role=driver"
+          },
+          {
+            "type": "command",
+            "command": "./node_modules/.bin/rhachet run --repo bhuild --role behaver --init claude.hooks/sessionstart.boot-behavior",
+            "timeout": 10,
+            "author": "repo=bhuild/role=behaver"
           }
         ]
       }

--- a/blackbox/__snapshots__/driver.route.journey.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.journey.acceptance.test.ts.snap
@@ -11,7 +11,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
 
 exports[`driver.route.journey.acceptance given: [journey] weather api route when: [t1] 1.vision artifact is created and pass attempted then: stdout has good vibes 1`] = `
 "🦉 the way speaks for itself
-   └─ ✗ judge.1 - blocked 0.5s
+   └─ ✗ judge.1 - blocked 0.4s
 
 🗿 route.stone.set
    ├─ stone = 1.vision
@@ -38,17 +38,20 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
 
 exports[`driver.route.journey.acceptance given: [journey] weather api route when: [t3] 1.vision pass is reattempted after approval then: stdout has good vibes 1`] = `
 "🦉 the way speaks for itself
-   └─ ✓ judge.1 - allowed 0.7s
+   └─ ✓ judge.1 - allowed 0.3s
 
 🗿 route.stone.set
    ├─ stone = 1.vision
    ├─ passage = allowed
-   └─ guard
-      ├─ artifacts
-      │   └─ 1.vision.md
-      └─ judges
-          └─ j1: rhx route.stone.judge --mechanism approved? --stone $stone --route $route
-              └─ finished [TIME] ✓
+   ├─ guard
+   │  ├─ artifacts
+   │  │   └─ 1.vision.md
+   │  └─ judges
+   │      └─ j1: rhx route.stone.judge --mechanism approved? --stone $stone --route $route
+   │          └─ finished [TIME] ✓
+   │
+   └─ the way continues, run
+      └─ rhx route.drive
 "
 `;
 
@@ -71,7 +74,10 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
 
 🗿 route.stone.set
    ├─ stone = 2.research
-   └─ passage = allowed (unguarded)
+   ├─ passage = allowed (unguarded)
+   │
+   └─ the way continues, run
+      └─ rhx route.drive
 "
 `;
 
@@ -182,7 +188,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ /review/self/3.blueprint.1.design-complete.md
+   │  │  └─ /review/self/for.3.blueprint._.r1.design-complete.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─
@@ -209,7 +215,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
 "🦉 the way speaks for itself
    ├─ ✓ review.1 - completed (cached)
    ├─ ✓ judge.1 - allowed (cached)
-   └─ ✗ judge.2 - blocked 1.7s
+   └─ ✗ judge.2 - blocked 0.3s
 
 🗿 route.stone.set
    ├─ stone = 3.blueprint
@@ -233,8 +239,8 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
 exports[`driver.route.journey.acceptance given: [journey] weather api route when: [t9] 3.blueprint pass reattempted after promise then: stdout has good vibes 1`] = `
 "🦉 the way speaks for itself
    ├─ ✓ review.1 - completed 0.0s
-   ├─ ✗ judge.1 - blocked 1.3s
-   └─ ✗ judge.2 - blocked 1.0s
+   ├─ ✗ judge.1 - blocked 0.4s
+   └─ ✗ judge.2 - blocked 0.3s
 
 🗿 route.stone.set
    ├─ stone = 3.blueprint
@@ -261,23 +267,26 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
 exports[`driver.route.journey.acceptance given: [journey] weather api route when: [t10] 3.blueprint approved and self-review completed then: stdout has good vibes 1`] = `
 "🦉 the way speaks for itself
    ├─ ✓ review.1 - completed (cached)
-   ├─ ✓ judge.1 - allowed 1.2s
-   └─ ✓ judge.2 - allowed 2.5s
+   ├─ ✓ judge.1 - allowed 0.3s
+   └─ ✓ judge.2 - allowed 0.3s
 
 🗿 route.stone.set
    ├─ stone = 3.blueprint
    ├─ passage = allowed
-   └─ guard
-      ├─ artifacts
-      │   └─ 3.blueprint.md
-      ├─ reviews
-      │   └─ r1: bash $route/.test/mock-review.sh
-      │       └─ · cached
-      └─ judges
-          ├─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 2
-          │   └─ finished [TIME] ✓
-          └─ j2: rhx route.stone.judge --mechanism approved? --stone $stone --route $route
-              └─ finished [TIME] ✓
+   ├─ guard
+   │  ├─ artifacts
+   │  │   └─ 3.blueprint.md
+   │  ├─ reviews
+   │  │   └─ r1: bash $route/.test/mock-review.sh
+   │  │       └─ · cached
+   │  └─ judges
+   │      ├─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 2
+   │      │   └─ finished [TIME] ✓
+   │      └─ j2: rhx route.stone.judge --mechanism approved? --stone $stone --route $route
+   │          └─ finished [TIME] ✓
+   │
+   └─ the way continues, run
+      └─ rhx route.drive
 "
 `;
 
@@ -292,22 +301,25 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
 
 exports[`driver.route.journey.acceptance given: [journey] weather api route when: [t12] 5.execute artifact created and pass attempted then: stdout has good vibes 1`] = `
 "🦉 the way speaks for itself
-   ├─ ✓ review.1 - completed 0.1s
-   └─ ✓ judge.1 - allowed 1.6s
+   ├─ ✓ review.1 - completed 0.0s
+   └─ ✓ judge.1 - allowed 0.3s
 
 🗿 route.stone.set
    ├─ stone = 5.execute
    ├─ passage = allowed
-   └─ guard
-      ├─ artifacts
-      │   └─ weather.ts
-      ├─ reviews
-      │   └─ r1: bash $route/.test/mock-review.sh
-      │       ├─ finished [TIME] ✓
-      │       └─ review: .route/5.execute.guard.review.i1.e5c031c5923de2dd7ebc77d84ac1c222cfdb9d3143fa8c0bc27ed9d821ce74e3.r1.md
-      └─ judges
-          └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
-              └─ finished [TIME] ✓
+   ├─ guard
+   │  ├─ artifacts
+   │  │   └─ weather.ts
+   │  ├─ reviews
+   │  │   └─ r1: bash $route/.test/mock-review.sh
+   │  │       ├─ finished [TIME] ✓
+   │  │       └─ review: .route/5.execute.guard.review.i1.e5c031c5923de2dd7ebc77d84ac1c222cfdb9d3143fa8c0bc27ed9d821ce74e3.r1.md
+   │  └─ judges
+   │      └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
+   │          └─ finished [TIME] ✓
+   │
+   └─ the way continues, run
+      └─ rhx route.drive
 "
 `;
 

--- a/blackbox/__snapshots__/driver.route.self-review.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.self-review.acceptance.test.ts.snap
@@ -67,7 +67,7 @@ exports[`driver.route.review.self.acceptance given: [case1] stone with reviews.s
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ /review/self/1.1.all-done.md
+   │  │  └─ /review/self/for.1._.r1.all-done.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─
@@ -157,7 +157,7 @@ exports[`driver.route.review.self.acceptance given: [case1] stone with reviews.s
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ ./review/self/1.1.tests-pass.md
+   │  │  └─ ./review/self/for.1._.r1.tests-pass.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─
@@ -191,22 +191,25 @@ exports[`driver.route.review.self.acceptance given: [case1] stone with reviews.s
 
 exports[`driver.route.review.self.acceptance given: [case1] stone with reviews.self defined when: [t3] pass attempted with all promises then: stdout has good vibes 1`] = `
 "🦉 the way speaks for itself
-   ├─ ✓ review.1 - completed 0.1s
-   └─ ✓ judge.1 - allowed 2.0s
+   ├─ ✓ review.1 - completed 0.0s
+   └─ ✓ judge.1 - allowed 0.6s
 
 🗿 route.stone.set
    ├─ stone = 1
    ├─ passage = allowed
-   └─ guard
-      ├─ artifacts
-      │   └─ 1.stone.i1.md
-      ├─ reviews
-      │   └─ r1: .test/mock-review.sh --paths 1.stone*.md
-      │       ├─ finished [TIME] ✓
-      │       └─ review: .route/1.guard.review.i1.3323f7a0e391b72d09ba5b4f51f33a2bfc06024571e276ee021a5f7e84874cc1.r1.md
-      └─ judges
-          └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0
-              └─ finished [TIME] ✓
+   ├─ guard
+   │  ├─ artifacts
+   │  │   └─ 1.stone.i1.md
+   │  ├─ reviews
+   │  │   └─ r1: .test/mock-review.sh --paths 1.stone*.md
+   │  │       ├─ finished [TIME] ✓
+   │  │       └─ review: .route/1.guard.review.i1.3323f7a0e391b72d09ba5b4f51f33a2bfc06024571e276ee021a5f7e84874cc1.r1.md
+   │  └─ judges
+   │      └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0
+   │          └─ finished [TIME] ✓
+   │
+   └─ the way continues, run
+      └─ rhx route.drive
 "
 `;
 
@@ -277,7 +280,7 @@ exports[`driver.route.review.self.acceptance given: [case3] hashless promises su
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ /review/self/1.2.tests-pass.md
+   │  │  └─ /review/self/for.1._.r2.tests-pass.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─
@@ -303,21 +306,24 @@ exports[`driver.route.review.self.acceptance given: [case3] hashless promises su
 exports[`driver.route.review.self.acceptance given: [case4] flat reviews array (backwards compatible) when: [t0] pass attempted with flat reviews then: stdout has good vibes 1`] = `
 "🦉 the way speaks for itself
    ├─ ✓ review.1 - completed 0.0s
-   └─ ✓ judge.1 - allowed 2.3s
+   └─ ✓ judge.1 - allowed 0.4s
 
 🗿 route.stone.set
    ├─ stone = 1
    ├─ passage = allowed
-   └─ guard
-      ├─ artifacts
-      │   └─ 1.stone.i1.md
-      ├─ reviews
-      │   └─ r1: .test/mock-review.sh --paths 1.stone*.md
-      │       ├─ finished [TIME] ✓
-      │       └─ review: .route/1.guard.review.i1.3323f7a0e391b72d09ba5b4f51f33a2bfc06024571e276ee021a5f7e84874cc1.r1.md
-      └─ judges
-          └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0
-              └─ finished [TIME] ✓
+   ├─ guard
+   │  ├─ artifacts
+   │  │   └─ 1.stone.i1.md
+   │  ├─ reviews
+   │  │   └─ r1: .test/mock-review.sh --paths 1.stone*.md
+   │  │       ├─ finished [TIME] ✓
+   │  │       └─ review: .route/1.guard.review.i1.3323f7a0e391b72d09ba5b4f51f33a2bfc06024571e276ee021a5f7e84874cc1.r1.md
+   │  └─ judges
+   │      └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0
+   │          └─ finished [TIME] ✓
+   │
+   └─ the way continues, run
+      └─ rhx route.drive
 "
 `;
 
@@ -381,7 +387,7 @@ exports[`driver.route.review.self.acceptance given: [case5] clone promises too q
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ ./review/self/1.1.all-done.md
+   │  │  └─ ./review/self/for.1._.r1.all-done.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─
@@ -462,7 +468,7 @@ exports[`driver.route.review.self.acceptance given: [case5] clone promises too q
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ ./review/self/1.1.all-done.md
+   │  │  └─ ./review/self/for.1._.r1.all-done.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─
@@ -525,7 +531,7 @@ exports[`driver.route.review.self.acceptance given: [case8] full challenge journ
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ ./review/self/1.1.all-done.md
+   │  │  └─ ./review/self/for.1._.r1.all-done.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─
@@ -606,7 +612,7 @@ exports[`driver.route.review.self.acceptance given: [case8] full challenge journ
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ ./review/self/1.1.all-done.md
+   │  │  └─ ./review/self/for.1._.r1.all-done.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─
@@ -636,7 +642,7 @@ exports[`driver.route.review.self.acceptance given: [case8] full challenge journ
    ├─ ...
    │
    ├─ the articulation is absent
-   │  └─ ./review/self/1.1.all-done.md
+   │  └─ ./review/self/for.1._.r1.all-done.md
    │
    ├─ a promise without words
    │  ├─ is not a promise
@@ -684,7 +690,7 @@ exports[`driver.route.review.self.acceptance given: [case8] full challenge journ
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ ./review/self/1.1.all-done.md
+   │  │  └─ ./review/self/for.1._.r1.all-done.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─
@@ -765,7 +771,7 @@ exports[`driver.route.review.self.acceptance given: [case8] full challenge journ
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ ./review/self/1.1.all-done.md
+   │  │  └─ ./review/self/for.1._.r1.all-done.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─
@@ -848,7 +854,7 @@ exports[`driver.route.review.self.acceptance given: [case8] full challenge journ
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ ./review/self/1.1.all-done.md
+   │  │  └─ ./review/self/for.1._.r1.all-done.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─
@@ -929,7 +935,7 @@ exports[`driver.route.review.self.acceptance given: [case8] full challenge journ
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ ./review/self/1.1.all-done.md
+   │  │  └─ ./review/self/for.1._.r1.all-done.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─
@@ -1019,7 +1025,7 @@ exports[`driver.route.review.self.acceptance given: [case8] full challenge journ
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ ./review/self/1.1.tests-pass.md
+   │  │  └─ ./review/self/for.1._.r1.tests-pass.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─

--- a/blackbox/driver.route.drive.acceptance.test.ts
+++ b/blackbox/driver.route.drive.acceptance.test.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { given, then, useBeforeAll, useThen, when } from 'test-fns';
 
+import { getSelfReviewArticulationPath } from '../src/domain.operations/route/guard/getSelfReviewArticulationPath';
 import {
   execAsync,
   genTempDirForRhachet,
@@ -359,11 +360,14 @@ describe('driver.route.drive.acceptance', () => {
       await backdateTriggeredReport({ tempDir, stone: '1', slug: 'all-done' });
 
       // create articulation file for first review.self (required by file presence check)
-      await fs.mkdir(path.join(tempDir, 'review', 'self'), { recursive: true });
-      await fs.writeFile(
-        path.join(tempDir, 'review', 'self', '1.1.all-done.md'),
-        '# self-review\n\nall done.',
-      );
+      const articulationPath1 = getSelfReviewArticulationPath({
+        route: tempDir,
+        stone: '1',
+        index: 1,
+        slug: 'all-done',
+      });
+      await fs.mkdir(path.dirname(articulationPath1), { recursive: true });
+      await fs.writeFile(articulationPath1, '# self-review\n\nall done.');
 
       // promise first review.self
       await invokeRouteSkill({
@@ -381,10 +385,13 @@ describe('driver.route.drive.acceptance', () => {
       await backdateTriggeredReport({ tempDir, stone: '1', slug: 'tests-pass' });
 
       // create articulation file for second review.self (required by file presence check)
-      await fs.writeFile(
-        path.join(tempDir, 'review', 'self', '1.2.tests-pass.md'),
-        '# self-review\n\ntests pass.',
-      );
+      const articulationPath2 = getSelfReviewArticulationPath({
+        route: tempDir,
+        stone: '1',
+        index: 2,
+        slug: 'tests-pass',
+      });
+      await fs.writeFile(articulationPath2, '# self-review\n\ntests pass.');
 
       // promise second review.self
       await invokeRouteSkill({

--- a/blackbox/driver.route.drive.blockedOn.acceptance.test.ts
+++ b/blackbox/driver.route.drive.blockedOn.acceptance.test.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { given, then, useBeforeAll, useThen, when } from 'test-fns';
 
+import { getSelfReviewArticulationPath } from '../src/domain.operations/route/guard/getSelfReviewArticulationPath';
 import {
   execAsync,
   genTempDirForRhachet,
@@ -308,16 +309,15 @@ describe('driver.route.drive.blocker.acceptance', () => {
         });
 
         // create articulation file (required by file presence check)
-        await fs.mkdir(path.join(scene.tempDir, 'review', 'self'), {
-          recursive: true,
+        const articulationPath = getSelfReviewArticulationPath({
+          route: scene.tempDir,
+          stone: '3.blueprint',
+          index: 1,
+          slug: 'design-complete',
         });
+        await fs.mkdir(path.dirname(articulationPath), { recursive: true });
         await fs.writeFile(
-          path.join(
-            scene.tempDir,
-            'review',
-            'self',
-            '3.blueprint.1.design-complete.md',
-          ),
+          articulationPath,
           '# design review\n\napi design is complete.',
         );
 

--- a/blackbox/driver.route.journey.acceptance.test.ts
+++ b/blackbox/driver.route.journey.acceptance.test.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { given, then, useBeforeAll, useThen, when } from 'test-fns';
 
+import { getSelfReviewArticulationPath } from '../src/domain.operations/route/guard/getSelfReviewArticulationPath';
 import {
   execAsync,
   genTempDirForRhachet,
@@ -378,12 +379,14 @@ describe('driver.route.journey.acceptance', () => {
     when('[t8.5] 3.blueprint review.self is promised', () => {
       const result = useThen('promise succeeds', async () => {
         // create articulation file (required by file presence check)
-        // format: {route}/review/self/{stone}.{index}.{slug}.md
-        await fs.mkdir(path.join(scene.tempDir, 'review', 'self'), { recursive: true });
-        await fs.writeFile(
-          path.join(scene.tempDir, 'review', 'self', '3.blueprint.1.design-complete.md'),
-          '# design review\n\napi design looks complete.',
-        );
+        const articulationPath = getSelfReviewArticulationPath({
+          route: scene.tempDir,
+          stone: '3.blueprint',
+          index: 1,
+          slug: 'design-complete',
+        });
+        await fs.mkdir(path.dirname(articulationPath), { recursive: true });
+        await fs.writeFile(articulationPath, '# design review\n\napi design looks complete.');
 
         // backdate triggered report to bypass time enforcement
         await backdateTriggeredReport({
@@ -511,10 +514,16 @@ describe('driver.route.journey.acceptance', () => {
           slug: 'design-complete',
         });
 
-        // create articulation file (format: {route}/review/self/{stone}.{index}.{slug}.md)
-        await fs.mkdir(path.join(scene.tempDir, 'review', 'self'), { recursive: true });
+        // create articulation file
+        const articulationPath = getSelfReviewArticulationPath({
+          route: scene.tempDir,
+          stone: '3.blueprint',
+          index: 1,
+          slug: 'design-complete',
+        });
+        await fs.mkdir(path.dirname(articulationPath), { recursive: true });
         await fs.writeFile(
-          path.join(scene.tempDir, 'review', 'self', '3.blueprint.1.design-complete.md'),
+          articulationPath,
           '# design review\n\napi design is complete with all endpoints documented.',
         );
 

--- a/blackbox/driver.route.self-review.acceptance.test.ts
+++ b/blackbox/driver.route.self-review.acceptance.test.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { given, then, useBeforeAll, useThen, when } from 'test-fns';
 
+import { getSelfReviewArticulationPath } from '../src/domain.operations/route/guard/getSelfReviewArticulationPath';
 import {
   execAsync,
   genTempDirForRhachet,
@@ -70,14 +71,26 @@ describe('driver.route.review.self.acceptance', () => {
         '# Implementation\n\nFeature implemented.',
       );
 
-      // create articulation files for both self-reviews (index prefix for sort order)
-      await fs.mkdir(path.join(tempDir, 'review', 'self'), { recursive: true });
+      // create articulation files for both self-reviews
+      const articulationPath1 = getSelfReviewArticulationPath({
+        route: tempDir,
+        stone: '1',
+        index: 1,
+        slug: 'all-done',
+      });
+      const articulationPath2 = getSelfReviewArticulationPath({
+        route: tempDir,
+        stone: '1',
+        index: 2,
+        slug: 'tests-pass',
+      });
+      await fs.mkdir(path.dirname(articulationPath1), { recursive: true });
       await fs.writeFile(
-        path.join(tempDir, 'review', 'self', '1.1.all-done.md'),
+        articulationPath1,
         '# Self-Review: all-done\n\nI reviewed all requirements.\n',
       );
       await fs.writeFile(
-        path.join(tempDir, 'review', 'self', '1.2.tests-pass.md'),
+        articulationPath2,
         '# Self-Review: tests-pass\n\nI verified all tests pass.\n',
       );
 
@@ -269,14 +282,26 @@ describe('driver.route.review.self.acceptance', () => {
         '# Implementation\n\nFeature implemented.',
       );
 
-      // create articulation files for both self-reviews (index prefix for sort order)
-      await fs.mkdir(path.join(tempDir, 'review', 'self'), { recursive: true });
+      // create articulation files for both self-reviews
+      const articulationPath1 = getSelfReviewArticulationPath({
+        route: tempDir,
+        stone: '1',
+        index: 1,
+        slug: 'all-done',
+      });
+      const articulationPath2 = getSelfReviewArticulationPath({
+        route: tempDir,
+        stone: '1',
+        index: 2,
+        slug: 'tests-pass',
+      });
+      await fs.mkdir(path.dirname(articulationPath1), { recursive: true });
       await fs.writeFile(
-        path.join(tempDir, 'review', 'self', '1.1.all-done.md'),
+        articulationPath1,
         '# Self-Review: all-done\n\nI reviewed all requirements.\n',
       );
       await fs.writeFile(
-        path.join(tempDir, 'review', 'self', '1.2.tests-pass.md'),
+        articulationPath2,
         '# Self-Review: tests-pass\n\nI verified all tests pass.\n',
       );
 
@@ -453,9 +478,15 @@ judges:
       );
 
       // create articulation file so test focuses on time enforcement (not absent file)
-      await fs.mkdir(path.join(tempDir, 'review', 'self'), { recursive: true });
+      const articulationPath = getSelfReviewArticulationPath({
+        route: tempDir,
+        stone: '1',
+        index: 1,
+        slug: 'all-done',
+      });
+      await fs.mkdir(path.dirname(articulationPath), { recursive: true });
       await fs.writeFile(
-        path.join(tempDir, 'review', 'self', '1.1.all-done.md'),
+        articulationPath,
         '# self-review\n\nreviewed and looks good.',
       );
 
@@ -574,12 +605,16 @@ judges:
           cwd: scene.tempDir,
         });
 
-        // create articulation file (required for promise to succeed, index prefix for sort order)
-        await fs.mkdir(path.join(scene.tempDir, 'review', 'self'), {
-          recursive: true,
+        // create articulation file (required for promise to succeed)
+        const articulationPath = getSelfReviewArticulationPath({
+          route: scene.tempDir,
+          stone: '1',
+          index: 1,
+          slug: 'all-done',
         });
+        await fs.mkdir(path.dirname(articulationPath), { recursive: true });
         await fs.writeFile(
-          path.join(scene.tempDir, 'review', 'self', '1.1.all-done.md'),
+          articulationPath,
           '# self-review\n\nreviewed and looks good.',
         );
 
@@ -645,9 +680,15 @@ judges:
 
     when('[t2] promise tests-pass and complete stone', () => {
       then('all self-reviews satisfied', async () => {
-        // create articulation file for tests-pass (required for promise to succeed, index prefix)
+        // create articulation file for tests-pass (required for promise to succeed)
+        const articulationPath = getSelfReviewArticulationPath({
+          route: scene.tempDir,
+          stone: '1',
+          index: 2,
+          slug: 'tests-pass',
+        });
         await fs.writeFile(
-          path.join(scene.tempDir, 'review', 'self', '1.2.tests-pass.md'),
+          articulationPath,
           '# self-review\n\nall tests pass.',
         );
 
@@ -698,10 +739,16 @@ judges:
         '# Implementation\n\nFeature implemented.',
       );
 
-      // create articulation file (required for plowthrough to work, index prefix for sort order)
-      await fs.mkdir(path.join(tempDir, 'review', 'self'), { recursive: true });
+      // create articulation file (required for plowthrough to work)
+      const articulationPath = getSelfReviewArticulationPath({
+        route: tempDir,
+        stone: '1',
+        index: 1,
+        slug: 'all-done',
+      });
+      await fs.mkdir(path.dirname(articulationPath), { recursive: true });
       await fs.writeFile(
-        path.join(tempDir, 'review', 'self', '1.1.all-done.md'),
+        articulationPath,
         '# Self-Review: all-done\n\nI reviewed and found everything in order.\n',
       );
 
@@ -787,7 +834,7 @@ judges:
       });
 
       then('shows articulation path with index', () => {
-        expect(result.stdout).toContain('review/self/1.1.all-done.md');
+        expect(result.stdout).toContain('review/self/for.1._.r1.all-done.md');
       });
 
       then('stdout has good vibes', () => {
@@ -832,12 +879,16 @@ judges:
 
     when('[t2] third promise attempt (file created, too soon)', () => {
       const result = useThen('returns challenge:rushed', async () => {
-        // create articulation file (index prefix for sort order)
-        await fs.mkdir(path.join(scene.tempDir, 'review', 'self'), {
-          recursive: true,
+        // create articulation file
+        const articulationPath = getSelfReviewArticulationPath({
+          route: scene.tempDir,
+          stone: '1',
+          index: 1,
+          slug: 'all-done',
         });
+        await fs.mkdir(path.dirname(articulationPath), { recursive: true });
         await fs.writeFile(
-          path.join(scene.tempDir, 'review', 'self', '1.1.all-done.md'),
+          articulationPath,
           '# self-review\n\nreviewed and looks good.',
         );
 

--- a/src/domain.operations/route/__snapshots__/formatRouteStoneEmit.test.ts.snap
+++ b/src/domain.operations/route/__snapshots__/formatRouteStoneEmit.test.ts.snap
@@ -7,7 +7,7 @@ exports[`formatRouteStoneEmit given: [case1] challenge:absent action when: [t0] 
    ├─ ...
    │
    ├─ the articulation is absent
-   │  └─ .behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md
+   │  └─ .behavior/v2026_03_08.feature/review/self/for.3.1.blueprint._.r1.design.md
    │
    ├─ a promise without words
    │  ├─ is not a promise
@@ -55,7 +55,7 @@ exports[`formatRouteStoneEmit given: [case1] challenge:absent action when: [t0] 
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ .behavior/v2026_03_08.feature/review/self/3.1.blueprint.1.design.md
+   │  │  └─ .behavior/v2026_03_08.feature/review/self/for.3.1.blueprint._.r1.design.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─

--- a/src/domain.operations/route/formatRouteStoneEmit.test.ts
+++ b/src/domain.operations/route/formatRouteStoneEmit.test.ts
@@ -1,19 +1,29 @@
 import { given, then, when } from 'test-fns';
 
 import { formatRouteStoneEmit } from './formatRouteStoneEmit';
+import { getSelfReviewArticulationPath } from './guard/getSelfReviewArticulationPath';
 
 describe('formatRouteStoneEmit', () => {
   given('[case1] challenge:absent action', () => {
+    const route = '.behavior/v2026_03_08.feature';
+    const stone = '3.1.blueprint';
+    const slug = 'design';
+    const articulationPath = getSelfReviewArticulationPath({
+      route,
+      stone,
+      index: 1,
+      slug,
+    });
+
     when('[t0] formatRouteStoneEmit called with challenge:absent', () => {
       then('output contains what have you seen header', () => {
         const output = formatRouteStoneEmit({
           operation: 'route.stone.set',
-          stone: '3.1.blueprint',
+          stone,
           action: 'challenge:absent',
-          slug: 'design',
-          route: '.behavior/v2026_03_08.feature',
-          articulationPath:
-            '.behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md',
+          slug,
+          route,
+          articulationPath,
         });
         expect(output).toContain('🍂 what have you seen?');
       });
@@ -21,27 +31,23 @@ describe('formatRouteStoneEmit', () => {
       then('output contains articulation path', () => {
         const output = formatRouteStoneEmit({
           operation: 'route.stone.set',
-          stone: '3.1.blueprint',
+          stone,
           action: 'challenge:absent',
-          slug: 'design',
-          route: '.behavior/v2026_03_08.feature',
-          articulationPath:
-            '.behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md',
+          slug,
+          route,
+          articulationPath,
         });
-        expect(output).toContain(
-          '.behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md',
-        );
+        expect(output).toContain(articulationPath);
       });
 
       then('output contains patience friend message', () => {
         const output = formatRouteStoneEmit({
           operation: 'route.stone.set',
-          stone: '3.1.blueprint',
+          stone,
           action: 'challenge:absent',
-          slug: 'design',
-          route: '.behavior/v2026_03_08.feature',
-          articulationPath:
-            '.behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md',
+          slug,
+          route,
+          articulationPath,
         });
         expect(output).toContain('🗿 patience, friend');
       });
@@ -49,12 +55,11 @@ describe('formatRouteStoneEmit', () => {
       then('snapshot matches vision', () => {
         const output = formatRouteStoneEmit({
           operation: 'route.stone.set',
-          stone: '3.1.blueprint',
+          stone,
           action: 'challenge:absent',
-          slug: 'design',
-          route: '.behavior/v2026_03_08.feature',
-          articulationPath:
-            '.behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md',
+          slug,
+          route,
+          articulationPath,
         });
         expect(output).toMatchSnapshot();
       });

--- a/src/domain.operations/route/guard/__snapshots__/formatLetsReflect.test.ts.snap
+++ b/src/domain.operations/route/guard/__snapshots__/formatLetsReflect.test.ts.snap
@@ -61,7 +61,7 @@ exports[`formatLetsReflect given: [case1] standard review.self when: [t0] format
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ .behavior/v2026_03_05.behavior-example/review/self/1.vision.1.all-done.md
+   │  │  └─ .behavior/v2026_03_05.behavior-example/review/self/for.1.vision._.r1.all-done.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─

--- a/src/domain.operations/route/guard/__snapshots__/formatPatienceFriend.test.ts.snap
+++ b/src/domain.operations/route/guard/__snapshots__/formatPatienceFriend.test.ts.snap
@@ -38,7 +38,7 @@ exports[`formatPatienceFriend given: [case1] challenged review.self when: [t0] f
    ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ .behavior/v2026_03_05.behavior-example/review/self/1.vision.1.all-done.md
+   │  │  └─ .behavior/v2026_03_05.behavior-example/review/self/for.1.vision._.r1.all-done.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─

--- a/src/domain.operations/route/guard/__snapshots__/formatWalkTheWay.test.ts.snap
+++ b/src/domain.operations/route/guard/__snapshots__/formatWalkTheWay.test.ts.snap
@@ -4,7 +4,7 @@ exports[`formatWalkTheWay given: [case1] articulation with drum blocks when: [t0
 "   ├─ walk the way 🪷
    │  │
    │  ├─ articulate into
-   │  │  └─ .behavior/v2026_03_05.behavior-example/review/self/1.vision.1.all-done.md
+   │  │  └─ .behavior/v2026_03_05.behavior-example/review/self/for.1.vision._.r1.all-done.md
    │  │
    │  ├─ for each found issue 🪘
    │  │  ├─

--- a/src/domain.operations/route/guard/__snapshots__/formatWhatHaveYouSeen.test.ts.snap
+++ b/src/domain.operations/route/guard/__snapshots__/formatWhatHaveYouSeen.test.ts.snap
@@ -5,7 +5,7 @@ exports[`formatWhatHaveYouSeen given: [case1] output structure matches vision wh
    ├─ ...
    │
    ├─ the articulation is absent
-   │  └─ .behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md
+   │  └─ .behavior/v2026_03_08.feature/review/self/for.3.1.blueprint._.r1.design.md
    │
    ├─ a promise without words
    │  ├─ is not a promise

--- a/src/domain.operations/route/guard/formatLetsReflect.test.ts
+++ b/src/domain.operations/route/guard/formatLetsReflect.test.ts
@@ -1,6 +1,7 @@
 import { given, then, when } from 'test-fns';
 
 import { formatLetsReflect } from './formatLetsReflect';
+import { getSelfReviewArticulationPath } from './getSelfReviewArticulationPath';
 
 describe('formatLetsReflect', () => {
   given('[case1] standard review.self', () => {
@@ -74,7 +75,12 @@ describe('formatLetsReflect', () => {
         expect(output).toContain('walk the way 🪷');
         expect(output).toContain('articulate into');
         expect(output).toContain(
-          '.behavior/v2026_03_05.behavior-example/review/self/1.vision.1.all-done.md',
+          getSelfReviewArticulationPath({
+            route: '.behavior/v2026_03_05.behavior-example',
+            stone: '1.vision',
+            index: 1,
+            slug: 'all-done',
+          }),
         );
         expect(output).toContain('for each found issue 🪘');
         expect(output).toContain('for each non issue 🪘');

--- a/src/domain.operations/route/guard/formatPatienceFriend.test.ts
+++ b/src/domain.operations/route/guard/formatPatienceFriend.test.ts
@@ -1,6 +1,7 @@
 import { given, then, when } from 'test-fns';
 
 import { formatPatienceFriend } from './formatPatienceFriend';
+import { getSelfReviewArticulationPath } from './getSelfReviewArticulationPath';
 
 describe('formatPatienceFriend', () => {
   given('[case1] challenged review.self', () => {
@@ -54,7 +55,12 @@ describe('formatPatienceFriend', () => {
         expect(output).toContain('walk the way 🪷');
         expect(output).toContain('articulate into');
         expect(output).toContain(
-          '.behavior/v2026_03_05.behavior-example/review/self/1.vision.1.all-done.md',
+          getSelfReviewArticulationPath({
+            route: '.behavior/v2026_03_05.behavior-example',
+            stone: '1.vision',
+            index: 1,
+            slug: 'all-done',
+          }),
         );
         expect(output).toContain('for each found issue 🪘');
         expect(output).toContain('for each non issue 🪘');

--- a/src/domain.operations/route/guard/formatWalkTheWay.test.ts
+++ b/src/domain.operations/route/guard/formatWalkTheWay.test.ts
@@ -1,6 +1,7 @@
 import { given, then, when } from 'test-fns';
 
 import { formatWalkTheWay } from './formatWalkTheWay';
+import { getSelfReviewArticulationPath } from './getSelfReviewArticulationPath';
 
 describe('formatWalkTheWay', () => {
   given('[case1] articulation with drum blocks', () => {
@@ -37,7 +38,12 @@ describe('formatWalkTheWay', () => {
 
         expect(output.join('\n')).toContain('articulate into');
         expect(output.join('\n')).toContain(
-          '.behavior/v2026_03_05.behavior-example/review/self/1.vision.1.all-done.md',
+          getSelfReviewArticulationPath({
+            route: '.behavior/v2026_03_05.behavior-example',
+            stone: '1.vision',
+            index: 1,
+            slug: 'all-done',
+          }),
         );
       });
 

--- a/src/domain.operations/route/guard/formatWhatHaveYouSeen.test.ts
+++ b/src/domain.operations/route/guard/formatWhatHaveYouSeen.test.ts
@@ -1,11 +1,16 @@
 import { given, then, when } from 'test-fns';
 
 import { formatWhatHaveYouSeen } from './formatWhatHaveYouSeen';
+import { getSelfReviewArticulationPath } from './getSelfReviewArticulationPath';
 
 describe('formatWhatHaveYouSeen', () => {
   given('[case1] output structure matches vision', () => {
-    const articulationPath =
-      '.behavior/v2026_03_08.feature/review/self/3.1.blueprint.design.md';
+    const articulationPath = getSelfReviewArticulationPath({
+      route: '.behavior/v2026_03_08.feature',
+      stone: '3.1.blueprint',
+      index: 1,
+      slug: 'design',
+    });
 
     when('[t0] formatWhatHaveYouSeen called', () => {
       then('contains fallen leaf header', () => {

--- a/src/domain.operations/route/guard/getSelfReviewArticulationPath.ts
+++ b/src/domain.operations/route/guard/getSelfReviewArticulationPath.ts
@@ -8,4 +8,4 @@ export const getSelfReviewArticulationPath = (input: {
   index: number;
   slug: string;
 }): string =>
-  `${input.route}/review/self/${input.stone}.${input.index}.${input.slug}.md`;
+  `${input.route}/review/self/for.${input.stone}._.r${input.index}.${input.slug}.md`;

--- a/src/domain.operations/route/promise/getSelfReviewChallengeDecision.test.ts
+++ b/src/domain.operations/route/promise/getSelfReviewChallengeDecision.test.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { given, then, when } from 'test-fns';
 
+import { getSelfReviewArticulationPath } from '../guard/getSelfReviewArticulationPath';
 import { getSelfReviewChallengeDecision } from './getSelfReviewChallengeDecision';
 import { setSelfReviewTriggeredReport } from './setSelfReviewTriggeredReport';
 
@@ -16,15 +17,10 @@ const createArticulationFile = async (input: {
   index: number;
   slug: string;
 }): Promise<void> => {
-  const articulationDir = path.join(input.route, 'review', 'self');
+  const articulationPath = getSelfReviewArticulationPath(input);
+  const articulationDir = path.dirname(articulationPath);
   await fs.mkdir(articulationDir, { recursive: true });
-  await fs.writeFile(
-    path.join(
-      articulationDir,
-      `${input.stone}.${input.index}.${input.slug}.md`,
-    ),
-    '# self-review\n',
-  );
+  await fs.writeFile(articulationPath, '# self-review\n');
 };
 
 describe('getSelfReviewChallengeDecision', () => {
@@ -58,7 +54,12 @@ describe('getSelfReviewChallengeDecision', () => {
 
           expect(result.decision).toEqual('challenge:absent');
           expect(result.articulationPath).toEqual(
-            `${tempDir}/review/self/1.vision.1.all-done.md`,
+            getSelfReviewArticulationPath({
+              route: tempDir,
+              stone: '1.vision',
+              index: 1,
+              slug: 'all-done',
+            }),
           );
 
           // cleanup
@@ -213,7 +214,12 @@ describe('getSelfReviewChallengeDecision', () => {
 
         expect(result.decision).toEqual('challenge:first');
         expect(result.articulationPath).toEqual(
-          `${tempDir}/review/self/1.vision.1.all-done.md`,
+          getSelfReviewArticulationPath({
+            route: tempDir,
+            stone: '1.vision',
+            index: 1,
+            slug: 'all-done',
+          }),
         );
 
         // cleanup

--- a/src/domain.operations/route/promise/getSelfReviewChallengeDecision.ts
+++ b/src/domain.operations/route/promise/getSelfReviewChallengeDecision.ts
@@ -65,14 +65,7 @@ export const getSelfReviewChallengeDecision = async (input: {
 
   // check articulation file presence (only after they've seen challenge:first)
   const fileExists = await fs
-    .access(
-      path.join(
-        input.route,
-        'review',
-        'self',
-        `${input.stone}.${input.index}.${input.slug}.md`,
-      ),
-    )
+    .access(articulationPath)
     .then(() => true)
     .catch(() => false);
   if (!fileExists) {

--- a/src/domain.operations/route/stepRouteStoneSet.integration.test.ts
+++ b/src/domain.operations/route/stepRouteStoneSet.integration.test.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { given, then, useBeforeAll, useThen, when } from 'test-fns';
 
+import { getSelfReviewArticulationPath } from './guard/getSelfReviewArticulationPath';
 import { stepRouteStoneSet } from './stepRouteStoneSet';
 
 const ASSETS_DIR = path.join(__dirname, '.test/assets');
@@ -169,13 +170,16 @@ describe('stepRouteStoneSet.integration', () => {
       });
       // create artifact for 1.vision
       await fs.writeFile(path.join(tempDir, '1.vision.md'), '# Vision');
-      // create articulation file for 1.vision.1.all-done (required by file presence check)
-      // format: {route}/review/self/{stone}.{index}.{slug}.md
-      await fs.mkdir(path.join(tempDir, 'review', 'self'), { recursive: true });
-      await fs.writeFile(
-        path.join(tempDir, 'review', 'self', '1.vision.1.all-done.md'),
-        '# self-review\n',
-      );
+      // create articulation file for 1.vision.r1.all-done (required by file presence check)
+      // format: {route}/review/self/{stone}.r{index}.{slug}.md
+      const articulationPath = getSelfReviewArticulationPath({
+        route: tempDir,
+        stone: '1.vision',
+        index: 1,
+        slug: 'all-done',
+      });
+      await fs.mkdir(path.dirname(articulationPath), { recursive: true });
+      await fs.writeFile(articulationPath, '# self-review\n');
     });
 
     afterEach(async () => {
@@ -250,13 +254,16 @@ describe('stepRouteStoneSet.integration', () => {
       });
       // create artifact for 1.vision
       await fs.writeFile(path.join(tempDir, '1.vision.md'), '# Vision');
-      // create articulation file for 1.vision.1.all-done (required by file presence check)
-      // format: {route}/review/self/{stone}.{index}.{slug}.md
-      await fs.mkdir(path.join(tempDir, 'review', 'self'), { recursive: true });
-      await fs.writeFile(
-        path.join(tempDir, 'review', 'self', '1.vision.1.all-done.md'),
-        '# self-review\n',
-      );
+      // create articulation file for 1.vision.r1.all-done (required by file presence check)
+      // format: {route}/review/self/{stone}.r{index}.{slug}.md
+      const articulationPath = getSelfReviewArticulationPath({
+        route: tempDir,
+        stone: '1.vision',
+        index: 1,
+        slug: 'all-done',
+      });
+      await fs.mkdir(path.dirname(articulationPath), { recursive: true });
+      await fs.writeFile(articulationPath, '# self-review\n');
     });
 
     afterEach(async () => {

--- a/src/domain.operations/route/stepRouteStoneSet.test.ts
+++ b/src/domain.operations/route/stepRouteStoneSet.test.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { getError, given, then, when } from 'test-fns';
 
+import { getSelfReviewArticulationPath } from './guard/getSelfReviewArticulationPath';
 import { stepRouteStoneSet } from './stepRouteStoneSet';
 
 const ASSETS_DIR = path.join(__dirname, '.test/assets');
@@ -171,13 +172,16 @@ describe('stepRouteStoneSet', () => {
       });
       // create artifact for 1.vision
       await fs.writeFile(path.join(tempDir, '1.vision.md'), '# Vision');
-      // create articulation file for 1.vision.1.all-done (required by file presence check)
-      // format: {route}/review/self/{stone}.{index}.{slug}.md
-      await fs.mkdir(path.join(tempDir, 'review', 'self'), { recursive: true });
-      await fs.writeFile(
-        path.join(tempDir, 'review', 'self', '1.vision.1.all-done.md'),
-        '# self-review\n',
-      );
+      // create articulation file for 1.vision.r1.all-done (required by file presence check)
+      // format: {route}/review/self/{stone}.r{index}.{slug}.md
+      const articulationPath = getSelfReviewArticulationPath({
+        route: tempDir,
+        stone: '1.vision',
+        index: 1,
+        slug: 'all-done',
+      });
+      await fs.mkdir(path.dirname(articulationPath), { recursive: true });
+      await fs.writeFile(articulationPath, '# self-review\n');
     });
 
     afterEach(async () => {


### PR DESCRIPTION
fix(route): disambiguate self-review articulation path format

- add for. prefix and ._. separator to path format
- changes: review/self/1.vision.1.all-done.md -> review/self/for.1.vision._.r1.all-done.md
- eliminates ambiguity between stone number and review index
- uses getSelfReviewArticulationPath as single source of truth everywhere
- fixes duplicate path construction in getSelfReviewChallengeDecision

---
🐢🌊 surfed in by seaturtle[bot]