### PR TITLE
fix(review): include untracked files in --diffs since-main

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -143,12 +143,6 @@
             "command": "./node_modules/.bin/rhx route.mutate.guard --mode hook",
             "timeout": 5,
             "author": "repo=bhrain/role=driver"
-          },
-          {
-            "type": "command",
-            "command": "./node_modules/.bin/rhx goal.guard",
-            "timeout": 5,
-            "author": "repo=bhrain/role=achiever"
           }
         ]
       },
@@ -173,18 +167,6 @@
             "command": "./node_modules/.bin/rhx route.drive --mode hook",
             "timeout": 5,
             "author": "repo=bhrain/role=driver"
-          },
-          {
-            "type": "command",
-            "command": "./node_modules/.bin/rhx goal.triage.next --when hook.onStop",
-            "timeout": 10,
-            "author": "repo=bhrain/role=achiever"
-          },
-          {
-            "type": "command",
-            "command": "./node_modules/.bin/rhx goal.infer.triage --mode hook.onStop",
-            "timeout": 10,
-            "author": "repo=bhrain/role=achiever"
           }
         ]
       }

--- a/blackbox/review.join-intersect.acceptance.test.ts
+++ b/blackbox/review.join-intersect.acceptance.test.ts
@@ -143,7 +143,8 @@ describe('review.join.acceptance', () => {
 
       then('debug log shows what was matched', () => {
         expect(res.debugLog).toBeDefined();
-        expect(res.debugLog.resolution.targetFilesFromDiffs).toEqual([]);
+        // note: since-main now includes untracked files (e.g., .agent/* from rhachet roles link)
+        // but they don't match src/*.ts so intersection is still empty
         expect(res.debugLog.resolution.targetFilesFromPaths).toContain('src/clean.ts');
         expect(res.debugLog.resolution.targetFilesFromPaths).toContain('src/dirty.ts');
         expect(res.debugLog.resolution.targetFiles).toEqual([]);

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "esbuild-register": "3.6.0",
     "husky": "8.0.3",
     "jest": "30.2.0",
-    "rhachet": "1.40.2",
+    "rhachet": "1.40.3",
     "rhachet-brains-anthropic": "0.4.0",
     "rhachet-brains-openai": "0.3.1",
     "rhachet-brains-xai": "0.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,26 +133,26 @@ importers:
         specifier: 30.2.0
         version: 30.2.0(@types/node@22.15.21)(esbuild-register@3.6.0(esbuild@0.25.12))(ts-node@10.9.2(@swc/core@1.15.3)(@types/node@22.15.21)(typescript@5.4.5))
       rhachet:
-        specifier: 1.40.2
-        version: 1.40.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
+        specifier: 1.40.3
+        version: 1.40.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
       rhachet-brains-anthropic:
         specifier: 0.4.0
-        version: 0.4.0(rhachet@1.40.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
+        version: 0.4.0(rhachet@1.40.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       rhachet-brains-openai:
         specifier: 0.3.1
-        version: 0.3.1(@openai/codex-sdk@0.87.0)(rhachet@1.40.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
+        version: 0.3.1(@openai/codex-sdk@0.87.0)(rhachet@1.40.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       rhachet-brains-xai:
         specifier: 0.3.3
-        version: 0.3.3(rhachet@1.40.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
+        version: 0.3.3(rhachet@1.40.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       rhachet-roles-bhrain:
         specifier: link:.
         version: 'link:'
       rhachet-roles-bhuild:
         specifier: 0.18.1
-        version: 0.18.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.40.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-roles-bhrain@)
+        version: 0.18.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.40.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-roles-bhrain@)
       rhachet-roles-ehmpathy:
         specifier: 1.34.32
-        version: 1.34.32(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.40.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
+        version: 1.34.32(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.40.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       test-fns:
         specifier: 1.15.7
         version: 1.15.7
@@ -4254,8 +4254,8 @@ packages:
     resolution: {integrity: sha512-2i7z+5E+voqzUrVsZDpJCooVUEBvgzNJNJbb/0Tmx9EKDrEbXr/APkXk/t2mX4MqoL4Q6hiDPKjk3OkEh1uNtQ==}
     engines: {node: '>=8.0.0'}
 
-  rhachet@1.40.2:
-    resolution: {integrity: sha512-jjQmE6B9V0b5ZZwhDhPK5H7Pk8Pl8urz2cL8wVOBwzvtQTrtuXVrf5fBZmH5vdJbJv0Tn6U4Qfy3BeWG0Leueg==}
+  rhachet@1.40.3:
+    resolution: {integrity: sha512-+QDzI47kc/IXU3vinXq1kj+1qtq39adVjIcIXGQ4osgZihR8IZkt+V8RQb3UMzTUpcn82YrsskWY93XXinnI+Q==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
@@ -8077,8 +8077,8 @@ snapshots:
       domain-objects: 0.31.3
       helpful-errors: 1.5.3
       joi: 17.4.0
-      rhachet: 1.40.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
-      rhachet-roles-ehmpathy: 1.34.32(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.40.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
+      rhachet: 1.40.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
+      rhachet-roles-ehmpathy: 1.34.32(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.40.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       type-fns: 1.21.0
       uuid-fns: 1.1.3
     transitivePeerDependencies:
@@ -9700,7 +9700,7 @@ snapshots:
       domain-objects: 0.31.9
       helpful-errors: 1.5.3
 
-  rhachet-brains-anthropic@0.4.0(rhachet@1.40.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
+  rhachet-brains-anthropic@0.4.0(rhachet@1.40.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
     dependencies:
       '@anthropic-ai/claude-agent-sdk': 0.1.76(zod@4.3.4)
       '@anthropic-ai/sdk': 0.71.2(zod@4.3.4)
@@ -9708,20 +9708,20 @@ snapshots:
       helpful-errors: 1.5.3
       iso-price: 1.1.1(domain-objects@0.31.9)
       iso-time: 1.11.1
-      rhachet: 1.40.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
+      rhachet: 1.40.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
       rhachet-artifact: 1.0.1
       rhachet-artifact-git: 1.1.5
       type-fns: 1.21.0
       zod: 4.3.4
 
-  rhachet-brains-openai@0.3.1(@openai/codex-sdk@0.87.0)(rhachet@1.40.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
+  rhachet-brains-openai@0.3.1(@openai/codex-sdk@0.87.0)(rhachet@1.40.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
     dependencies:
       '@openai/codex-sdk': 0.87.0
       domain-objects: 0.31.9
       helpful-errors: 1.5.3
       iso-price: 1.1.1(domain-objects@0.31.9)
       openai: 5.8.2(zod@4.3.4)
-      rhachet: 1.40.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
+      rhachet: 1.40.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
       rhachet-artifact: 1.0.1
       rhachet-artifact-git: 1.1.5
       type-fns: 1.21.0
@@ -9730,13 +9730,13 @@ snapshots:
     transitivePeerDependencies:
       - ws
 
-  rhachet-brains-xai@0.3.3(rhachet@1.40.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
+  rhachet-brains-xai@0.3.3(rhachet@1.40.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
     dependencies:
       domain-objects: 0.31.9
       helpful-errors: 1.5.3
       iso-price: 1.1.1(domain-objects@0.31.9)
       openai: 5.8.2(zod@4.3.4)
-      rhachet: 1.40.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
+      rhachet: 1.40.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
       rhachet-artifact: 1.0.1
       rhachet-artifact-git: 1.1.5
       type-fns: 1.21.0
@@ -9744,13 +9744,13 @@ snapshots:
     transitivePeerDependencies:
       - ws
 
-  rhachet-roles-bhuild@0.18.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.40.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-roles-bhrain@):
+  rhachet-roles-bhuild@0.18.1(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet-brains-xai@0.3.3(rhachet@1.40.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)))(rhachet-roles-bhrain@):
     dependencies:
       domain-objects: 0.31.9
       emoji-space-shim: 0.0.0
       helpful-errors: 1.5.3
       iso-time: 1.11.3
-      rhachet-brains-xai: 0.3.3(rhachet@1.40.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
+      rhachet-brains-xai: 0.3.3(rhachet@1.40.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       rhachet-roles-bhrain: 'link:'
       test-fns: 1.15.0(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)
       zod: 4.3.4
@@ -9761,7 +9761,7 @@ snapshots:
       - aws-crt
       - ws
 
-  rhachet-roles-ehmpathy@1.34.32(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.40.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
+  rhachet-roles-ehmpathy@1.34.32(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.40.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4)):
     dependencies:
       '@atjsh/llmlingua-2': 2.0.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(js-tiktoken@1.0.21)
       '@ehmpathy/as-command': 1.0.3
@@ -9775,7 +9775,7 @@ snapshots:
       openai: 5.8.2(zod@4.3.4)
       rhachet-artifact: 1.0.0
       rhachet-artifact-git: 1.1.0
-      rhachet-brains-xai: 0.3.3(rhachet@1.40.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
+      rhachet-brains-xai: 0.3.3(rhachet@1.40.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       serde-fns: 1.2.0
       simple-in-memory-cache: 0.4.0
       simple-on-disk-cache: 1.7.3
@@ -9792,7 +9792,7 @@ snapshots:
       - rhachet
       - ws
 
-  rhachet@1.40.2(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4):
+  rhachet@1.40.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4):
     dependencies:
       '@noble/curves': 2.0.1
       '@noble/hashes': 2.0.1

--- a/src/domain.operations/review/enumFilesFromDiffs.integration.test.ts
+++ b/src/domain.operations/review/enumFilesFromDiffs.integration.test.ts
@@ -240,8 +240,63 @@ describe('enumFilesFromDiffs', () => {
     });
   });
 
+  given('[case6] --diffs since-main includes untracked files', () => {
+    const scene = usePrep(async () => {
+      const { repoPath, cleanup } = setupTestRepo();
+
+      // create a branch from main
+      execSync('git checkout -b feature', { cwd: repoPath });
+
+      // add a committed file
+      fs.writeFileSync(
+        path.join(repoPath, 'src/committed-file.ts'),
+        'export const committed = true;',
+      );
+      execSync('git add .', { cwd: repoPath });
+      execSync('git commit -m "committed file"', {
+        cwd: repoPath,
+        env: GIT_ENV,
+      });
+
+      // add an untracked file (not staged, not committed)
+      fs.writeFileSync(
+        path.join(repoPath, 'src/untracked-file.ts'),
+        'export const untracked = true;',
+      );
+
+      // add a staged but not committed file
+      fs.writeFileSync(
+        path.join(repoPath, 'src/staged-file.ts'),
+        'export const staged = true;',
+      );
+      execSync('git add src/staged-file.ts', { cwd: repoPath });
+
+      return { repoPath, cleanup };
+    });
+
+    afterAll(() => scene.cleanup());
+
+    when('[t0] untracked files exist on feature branch', () => {
+      then('returns untracked files along with committed changes', async () => {
+        const files = await enumFilesFromDiffs({
+          range: 'since-main',
+          cwd: scene.repoPath,
+        });
+
+        // committed file should be included
+        expect(files).toContain('src/committed-file.ts');
+
+        // untracked file should ALSO be included (critical for reviews)
+        expect(files).toContain('src/untracked-file.ts');
+
+        // staged file should also be included
+        expect(files).toContain('src/staged-file.ts');
+      });
+    });
+  });
+
   given(
-    '[case6] --diffs since-main compares against origin/main not local main',
+    '[case7] --diffs since-main compares against origin/main not local main',
     () => {
       const scene = usePrep(async () => {
         // create a bare repo to act as "origin"

--- a/src/domain.operations/review/enumFilesFromDiffs.ts
+++ b/src/domain.operations/review/enumFilesFromDiffs.ts
@@ -42,8 +42,26 @@ const resolveMainBranch = (input: { cwd: string }): string => {
 };
 
 /**
+ * .what = enumerates untracked files in a git repo
+ * .why = git diff doesn't show untracked files, but reviews need them
+ */
+const enumUntrackedFiles = (input: { cwd: string }): string[] => {
+  const output = execSync('git ls-files --others --exclude-standard', {
+    cwd: input.cwd,
+    encoding: 'utf-8',
+  });
+  return output
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+};
+
+/**
  * .what = enumerates files changed in a git diff range
- * .why = supports --diffs input for reviewing changed files
+ * .why = supports --diffs input for review of changed files
+ *
+ * .note = for since-main and since-commit, untracked files are included
+ *         because they represent new work that should be reviewed
  */
 export const enumFilesFromDiffs = async (input: {
   range: 'since-main' | 'since-commit' | 'since-staged';
@@ -51,8 +69,11 @@ export const enumFilesFromDiffs = async (input: {
 }): Promise<string[]> => {
   const cwd = input.cwd ?? process.cwd();
 
-  // build git command based on range
-  const gitCommand = (() => {
+  // collect all file paths from relevant git commands
+  const allPaths: string[] = [];
+
+  // get diff-based changes
+  const gitDiffCommand = (() => {
     if (input.range === 'since-main') {
       const mainBranch = resolveMainBranch({ cwd });
       // use merge-base to only show changes since branch point, not changes on main
@@ -67,21 +88,40 @@ export const enumFilesFromDiffs = async (input: {
     throw new UnexpectedCodePathError('invalid range', { range: input.range });
   })();
 
-  // execute git command
-  const output = execSync(gitCommand, {
+  // execute git diff command
+  const diffOutput = execSync(gitDiffCommand, {
     cwd,
     encoding: 'utf-8',
   });
+  allPaths.push(
+    ...diffOutput
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0),
+  );
 
-  // parse output into file paths
-  const paths = output
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line.length > 0);
+  // for since-main and since-commit, also include staged changes and untracked files
+  // (these represent new work that should be reviewed)
+  if (input.range === 'since-main' || input.range === 'since-commit') {
+    // include staged changes (git diff --staged)
+    const stagedOutput = execSync('git diff --staged --name-only', {
+      cwd,
+      encoding: 'utf-8',
+    });
+    allPaths.push(
+      ...stagedOutput
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0),
+    );
+
+    // include untracked files
+    allPaths.push(...enumUntrackedFiles({ cwd }));
+  }
 
   // filter to only include files (exclude directories and symlinks to directories)
   const files = await Promise.all(
-    paths.map(async (filePath) => {
+    allPaths.map(async (filePath) => {
       try {
         const stat = await fs.stat(path.join(cwd, filePath));
         return stat.isFile() ? filePath : null;


### PR DESCRIPTION
fix(review): include untracked files in --diffs since-main

- added enumUntrackedFiles() using git ls-files --others
- since-main and since-commit now include staged + untracked files
- added test coverage for untracked file visibility
- fixes critical scenario where new files were invisible to peer reviews

---
🐢🌊 surfed in by seaturtle[bot]