### PR TITLE
fix(guard): show glob patterns in cached review output

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -33,6 +33,18 @@
             "command": "./node_modules/.bin/rhachet run --repo bhuild --role behaver --init claude.hooks/sessionstart.boot-behavior",
             "timeout": 10,
             "author": "repo=bhuild/role=behaver"
+          },
+          {
+            "type": "command",
+            "command": "./node_modules/.bin/rhachet roles boot --repo ehmpathy --role architect",
+            "timeout": 60,
+            "author": "repo=ehmpathy/role=architect"
+          },
+          {
+            "type": "command",
+            "command": "./node_modules/.bin/rhachet roles boot --repo ehmpathy --role ergonomist",
+            "timeout": 60,
+            "author": "repo=ehmpathy/role=ergonomist"
           }
         ]
       }

--- a/blackbox/__snapshots__/driver.route.set.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.set.acceptance.test.ts.snap
@@ -52,16 +52,14 @@ exports[`driver.route.set.acceptance given: [case5] route.stone.set with flexibl
 exports[`driver.route.set.acceptance given: [case5] route.stone.set with flexible pattern lookup when: [t1] numeric prefix pattern agent approval locked then: stdout matches snapshot 1`] = `
 "🦉 the way speaks for itself
 
-🦉 patience, friend.
-
 🗿 route.stone.set
    ├─ stone = 2.criteria
    ├─ ✗ only humans can approve
    │
    └─ as a driver, you should:
-         ├─ \`--as passed\` = signal work complete, proceed
-         ├─ \`--as arrived\` = signal work complete, request review
-         └─ \`--as blocked\` = escalate if stuck
+         ├─ \`--as passed\` to signal work complete, proceed
+         ├─ \`--as arrived\` to signal work complete, request review
+         └─ \`--as blocked\` to escalate if stuck
       
       the human will run \`--as approved\` when ready.
 "
@@ -78,6 +76,31 @@ exports[`driver.route.set.acceptance given: [case6] route.stone.set with ambiguo
     "3.plan"
   ]
 }
