### PR TITLE
fix(test): deflake acceptance tests with when.repeatably

### DIFF
--- a/blackbox/review.exhaustive-dirty.acceptance.test.ts
+++ b/blackbox/review.exhaustive-dirty.acceptance.test.ts
@@ -12,9 +12,20 @@ import {
 
 const ASSETS_DIR = path.join(__dirname, '.test/assets/codebase-mechanic');
 
+/**
+ * .what = config for probabilistic tests that invoke LLM brains
+ * .why = LLM responses can timeout or vary; retry ensures CI stability
+ *
+ * @see .agent/repo=.this/role=any/briefs/rule.require.repeatable-for-llm-tests.md
+ */
+const REPEATABLE_CONFIG = {
+  attempts: 3,
+  criteria: process.env.CI ? 'SOME' : 'EVERY',
+} as const;
+
 describe('review.acceptance', () => {
   given('[case3] mechanic codebase with dirty code', () => {
-    when('[t0] review skill on dirty.ts with goal=exhaustive', () => {
+    when.repeatably(REPEATABLE_CONFIG)('[t0] review skill on dirty.ts with goal=exhaustive', () => {
       const res = useThen('invoke review skill with exhaustive goal', async () => {
         // clone fixture to temp dir with git initialized
         const tempDir = genTempDirForRhachet({ slug: 'review-exh-dirty', clone: ASSETS_DIR });

--- a/blackbox/review.output-default.acceptance.test.ts
+++ b/blackbox/review.output-default.acceptance.test.ts
@@ -11,9 +11,20 @@ import {
 
 const ASSETS_DIR = path.join(__dirname, '.test/assets/codebase-mechanic');
 
+/**
+ * .what = config for probabilistic tests that invoke LLM brains
+ * .why = LLM responses can timeout or vary; retry ensures CI stability
+ *
+ * @see .agent/repo=.this/role=any/briefs/rule.require.repeatable-for-llm-tests.md
+ */
+const REPEATABLE_CONFIG = {
+  attempts: 3,
+  criteria: process.env.CI ? 'SOME' : 'EVERY',
+} as const;
+
 describe('review.output-default.acceptance', () => {
   given('[case1] mechanic codebase with review skill', () => {
-    when('[t0] review skill invoked without --output flag', () => {
+    when.repeatably(REPEATABLE_CONFIG)('[t0] review skill invoked without --output flag', () => {
       const res = useThen('invoke review skill without --output', async () => {
         // clone fixture to temp dir with git initialized
         const tempDir = genTempDirForRhachet({


### PR DESCRIPTION
fix(test): deflake acceptance tests with when.repeatably

- added REPEATABLE_CONFIG for LLM-invoking acceptance tests
- wrapped when blocks with when.repeatably(REPEATABLE_CONFIG)
- ensures CI stability despite LLM timeout variance

---
🐢🌊 surfed in by seaturtle[bot]