### PR TITLE
fix(test): add when.repeatably to grok-4.1-fast integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "rhachet-roles-bhrain": "link:.",
     "rhachet-roles-bhuild": "0.14.4",
     "rhachet-roles-ehmpathy": "1.34.1",
-    "test-fns": "1.15.0",
+    "test-fns": "1.15.7",
     "tsc-alias": "1.8.10",
     "tsx": "4.20.6",
     "typescript": "5.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,8 +151,8 @@ importers:
         specifier: 1.34.1
         version: 1.34.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.37.18(zod@4.3.4))
       test-fns:
-        specifier: 1.15.0
-        version: 1.15.0(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
+        specifier: 1.15.7
+        version: 1.15.7
       tsc-alias:
         specifier: 1.8.10
         version: 1.8.10
@@ -4479,6 +4479,10 @@ packages:
 
   test-fns@1.15.0:
     resolution: {integrity: sha512-zC/qUA2lwfiXoQ00Ws8yD8LPA7p3n2a+Dl7wmI4iTXz4HbrU52riPY+AceGWgCAINs/cJ7cs9jnnASSPBwyGpg==}
+    engines: {node: '>=8.0.0'}
+
+  test-fns@1.15.7:
+    resolution: {integrity: sha512-wfILa+sblkaG3QQS9MEX+ZPxKrAOAoNVqSxi2OdIdHMQ1hFyKSSHRxfgCwoRujgcH1D6H1liHE+WO8+yJuQkbg==}
     engines: {node: '>=8.0.0'}
 
   test-fns@1.4.2:
@@ -9751,7 +9755,7 @@ snapshots:
       simple-in-memory-cache: 0.4.0
       simple-on-disk-cache: 1.7.3
       type-fns: 1.21.0
-      with-simple-cache: 0.15.3(zod@4.3.4)
+      with-simple-cache: 0.15.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
       with-simple-caching: 0.14.4
       wrapper-fns: 1.1.7
       zod: 4.3.4
@@ -10095,6 +10099,13 @@ snapshots:
       - ws
       - zod
 
+  test-fns@1.15.7:
+    dependencies:
+      domain-objects: 0.31.9
+      helpful-errors: 1.5.3
+      iso-time: 1.11.3
+      uuid: 10.0.0
+
   test-fns@1.4.2:
     dependencies:
       '@ehmpathy/error-fns': 1.3.1
@@ -10340,7 +10351,7 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  with-simple-cache@0.15.3(zod@4.3.4):
+  with-simple-cache@0.15.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4):
     dependencies:
       '@ehmpathy/uni-time': 1.8.1
       domain-objects: 0.31.7(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
@@ -10351,7 +10362,11 @@ snapshots:
       simple-on-disk-cache: 1.7.3
       type-fns: 1.21.0
     transitivePeerDependencies:
+      - '@huggingface/transformers'
+      - '@tensorflow/tfjs'
+      - '@types/node'
       - aws-crt
+      - ws
       - zod
 
   with-simple-caching@0.14.2:

--- a/src/domain.operations/reflect/stepReflect.casePriorRules.grok-4.1-fast.integration.test.ts
+++ b/src/domain.operations/reflect/stepReflect.casePriorRules.grok-4.1-fast.integration.test.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import { given, then, useBeforeAll, useThen, when } from 'test-fns';
 
 import { genTestBrainContext } from '@src/.test/genTestBrainContext';
+import { REPEATABLY_CONFIG } from '@src/.test/infra/repeatably';
 import type { ReviewerReflectManifest } from '@src/domain.objects/Reviewer/ReviewerReflectManifest';
 
 import { setupSourceRepo, setupTargetDir } from './.test/setup';
@@ -17,7 +18,7 @@ describe('stepReflect.casePriorRules.grok-4.1-fast', () => {
   }));
 
   given('[case1] target with prior rule (explicit brain arg)', () => {
-    when('[t0] stepReflect completes', () => {
+    when.repeatably(REPEATABLY_CONFIG)('[t0] stepReflect completes', () => {
       // single API call, result shared across assertions
       const scene = useThen('stepReflect succeeds', async () => {
         // setup source and target

--- a/src/domain.operations/reflect/stepReflect.casePriorRules.grok-4.1-fast.integration.test.ts
+++ b/src/domain.operations/reflect/stepReflect.casePriorRules.grok-4.1-fast.integration.test.ts
@@ -18,6 +18,15 @@ describe('stepReflect.casePriorRules.grok-4.1-fast', () => {
   }));
 
   given('[case1] target with prior rule (explicit brain arg)', () => {
+    // track cleanup paths outside useThen to avoid deferred proxy issues
+    const cleanup: { sourceDir?: string; targetDir?: string } = {};
+    afterAll(async () => {
+      if (cleanup.sourceDir)
+        await fs.rm(cleanup.sourceDir, { recursive: true, force: true });
+      if (cleanup.targetDir)
+        await fs.rm(cleanup.targetDir, { recursive: true, force: true });
+    });
+
     when.repeatably(REPEATABLY_CONFIG)('[t0] stepReflect completes', () => {
       // single API call, result shared across assertions
       const scene = useThen('stepReflect succeeds', async () => {
@@ -25,6 +34,10 @@ describe('stepReflect.casePriorRules.grok-4.1-fast', () => {
         const { repoDir: sourceDir } =
           await setupSourceRepo('typescript-quality');
         const { targetDir } = await setupTargetDir();
+
+        // track for cleanup
+        cleanup.sourceDir = sourceDir;
+        cleanup.targetDir = targetDir;
 
         // add prior rule that matches feedback topic
         await fs.mkdir(path.join(targetDir, 'practices'), {
@@ -47,11 +60,6 @@ describe('stepReflect.casePriorRules.grok-4.1-fast', () => {
         );
 
         return { sourceDir, targetDir, result };
-      });
-
-      afterAll(async () => {
-        await fs.rm(scene.sourceDir, { recursive: true, force: true });
-        await fs.rm(scene.targetDir, { recursive: true, force: true });
       });
 
       then('manifest includes operations for all pure rules', async () => {


### PR DESCRIPTION
fix(test): add when.repeatably to grok-4.1-fast integration test

- import REPEATABLY_CONFIG from shared infra
- wrap brain-invoking when block with repeatably
- deflakes CI failures from transient LLM JSON parse errors

---
🐢🌊 surfed in by seaturtle[bot]