### PR TITLE
fix(deps): add rhachet-brains-xai as required peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,9 @@
     "prepare": "if [ -e .git ] && [ -z $CI ]; then npm run prepare:husky && npm run prepare:rhachet; fi",
     "upgrade:rhachet": "rhachet upgrade"
   },
+  "peerDependencies": {
+    "rhachet-brains-xai": ">=0.3.0"
+  },
   "dependencies": {
     "@ehmpathy/as-command": "1.0.3",
     "@ehmpathy/uni-time": "1.8.1",


### PR DESCRIPTION
fix(deps): add rhachet-brains-xai as required peer dependency

- consumers will see warning if not explicitly installed
- version constraint >=0.3.0 for flexibility

---
🐢🌊 surfed in by seaturtle[bot]