### PR TITLE
fix(reflect): capture all peer brain transcripts in snapshot

### DIFF
--- a/blackbox/__snapshots__/reflect.journey.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/reflect.journey.acceptance.test.ts.snap
@@ -8,7 +8,7 @@ exports[`reflect.journey.acceptance given: [journey] full reflect workflow when:
    ├─ tree = [ISO_TEMP].reflect-journey.[HASH]
    ├─ branch = main
    │
-   ├─ commit = ff72aa2
+   ├─ commit = 577edf8
    ├─ staged.patch = [SIZE]ytes
    ├─ unstaged.patch = [SIZE]ytes
    ├─ patches.hash = [HASH]
@@ -30,7 +30,7 @@ exports[`reflect.journey.acceptance given: [journey] full reflect workflow when:
    ├─ tree = [ISO_TEMP].reflect-journey.[HASH]
    ├─ branch = main
    │
-   ├─ commit = ff72aa2
+   ├─ commit = 577edf8
    ├─ staged.patch = [SIZE]ytes
    ├─ unstaged.patch = [SIZE]ytes
    ├─ patches.hash = [HASH]
@@ -56,10 +56,10 @@ exports[`reflect.journey.acceptance given: [journey] full reflect workflow when:
    ├─ size = [SIZE]ytes
    │
    └─ list
-      ├─ [TIMESTAMP] (commit=ff72aa2, patches=04f1ec0, [SIZE]ytes)
+      ├─ [TIMESTAMP] (commit=577edf8, patches=04f1ec0, [SIZE]ytes)
       │  ├─ [TIMESTAMP].staged.patch
       │  └─ [TIMESTAMP].unstaged.patch
-      └─ [TIMESTAMP] (commit=ff72aa2, patches=8f56415, [SIZE]ytes)
+      └─ [TIMESTAMP] (commit=577edf8, patches=8f56415, [SIZE]ytes)
          ├─ [TIMESTAMP].staged.patch
          └─ [TIMESTAMP].unstaged.patch
 
@@ -120,8 +120,8 @@ exports[`reflect.journey.acceptance given: [journey] full reflect workflow when:
    ├─ branch = main
    │
    ├─ transcript
-   │  ├─ episodes = [N]
-   │  └─ mainFile = abc123-def456.jsonl
+   │  ├─ sessions = 1
+   │  └─ files = 1
    │
    ├─ savepoints = 3 (+1 fresh at [STACK]
    ├─ annotations = 2
@@ -147,7 +147,7 @@ exports[`reflect.journey.acceptance given: [journey] full reflect workflow when:
    ├─ size = [SIZE]
    │
    └─ list
-      └─ [TIMESTAMP] (episodes=1, savepoints=3)
+      └─ [TIMESTAMP] (sessions=1, savepoints=3)
          └─ ~/.rhachet/storage/repo=bhrain/role=reflector/skills/reflect.snapshot/gitrepo=[ISO_TEMP].reflect-journey.[HASH]/worktree=[ISO_TEMP].reflect-journey.[HASH]/branch=main/snapshots/date=[DATE]/[TIMESTAMP].snap.zip
 
 "

--- a/blackbox/reflect.journey.acceptance.test.ts
+++ b/blackbox/reflect.journey.acceptance.test.ts
@@ -269,8 +269,8 @@ describe('reflect.journey.acceptance', () => {
       });
 
       then('output shows transcript stats', () => {
-        expect(result.stdout).toContain('episodes');
-        expect(result.stdout).toContain('mainFile');
+        expect(result.stdout).toContain('sessions');
+        expect(result.stdout).toContain('files');
       });
 
       then('output shows savepoints bundled', () => {

--- a/src/contract/cli/reflect.ts
+++ b/src/contract/cli/reflect.ts
@@ -203,9 +203,9 @@ export const reflectSnapshotCapture = async (): Promise<void> => {
   console.log(`   │`);
   console.log(`   ├─ transcript`);
   console.log(
-    `   │  ├─ episodes = ${snapshot.metadata.transcript.episodeCount}`,
+    `   │  ├─ sessions = ${snapshot.metadata.transcript.sessionCount}`,
   );
-  console.log(`   │  └─ mainFile = ${snapshot.metadata.transcript.mainFile}`);
+  console.log(`   │  └─ files = ${snapshot.metadata.transcript.fileCount}`);
   console.log(`   │`);
   console.log(
     `   ├─ savepoints = ${snapshot.metadata.savepoints.count} (+1 fresh at ${snapshot.metadata.savepoints.freshTimestamp})`,
@@ -253,7 +253,10 @@ export const reflectSnapshotGet = async (): Promise<void> => {
     console.log(`   │`);
     console.log(`   ├─ transcript`);
     console.log(
-      `   │  └─ episodes = ${snapshot.metadata.transcript.episodeCount}`,
+      `   │  ├─ sessions = ${snapshot.metadata.transcript.sessionCount}`,
+    );
+    console.log(
+      `   │  └─ files = ${snapshot.metadata.transcript.fileCount}`,
     );
     console.log(`   │`);
     console.log(`   ├─ savepoints = ${snapshot.metadata.savepoints.count}`);
@@ -286,7 +289,7 @@ export const reflectSnapshotGet = async (): Promise<void> => {
         const continuation = isLast ? ' ' : '│';
         const meta = snap.metadata;
         const stats = meta
-          ? `(episodes=${meta.transcript.episodeCount}, savepoints=${meta.savepoints.count})`
+          ? `(sessions=${meta.transcript.sessionCount}, savepoints=${meta.savepoints.count})`
           : '';
         console.log(`      ${prefix} ${snap.timestamp} ${stats}`);
         console.log(`      ${continuation}  └─ ${asHomePath(snap.path)}`);

--- a/src/contract/cli/reflect.ts
+++ b/src/contract/cli/reflect.ts
@@ -255,9 +255,7 @@ export const reflectSnapshotGet = async (): Promise<void> => {
     console.log(
       `   │  ├─ sessions = ${snapshot.metadata.transcript.sessionCount}`,
     );
-    console.log(
-      `   │  └─ files = ${snapshot.metadata.transcript.fileCount}`,
-    );
+    console.log(`   │  └─ files = ${snapshot.metadata.transcript.fileCount}`);
     console.log(`   │`);
     console.log(`   ├─ savepoints = ${snapshot.metadata.savepoints.count}`);
     console.log(`   ├─ annotations = ${snapshot.metadata.annotations.count}`);

--- a/src/domain.operations/reflect/snapshot/captureSnapshot.integration.test.ts
+++ b/src/domain.operations/reflect/snapshot/captureSnapshot.integration.test.ts
@@ -102,10 +102,10 @@ describe('captureSnapshot', () => {
       });
 
       then('metadata should include transcript info', () => {
-        expect(scene.snapshot.metadata.transcript.episodeCount).toBeGreaterThan(
+        expect(scene.snapshot.metadata.transcript.sessionCount).toBeGreaterThan(
           0,
         );
-        expect(scene.snapshot.metadata.transcript.mainFile).toBeDefined();
+        expect(scene.snapshot.metadata.transcript.fileCount).toBeGreaterThan(0);
       });
 
       then('metadata should include savepoint count', () => {

--- a/src/domain.operations/reflect/snapshot/captureSnapshot.integration.test.ts
+++ b/src/domain.operations/reflect/snapshot/captureSnapshot.integration.test.ts
@@ -12,26 +12,36 @@ import { captureSnapshot } from './captureSnapshot';
  * .what = creates a mock claude code project for tests
  * .why = captureSnapshot requires transcript source to exist
  */
-const setupMockClaudeProject = (input: { cwd: string }): string => {
+const setupMockClaudeProject = (input: {
+  cwd: string;
+  sessionCount?: number;
+}): string => {
   // compute project slug (same as getTranscriptSource)
   const slug = input.cwd.replace(/\//g, '-');
   const projectDir = path.join(os.homedir(), '.claude', 'projects', slug);
   fs.mkdirSync(projectDir, { recursive: true });
 
-  // create mock transcript file
-  const transcriptPath = path.join(projectDir, 'test-transcript.jsonl');
-  const mockMessages = [
-    { type: 'user', timestamp: '2026-03-16T12:00:00.000Z', message: 'hello' },
-    {
-      type: 'assistant',
-      timestamp: '2026-03-16T12:00:01.000Z',
-      message: 'hi there',
-    },
-  ];
-  fs.writeFileSync(
-    transcriptPath,
-    mockMessages.map((m) => JSON.stringify(m)).join('\n'),
-  );
+  // create mock transcript files (default 1 session)
+  const count = input.sessionCount ?? 1;
+  for (let i = 0; i < count; i++) {
+    const transcriptPath = path.join(projectDir, `session-${i}.jsonl`);
+    const mockMessages = [
+      {
+        type: 'user',
+        timestamp: `2026-03-16T1${i}:00:00.000Z`,
+        message: `hello from session ${i}`,
+      },
+      {
+        type: 'assistant',
+        timestamp: `2026-03-16T1${i}:00:01.000Z`,
+        message: `hi there from session ${i}`,
+      },
+    ];
+    fs.writeFileSync(
+      transcriptPath,
+      mockMessages.map((m) => JSON.stringify(m)).join('\n'),
+    );
+  }
 
   return projectDir;
 };
@@ -122,7 +132,55 @@ describe('captureSnapshot', () => {
     });
   });
 
-  given('[case2] repo without claude project', () => {
+  given('[case2] repo with multiple peer brain sessions', () => {
+    const tempDir = path.join(
+      os.tmpdir(),
+      `reflect-capture-peers-${Date.now()}`,
+    );
+    let mockProjectDir: string;
+
+    const scene = useBeforeAll(async () => {
+      // create temp git repo
+      fs.mkdirSync(tempDir, { recursive: true });
+      const { execSync } = require('child_process');
+      execSync('git init', { cwd: tempDir });
+      execSync('git config user.email "test@test.com"', { cwd: tempDir });
+      execSync('git config user.name "Test"', { cwd: tempDir });
+
+      // create initial commit
+      fs.writeFileSync(path.join(tempDir, 'init.txt'), 'init');
+      execSync('git add init.txt', { cwd: tempDir });
+      execSync('git commit -m "initial"', { cwd: tempDir });
+
+      // setup mock claude project with 3 peer brain sessions
+      mockProjectDir = setupMockClaudeProject({ cwd: tempDir, sessionCount: 3 });
+
+      // get scope and capture snapshot
+      const scope = getReflectScope({ cwd: tempDir });
+      const snapshot = await captureSnapshot({ scope });
+
+      return { scope, snapshot };
+    });
+
+    afterAll(() => {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+      if (mockProjectDir && fs.existsSync(mockProjectDir)) {
+        fs.rmSync(mockProjectDir, { recursive: true, force: true });
+      }
+    });
+
+    when('[t0] snapshot captures all peer sessions', () => {
+      then('sessionCount should be 3', () => {
+        expect(scene.snapshot.metadata.transcript.sessionCount).toEqual(3);
+      });
+
+      then('fileCount should be 3 (one file per session)', () => {
+        expect(scene.snapshot.metadata.transcript.fileCount).toEqual(3);
+      });
+    });
+  });
+
+  given('[case3] repo without claude project', () => {
     const tempDir = path.join(
       os.tmpdir(),
       `reflect-capture-noproj-${Date.now()}`,

--- a/src/domain.operations/reflect/snapshot/captureSnapshot.integration.test.ts
+++ b/src/domain.operations/reflect/snapshot/captureSnapshot.integration.test.ts
@@ -153,7 +153,10 @@ describe('captureSnapshot', () => {
       execSync('git commit -m "initial"', { cwd: tempDir });
 
       // setup mock claude project with 3 peer brain sessions
-      mockProjectDir = setupMockClaudeProject({ cwd: tempDir, sessionCount: 3 });
+      mockProjectDir = setupMockClaudeProject({
+        cwd: tempDir,
+        sessionCount: 3,
+      });
 
       // get scope and capture snapshot
       const scope = getReflectScope({ cwd: tempDir });

--- a/src/domain.operations/reflect/snapshot/captureSnapshot.ts
+++ b/src/domain.operations/reflect/snapshot/captureSnapshot.ts
@@ -32,8 +32,14 @@ export interface Snapshot {
     worktreeName: string;
     branch: string;
     transcript: {
-      episodeCount: number;
-      mainFile: string;
+      /**
+       * number of peer brain sessions captured
+       */
+      sessionCount: number;
+      /**
+       * total number of files (main + subagent transcripts)
+       */
+      fileCount: number;
     };
     savepoints: {
       count: number;
@@ -99,25 +105,29 @@ export const captureSnapshot = async (input: {
   // create temp directory for assembly
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reflect-snapshot-'));
 
+  // count total transcript files for metadata
+  let transcriptFileCount = 0;
+
   try {
-    // copy transcript files
+    // copy transcript files from all sessions (peer brains)
     const transcriptDir = path.join(tempDir, 'transcript');
     fs.mkdirSync(transcriptDir, { recursive: true });
 
-    // copy main transcript file
-    const mainFileName = path.basename(transcriptSource.mainFile);
-    fs.copyFileSync(
-      transcriptSource.mainFile,
-      path.join(transcriptDir, mainFileName),
-    );
+    for (const session of transcriptSource.sessions) {
+      // copy main transcript file for this session
+      const mainFileName = path.basename(session.mainFile);
+      fs.copyFileSync(session.mainFile, path.join(transcriptDir, mainFileName));
+      transcriptFileCount++;
 
-    // copy compaction files if present
-    for (const compactionFile of transcriptSource.compactionFiles) {
-      const compactionFileName = path.basename(compactionFile);
-      fs.copyFileSync(
-        compactionFile,
-        path.join(transcriptDir, compactionFileName),
-      );
+      // copy subagent files for this session
+      for (const subagentFile of session.subagentFiles) {
+        const subagentFileName = path.basename(subagentFile);
+        fs.copyFileSync(
+          subagentFile,
+          path.join(transcriptDir, subagentFileName),
+        );
+        transcriptFileCount++;
+      }
     }
 
     // copy savepoint patches
@@ -182,8 +192,8 @@ export const captureSnapshot = async (input: {
       branch: input.scope.branch,
       timestamp,
       transcript: {
-        episodeCount: transcriptSource.episodeCount,
-        mainFile: mainFileName,
+        sessionCount: transcriptSource.sessionCount,
+        fileCount: transcriptFileCount,
       },
       savepoints: {
         count: savepointsSummary.count,

--- a/src/domain.operations/reflect/snapshot/getAllSnapshots.integration.test.ts
+++ b/src/domain.operations/reflect/snapshot/getAllSnapshots.integration.test.ts
@@ -114,7 +114,7 @@ describe('getAllSnapshots', () => {
         const result = getAllSnapshots({ scope: scene.scope });
         for (const snapshot of result.snapshots) {
           expect(snapshot.metadata).not.toBeNull();
-          expect(snapshot.metadata?.transcript.episodeCount).toBeGreaterThan(0);
+          expect(snapshot.metadata?.transcript.sessionCount).toBeGreaterThan(0);
         }
       });
     });

--- a/src/domain.operations/reflect/snapshot/getAllSnapshots.ts
+++ b/src/domain.operations/reflect/snapshot/getAllSnapshots.ts
@@ -61,7 +61,10 @@ const readMetadataFromZip = (
     const full = JSON.parse(content);
 
     return {
-      transcript: { sessionCount: full.transcript?.sessionCount ?? full.transcript?.episodeCount ?? 0 },
+      transcript: {
+        sessionCount:
+          full.transcript?.sessionCount ?? full.transcript?.episodeCount ?? 0,
+      },
       savepoints: { count: full.savepoints?.count ?? 0 },
       annotations: { count: full.annotations?.count ?? 0 },
     };

--- a/src/domain.operations/reflect/snapshot/getAllSnapshots.ts
+++ b/src/domain.operations/reflect/snapshot/getAllSnapshots.ts
@@ -15,7 +15,7 @@ export interface SnapshotSummaryItem {
   sizeBytes: number;
   metadata: {
     transcript: {
-      episodeCount: number;
+      sessionCount: number;
     };
     savepoints: {
       count: number;
@@ -61,7 +61,7 @@ const readMetadataFromZip = (
     const full = JSON.parse(content);
 
     return {
-      transcript: { episodeCount: full.transcript?.episodeCount ?? 0 },
+      transcript: { sessionCount: full.transcript?.sessionCount ?? full.transcript?.episodeCount ?? 0 },
       savepoints: { count: full.savepoints?.count ?? 0 },
       annotations: { count: full.annotations?.count ?? 0 },
     };

--- a/src/domain.operations/reflect/snapshot/getOneSnapshot.integration.test.ts
+++ b/src/domain.operations/reflect/snapshot/getOneSnapshot.integration.test.ts
@@ -107,7 +107,7 @@ describe('getOneSnapshot', () => {
           at: scene.snapshot.timestamp,
         });
         expect(result?.metadata).toBeDefined();
-        expect(result?.metadata.transcript.episodeCount).toBeGreaterThan(0);
+        expect(result?.metadata.transcript.sessionCount).toBeGreaterThan(0);
       });
     });
   });

--- a/src/domain.operations/reflect/snapshot/getOneSnapshot.ts
+++ b/src/domain.operations/reflect/snapshot/getOneSnapshot.ts
@@ -33,8 +33,8 @@ export interface SnapshotDetails {
     worktreeName: string;
     branch: string;
     transcript: {
-      episodeCount: number;
-      mainFile: string;
+      sessionCount: number;
+      fileCount: number;
     };
     savepoints: {
       count: number;

--- a/src/domain.operations/reflect/transcript/getTranscriptSource.integration.test.ts
+++ b/src/domain.operations/reflect/transcript/getTranscriptSource.integration.test.ts
@@ -20,20 +20,25 @@ describe('getTranscriptSource', () => {
         expect(source.projectDir.startsWith(os.homedir())).toBe(true);
       });
 
-      then('should find main transcript file', () => {
+      then('should have at least 1 session', () => {
         if (!source) return;
-        expect(source.mainFile).toBeDefined();
-        expect(source.mainFile.endsWith('.jsonl')).toBe(true);
+        expect(source.sessionCount).toBeGreaterThanOrEqual(1);
+        expect(source.sessions.length).toBeGreaterThanOrEqual(1);
       });
 
-      then('should have at least 1 episode', () => {
+      then('each session should have main file with .jsonl extension', () => {
         if (!source) return;
-        expect(source.episodeCount).toBeGreaterThanOrEqual(1);
+        for (const session of source.sessions) {
+          expect(session.mainFile).toBeDefined();
+          expect(session.mainFile.endsWith('.jsonl')).toBe(true);
+        }
       });
 
-      then('compactionFiles should be array', () => {
+      then('each session subagentFiles should be array', () => {
         if (!source) return;
-        expect(Array.isArray(source.compactionFiles)).toBe(true);
+        for (const session of source.sessions) {
+          expect(Array.isArray(session.subagentFiles)).toBe(true);
+        }
       });
     });
   });

--- a/src/domain.operations/reflect/transcript/getTranscriptSource.ts
+++ b/src/domain.operations/reflect/transcript/getTranscriptSource.ts
@@ -3,6 +3,22 @@ import * as os from 'os';
 import * as path from 'path';
 
 /**
+ * .what = a single transcript session with its subagent files
+ * .why = represents one claude code conversation and its spawned subagents
+ */
+export interface TranscriptSession {
+  /**
+   * path to the main transcript file for this session
+   */
+  mainFile: string;
+
+  /**
+   * paths to subagent transcript files for this session
+   */
+  subagentFiles: string[];
+}
+
+/**
  * .what = transcript source info from claude code project
  * .why = provides paths to transcript files for snapshot capture
  */
@@ -13,19 +29,14 @@ export interface TranscriptSource {
   projectDir: string;
 
   /**
-   * path to main transcript file (most recent *.jsonl)
+   * all transcript sessions (one per peer brain)
    */
-  mainFile: string;
+  sessions: TranscriptSession[];
 
   /**
-   * paths to compaction/subagent transcript files
+   * total session count (number of peer brains)
    */
-  compactionFiles: string[];
-
-  /**
-   * total episode count (main + compactions)
-   */
-  episodeCount: number;
+  sessionCount: number;
 }
 
 /**
@@ -49,10 +60,10 @@ export const computeProjectSlug = (input: { cwd: string }): string => {
 };
 
 /**
- * .what = finds most recent jsonl file in directory by mtime
- * .why = the main transcript is the most recently modified jsonl file
+ * .what = finds all jsonl files in directory sorted by mtime (newest first)
+ * .why = captures all peer brain transcripts for complete experience preservation
  */
-const findMostRecentJsonl = (input: { dir: string }): string | null => {
+const findAllJsonl = (input: { dir: string }): string[] => {
   const files = fs.readdirSync(input.dir);
   const jsonlFiles = files
     .filter((f) => f.endsWith('.jsonl'))
@@ -63,7 +74,7 @@ const findMostRecentJsonl = (input: { dir: string }): string | null => {
     }))
     .sort((a, b) => b.mtime - a.mtime);
 
-  return jsonlFiles[0]?.path ?? null;
+  return jsonlFiles.map((f) => f.path);
 };
 
 /**
@@ -82,33 +93,35 @@ export const getTranscriptSource = (input: {
     return null;
   }
 
-  // find main transcript file
-  const mainFile = findMostRecentJsonl({ dir: projectDir });
-  if (!mainFile) {
+  // find all transcript files (one per peer brain session)
+  const mainFiles = findAllJsonl({ dir: projectDir });
+  if (mainFiles.length === 0) {
     return null;
   }
 
-  // find compaction files
-  // they live in <UUID>/subagents/ directories
-  const compactionFiles: string[] = [];
-  const mainFileName = path.basename(mainFile, '.jsonl');
-  const subagentsDir = path.join(projectDir, mainFileName, 'subagents');
+  // build sessions array with each main file and its subagents
+  const sessions: TranscriptSession[] = mainFiles.map((mainFile) => {
+    const mainFileName = path.basename(mainFile, '.jsonl');
+    const subagentsDir = path.join(projectDir, mainFileName, 'subagents');
+    const subagentFiles: string[] = [];
 
-  if (fs.existsSync(subagentsDir)) {
-    const subagentFiles = fs.readdirSync(subagentsDir);
-    for (const file of subagentFiles) {
-      if (file.endsWith('.jsonl')) {
-        compactionFiles.push(path.join(subagentsDir, file));
+    if (fs.existsSync(subagentsDir)) {
+      const files = fs.readdirSync(subagentsDir);
+      for (const file of files) {
+        if (file.endsWith('.jsonl')) {
+          subagentFiles.push(path.join(subagentsDir, file));
+        }
       }
+      // sort by name (they have timestamps in names)
+      subagentFiles.sort();
     }
-    // sort by name (they have timestamps in names)
-    compactionFiles.sort();
-  }
+
+    return { mainFile, subagentFiles };
+  });
 
   return {
     projectDir,
-    mainFile,
-    compactionFiles,
-    episodeCount: 1 + compactionFiles.length,
+    sessions,
+    sessionCount: sessions.length,
   };
 };


### PR DESCRIPTION
fix(reflect): capture all peer brain transcripts in snapshot

- changed from single most-recent transcript to all sessions
- added TranscriptSession interface with mainFile + subagentFiles
- updated getTranscriptSource to find all jsonl files
- renamed episodeCount to sessionCount for clarity
- added backwards compat for old snapshots with episodeCount
- updated CLI output to show sessions/files instead of episodes/mainFile

---
🐢🌊 surfed in by seaturtle[bot]