+"
+`;
+
+exports[`driver.route.set.acceptance given: [case7] route.stone.set --as passed with guard (cached) when: [t0] second run with same artifact reuses cached results then: stdout matches snapshot 1`] = `
+"🦉 the way speaks for itself
+   ├─ ✓ review.1 - completed (cached)
+   └─ ✓ judge.1 - allowed (cached)
+
+🗿 route.stone.set
+   ├─ stone = 1.test
+   ├─ passage = allowed
+   ├─ guard
+   │  ├─ artifacts
+   │  │   └─ 1.test.md
+   │  ├─ reviews
+   │  │   └─ r1: echo "blockers: 0\\nnitpicks: 1\\ntest review content"
+   │  │       └─ · cached
+   │  │          └─ on 1.test*.md
+   │  └─ judges
+   │      └─ j1: echo "passed: true\\nreason: all checks passed"
+   │          └─ · cached
+   │             └─ on 1.test*.md
+   │
+   └─ the way continues, run
+      └─ rhx route.drive
 "
 `;
 

--- a/blackbox/driver.route.set.acceptance.test.ts
+++ b/blackbox/driver.route.set.acceptance.test.ts
@@ -522,8 +522,17 @@ describe('driver.route.set.acceptance', () => {
         expect(res.cli.stdout).toContain('cached');
       });
 
+      then('stdout shows glob pattern under cached indicator with on prefix', () => {
+        // the cachedOn feature shows the original glob (what invalidates the cache)
+        expect(res.cli.stdout).toContain('on 1.test*.md');
+      });
+
       then('stdout contains passage = allowed', () => {
         expect(res.cli.stdout).toContain('passage = allowed');
+      });
+
+      then('stdout matches snapshot', () => {
+        expect(res.cli.stdout).toMatchSnapshot();
       });
     });
   });

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "preversion": "npm run prepush",
     "postversion": "git push origin HEAD --tags --no-verify",
     "prepare:husky": "husky install && chmod ug+x .husky/*",
-    "prepare:rhachet": "rhachet init --hooks --roles behaver driver mechanic reviewer",
+    "prepare:rhachet": "npm run build && rhachet init --hooks --roles mechanic behaver driver reviewer librarian ergonomist architect reflector dreamer",
     "prepare": "if [ -e .git ] && [ -z $CI ]; then npm run prepare:husky && npm run prepare:rhachet; fi",
     "upgrade:rhachet": "rhachet upgrade"
   },
@@ -121,7 +121,7 @@
     "rhachet-brains-xai": "0.3.2",
     "rhachet-roles-bhrain": "link:.",
     "rhachet-roles-bhuild": "0.14.4",
-    "rhachet-roles-ehmpathy": "1.34.3",
+    "rhachet-roles-ehmpathy": "1.34.7",
     "test-fns": "1.15.7",
     "tsc-alias": "1.8.10",
     "tsx": "4.20.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,8 +148,8 @@ importers:
         specifier: 0.14.4
         version: 0.14.4(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet-roles-bhrain@)
       rhachet-roles-ehmpathy:
-        specifier: 1.34.3
-        version: 1.34.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.37.19(zod@4.3.4))
+        specifier: 1.34.7
+        version: 1.34.7(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.37.19(zod@4.3.4))
       test-fns:
         specifier: 1.15.7
         version: 1.15.7
@@ -4238,8 +4238,8 @@ packages:
     peerDependencies:
       rhachet-roles-bhrain: '>=0.12.1'
 
-  rhachet-roles-ehmpathy@1.34.3:
-    resolution: {integrity: sha512-6dsW8A+py/RMb0kIB1Et92N3G6sYkaG9mpK+B3IvkpIOwyu9P0bcjELMbEf4jAukNK6bKOda9sKhvJegvdzINg==}
+  rhachet-roles-ehmpathy@1.34.7:
+    resolution: {integrity: sha512-7jOXt4dNrG3p9BoFGt4uDHsA9xdVR/2PuVhGsw3BzP3j5xirB9E+tBCfH1B7i8oV3hkq3tgMBlCkmTLmjsoe4g==}
     engines: {node: '>=8.0.0'}
 
   rhachet@1.37.19:
@@ -8066,7 +8066,7 @@ snapshots:
       helpful-errors: 1.5.3
       joi: 17.4.0
       rhachet: 1.37.19(zod@4.3.4)
-      rhachet-roles-ehmpathy: 1.34.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.37.19(zod@4.3.4))
+      rhachet-roles-ehmpathy: 1.34.7(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.37.19(zod@4.3.4))
       type-fns: 1.21.0
       uuid-fns: 1.1.3
     transitivePeerDependencies:
@@ -9736,7 +9736,7 @@ snapshots:
       - aws-crt
       - ws
 
-  rhachet-roles-ehmpathy@1.34.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.37.19(zod@4.3.4)):
+  rhachet-roles-ehmpathy@1.34.7(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.37.19(zod@4.3.4)):
     dependencies:
       '@atjsh/llmlingua-2': 2.0.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(js-tiktoken@1.0.21)
       '@ehmpathy/as-command': 1.0.3

--- a/src/domain.operations/route/formatRouteStoneEmit.ts
+++ b/src/domain.operations/route/formatRouteStoneEmit.ts
@@ -100,7 +100,7 @@ type FormatInput =
         reviews: Array<{
           index: number;
           cmd: string;
-          cached: boolean;
+          cached: { hit: true; on: string[] } | false;
           durationSec: number | null;
           blockers: number;
           nitpicks: number;
@@ -109,7 +109,7 @@ type FormatInput =
         judges: Array<{
           index: number;
           cmd: string;
-          cached: boolean;
+          cached: { hit: true; on: string[] } | false;
           durationSec: number | null;
           passed: boolean;
           reason: string | null;

--- a/src/domain.operations/route/guard/__snapshots__/formatGuardTree.test.ts.snap
+++ b/src/domain.operations/route/guard/__snapshots__/formatGuardTree.test.ts.snap
@@ -50,6 +50,7 @@ exports[`formatGuardTree given: [case3] some cached reviews — 1 cached + 1 fre
       ├─ reviews
       │   ├─ r1: reviewer/reflect
       │   │   └─ · cached
+      │   │      └─ on 1.vision.v1.md
       │   └─ r2: reviewer/review
       │       ├─ finished 10.3s ✓
       │       ├─ review: .route/1.vision.guard.review.i1.abc123.r2.md
@@ -69,9 +70,11 @@ exports[`formatGuardTree given: [case4] all cached — all reviews + judges cach
       ├─ reviews
       │   └─ r1: reviewer/reflect
       │       └─ · cached
+      │          └─ on 1.vision.v1.md
       └─ judges
           └─ j1: reviewed?
-              └─ · cached"
+              └─ · cached
+                 └─ on 1.vision.v1.md"
 `;
 
 exports[`formatGuardTree given: [case5] unguarded stone — no guard input when: [t0] called with no guard then: output matches snapshot 1`] = `
@@ -154,9 +157,11 @@ exports[`formatGuardTree given: [case10] cached judge that had failed — shows 
       ├─ reviews
       │   └─ r1: reviewer/reflect
       │       └─ · cached
+      │          └─ on 1.vision.v1.md
       └─ judges
           └─ j1: reviewed?
-              └─ · cached"
+              └─ · cached
+                 └─ on 1.vision.v1.md"
 `;
 
 exports[`formatGuardTree given: [case11] passage with reason — blocked + combined reasons when: [t0] called with blocked and reason then: output matches snapshot 1`] = `
@@ -179,4 +184,23 @@ exports[`formatGuardTree given: [case11] passage with reason — blocked + combi
           └─ j2: approved?
               ├─ finished 0.2s ✗
               └─ reason: judge 2 failed"
+`;
+
+exports[`formatGuardTree given: [case12] cached review on src/**/* artifacts — 5.1.execute stone with glob pattern when: [t0] called with cached review and glob pattern then: output contains glob pattern, not enumerated files 1`] = `
+"🗿 route.stone.set
+   ├─ stone = 5.1.execute
+   ├─ passage = allowed
+   └─ guard
+      ├─ artifacts
+      │   ├─ src/domain/execute.ts
+      │   ├─ src/domain/execute.test.ts
+      │   └─ src/utils/helper.ts
+      ├─ reviews
+      │   └─ r1: reviewer/review --rules ".agent/**/rules/*.md" --paths "src/**/*"
+      │       └─ · cached
+      │          └─ on src/**/*
+      └─ judges
+          └─ j1: reviewed?
+              └─ · cached
+                 └─ on src/**/*"
 `;

--- a/src/domain.operations/route/guard/formatGuardTree.test.ts
+++ b/src/domain.operations/route/guard/formatGuardTree.test.ts
@@ -127,7 +127,7 @@ describe('formatGuardTree', () => {
                 {
                   index: 1,
                   cmd: 'reviewer/reflect',
-                  cached: true,
+                  cached: { hit: true, on: ['1.vision.v1.md'] },
                   durationSec: null,
                   blockers: 0,
                   nitpicks: 0,
@@ -179,7 +179,7 @@ describe('formatGuardTree', () => {
               {
                 index: 1,
                 cmd: 'reviewer/reflect',
-                cached: true,
+                cached: { hit: true, on: ['1.vision.v1.md'] },
                 durationSec: null,
                 blockers: 0,
                 nitpicks: 0,
@@ -190,7 +190,7 @@ describe('formatGuardTree', () => {
               {
                 index: 1,
                 cmd: 'reviewed?',
-                cached: true,
+                cached: { hit: true, on: ['1.vision.v1.md'] },
                 durationSec: null,
                 passed: true,
                 reason: null,
@@ -393,7 +393,7 @@ describe('formatGuardTree', () => {
                 {
                   index: 1,
                   cmd: 'reviewer/reflect',
-                  cached: true,
+                  cached: { hit: true, on: ['1.vision.v1.md'] },
                   durationSec: null,
                   blockers: 0,
                   nitpicks: 0,
@@ -404,7 +404,7 @@ describe('formatGuardTree', () => {
                 {
                   index: 1,
                   cmd: 'reviewed?',
-                  cached: true,
+                  cached: { hit: true, on: ['1.vision.v1.md'] },
                   durationSec: null,
                   passed: false,
                   reason: 'blockers exceed threshold',
@@ -472,4 +472,59 @@ describe('formatGuardTree', () => {
       });
     });
   });
+
+  given(
+    '[case12] cached review on src/**/* artifacts — 5.1.execute stone with glob pattern',
+    () => {
+      when('[t0] called with cached review and glob pattern', () => {
+        then('output contains glob pattern, not enumerated files', () => {
+          const result = formatGuardTree({
+            stone: '5.1.execute',
+            passage: 'allowed',
+            note: null,
+            reason: null,
+            guard: {
+              // artifactFiles = expanded files (what matched the glob)
+              artifactFiles: [
+                'src/domain/execute.ts',
+                'src/domain/execute.test.ts',
+                'src/utils/helper.ts',
+              ],
+              reviews: [
+                {
+                  index: 1,
+                  cmd: 'reviewer/review --rules ".agent/**/rules/*.md" --paths "src/**/*"',
+                  // cached.on = original glob (what invalidates the cache)
+                  cached: { hit: true, on: ['src/**/*'] },
+                  durationSec: null,
+                  blockers: 0,
+                  nitpicks: 0,
+                  path: '.route/5.1.execute.guard.review.i1.abc123.r1.md',
+                },
+              ],
+              judges: [
+                {
+                  index: 1,
+                  cmd: 'reviewed?',
+                  cached: { hit: true, on: ['src/**/*'] },
+                  durationSec: null,
+                  passed: true,
+                  reason: null,
+                  path: '.route/5.1.execute.guard.judge.i1p1.abc123.def456.j1.md',
+                },
+              ],
+            },
+          });
+          expect(result).toContain('stone = 5.1.execute');
+          expect(result).toContain('· cached');
+          // glob pattern displayed, not individual files
+          expect(result).toContain('on src/**/*');
+          expect(result).not.toContain('on src/domain/execute.ts');
+          expect(result).not.toContain('on src/domain/execute.test.ts');
+          expect(result).not.toContain('on src/utils/helper.ts');
+          expect(result).toMatchSnapshot();
+        });
+      });
+    },
+  );
 });

--- a/src/domain.operations/route/guard/formatGuardTree.ts
+++ b/src/domain.operations/route/guard/formatGuardTree.ts
@@ -12,7 +12,7 @@ export const formatGuardTree = (input: {
     reviews: Array<{
       index: number;
       cmd: string;
-      cached: boolean;
+      cached: { hit: true; on: string[] } | false;
       durationSec: number | null;
       blockers: number;
       nitpicks: number;
@@ -21,7 +21,7 @@ export const formatGuardTree = (input: {
     judges: Array<{
       index: number;
       cmd: string;
-      cached: boolean;
+      cached: { hit: true; on: string[] } | false;
       durationSec: number | null;
       passed: boolean;
       reason: string | null;
@@ -116,9 +116,17 @@ export const formatGuardTree = (input: {
         );
 
         if (review.cached) {
+          // show what artifacts the cache was based on
           lines.push(
             `${guardIndent}${sectionIndent} ${reviewIndent} └─ · cached`,
           );
+          for (let c = 0; c < review.cached.on.length; c++) {
+            const isCachedOnLast = c === review.cached.on.length - 1;
+            const cachedOnPrefix = isCachedOnLast ? '└─' : '├─';
+            lines.push(
+              `${guardIndent}${sectionIndent} ${reviewIndent}    ${cachedOnPrefix} on ${review.cached.on[c]}`,
+            );
+          }
         } else {
           // build detail lines for fresh review
           const detailLines: string[] = [];
@@ -161,9 +169,17 @@ export const formatGuardTree = (input: {
         );
 
         if (judge.cached) {
+          // show what artifacts the cache was based on
           lines.push(
             `${guardIndent}${sectionIndent} ${judgeIndent} └─ · cached`,
           );
+          for (let c = 0; c < judge.cached.on.length; c++) {
+            const isCachedOnLast = c === judge.cached.on.length - 1;
+            const cachedOnPrefix = isCachedOnLast ? '└─' : '├─';
+            lines.push(
+              `${guardIndent}${sectionIndent} ${judgeIndent}    ${cachedOnPrefix} on ${judge.cached.on[c]}`,
+            );
+          }
         } else {
           const detailLines: string[] = [];
           const dur =

--- a/src/domain.operations/route/stones/setStoneAsPassed.ts
+++ b/src/domain.operations/route/stones/setStoneAsPassed.ts
@@ -515,18 +515,27 @@ const computeGuardData = (input: {
     ? getGuardPeerReviews(input.stone.guard)
     : [];
 
+  // compute artifact file names for display
+  const artifactFileNames = input.artifactFiles.map((f) => path.basename(f));
+
+  // use original artifact globs for cachedOn (shows what invalidates the cache)
+  const artifactGlobs = input.stone.guard?.artifacts ?? [];
+
   return {
-    artifactFiles: input.artifactFiles.map((f) => path.basename(f)),
+    artifactFiles: artifactFileNames,
     reviews: input.reviewArtifacts.map((r) => {
       // match event by step.index (0-based) to artifact.index (1-based)
       const event = reviewEventsCompleted.find(
         (e) => e.step.index === r.index - 1,
       );
       const durationSec = computeDuration(event);
+      const isCached = !event;
       return {
         index: r.index,
         cmd: stonePeerReviews[r.index - 1] ?? '',
-        cached: !event,
+        cached: isCached
+          ? ({ hit: true, on: artifactGlobs } as { hit: true; on: string[] })
+          : (false as const),
         durationSec,
         blockers: r.blockers,
         nitpicks: r.nitpicks,
@@ -538,10 +547,13 @@ const computeGuardData = (input: {
         (e) => e.step.index === j.index - 1,
       );
       const durationSec = computeDuration(event);
+      const isCached = !event;
       return {
         index: j.index,
         cmd: input.stone.guard?.judges[j.index - 1] ?? '',
-        cached: !event,
+        cached: isCached
+          ? ({ hit: true, on: artifactGlobs } as { hit: true; on: string[] })
+          : (false as const),
         durationSec,
         passed: j.passed,
         reason: j.reason,


### PR DESCRIPTION
fix(guard): show glob patterns in cached review output

- display original artifact globs (e.g., src/**/*) instead of enumerating files
- refactor cached type to { hit: true, on: string[] } | false
- eliminates impossible state (cached: true + cachedOn: null)

---
🐢🌊 surfed in by seaturtle[bot]