### PR TITLE
fix(test): deflake acceptance tests with when.repeatably

### DIFF
--- a/.handoff/test-fns.timeout-for-repeatably.md
+++ b/.handoff/test-fns.timeout-for-repeatably.md
@@ -1,0 +1,55 @@
+# feature request: timeout option for repeatably
+
+## problem
+
+`when.repeatably(REPEATABLE_CONFIG)` for probabilistic LLM tests:
+- jest has a default 90s timeout per test
+- if attempt 1 takes >90s, jest kills the test BEFORE test-fns can try attempt 2
+- `criteria: 'SOME'` never gets to use subsequent attempts
+
+observed failure:
+```
+review.representative-dirty.acceptance.test.ts
+  timeout of 90000ms exceeded
+```
+
+## requested feature
+
+add `timeout` option to repeatably config:
+
+```ts
+when.repeatably({
+  attempts: 3,
+  criteria: 'SOME',
+  timeout: 180_000, // per-attempt timeout in ms
+})('[t0] llm generates response', () => {
+  // ...
+});
+```
+
+behavior:
+- sets `jest.setTimeout(timeout)` for the describe block
+- OR wraps each attempt with Promise.race timeout to enable test-fns retry logic
+
+## why this matters
+
+LLM operations can take 60-120s based on load. the 90s jest timeout is reasonable for most tests but breaks probabilistic retry patterns.
+
+## workaround
+
+for now, manually add `jest.setTimeout(180_000)` at the top of test files that invoke LLMs.
+
+## alternative: withTimeout wrapper
+
+export a `withTimeout(fn, ms)` wrapper that users can apply inside useThen:
+
+```ts
+const result = useThen('invoke skill', async () =>
+  withTimeout(
+    () => invokeReviewSkill({ ... }),
+    120_000, // timeout before retry kicks in
+  ),
+);
+```
+
+this would timeout and throw early, which enables test-fns to catch and retry on subsequent attempts.

--- a/blackbox/review.exhaustive-dirty.acceptance.test.ts
+++ b/blackbox/review.exhaustive-dirty.acceptance.test.ts
@@ -13,6 +13,14 @@ import {
 const ASSETS_DIR = path.join(__dirname, '.test/assets/codebase-mechanic');
 
 /**
+ * .what = extend jest timeout for LLM tests
+ * .why = LLM operations can take 60-120s; default 90s timeout kills test before retry
+ *
+ * @see .handoff/test-fns.timeout-for-repeatably.md
+ */
+jest.setTimeout(180_000);
+
+/**
  * .what = config for probabilistic tests that invoke LLM brains
  * .why = LLM responses can timeout or vary; retry ensures CI stability
  *

--- a/blackbox/review.join-intersect.acceptance.test.ts
+++ b/blackbox/review.join-intersect.acceptance.test.ts
@@ -12,6 +12,14 @@ import {
 const ASSETS_DIR = path.join(__dirname, '.test/assets/codebase-mechanic');
 
 /**
+ * .what = extend jest timeout for LLM tests
+ * .why = LLM operations can take 60-120s; default 90s timeout kills test before retry
+ *
+ * @see .handoff/test-fns.timeout-for-repeatably.md
+ */
+jest.setTimeout(180_000);
+
+/**
  * .what = config for probabilistic tests that invoke LLM brains
  * .why = LLM responses can timeout or vary; retry ensures CI stability
  *

--- a/blackbox/review.output-default.acceptance.test.ts
+++ b/blackbox/review.output-default.acceptance.test.ts
@@ -12,6 +12,14 @@ import {
 const ASSETS_DIR = path.join(__dirname, '.test/assets/codebase-mechanic');
 
 /**
+ * .what = extend jest timeout for LLM tests
+ * .why = LLM operations can take 60-120s; default 90s timeout kills test before retry
+ *
+ * @see .handoff/test-fns.timeout-for-repeatably.md
+ */
+jest.setTimeout(180_000);
+
+/**
  * .what = config for probabilistic tests that invoke LLM brains
  * .why = LLM responses can timeout or vary; retry ensures CI stability
  *

--- a/blackbox/review.output-mkdir.acceptance.test.ts
+++ b/blackbox/review.output-mkdir.acceptance.test.ts
@@ -14,6 +14,14 @@ import {
 const ASSETS_DIR = path.join(__dirname, '.test/assets/codebase-mechanic');
 
 /**
+ * .what = extend jest timeout for LLM tests
+ * .why = LLM operations can take 60-120s; default 90s timeout kills test before retry
+ *
+ * @see .handoff/test-fns.timeout-for-repeatably.md
+ */
+jest.setTimeout(180_000);
+
+/**
  * .what = config for probabilistic tests that invoke LLM brains
  * .why = LLM responses can timeout or vary; retry ensures CI stability
  *

--- a/blackbox/review.output-mkdir.acceptance.test.ts
+++ b/blackbox/review.output-mkdir.acceptance.test.ts
@@ -13,9 +13,20 @@ import {
 
 const ASSETS_DIR = path.join(__dirname, '.test/assets/codebase-mechanic');
 
+/**
+ * .what = config for probabilistic tests that invoke LLM brains
+ * .why = LLM responses can timeout or vary; retry ensures CI stability
+ *
+ * @see .agent/repo=.this/role=any/briefs/rule.require.repeatable-for-llm-tests.md
+ */
+const REPEATABLE_CONFIG = {
+  attempts: 3,
+  criteria: process.env.CI ? 'SOME' : 'EVERY',
+} as const;
+
 describe('review.output-mkdir.acceptance', () => {
   given('[case1] mechanic codebase with review skill', () => {
-    when('[t0] review skill invoked with --output to absent parent dir', () => {
+    when.repeatably(REPEATABLE_CONFIG)('[t0] review skill invoked with --output to absent parent dir', () => {
       const res = useThen(
         'invoke review skill with --output to absent parent',
         async () => {

--- a/blackbox/review.refs-glob.acceptance.test.ts
+++ b/blackbox/review.refs-glob.acceptance.test.ts
@@ -13,6 +13,14 @@ import {
 const ASSETS_DIR = path.join(__dirname, '.test/assets/codebase-mechanic');
 
 /**
+ * .what = extend jest timeout for LLM tests
+ * .why = LLM operations can take 60-120s; default 90s timeout kills test before retry
+ *
+ * @see .handoff/test-fns.timeout-for-repeatably.md
+ */
+jest.setTimeout(180_000);
+
+/**
  * .what = config for probabilistic tests that invoke LLM brains
  * .why = LLM responses can timeout or vary; retry ensures CI stability
  *

--- a/blackbox/review.refs-glob.acceptance.test.ts
+++ b/blackbox/review.refs-glob.acceptance.test.ts
@@ -12,12 +12,23 @@ import {
 
 const ASSETS_DIR = path.join(__dirname, '.test/assets/codebase-mechanic');
 
+/**
+ * .what = config for probabilistic tests that invoke LLM brains
+ * .why = LLM responses can timeout or vary; retry ensures CI stability
+ *
+ * @see .agent/repo=.this/role=any/briefs/rule.require.repeatable-for-llm-tests.md
+ */
+const REPEATABLE_CONFIG = {
+  attempts: 3,
+  criteria: process.env.CI ? 'SOME' : 'EVERY',
+} as const;
+
 describe('review.refs-glob.acceptance', () => {
   /**
    * usecase.2: pass multiple refs via glob pattern
    */
   given('[case1] glob pattern matches multiple ref files', () => {
-    when('[t0] review skill invoked with --refs set to glob pattern', () => {
+    when.repeatably(REPEATABLE_CONFIG)('[t0] review skill invoked with --refs set to glob pattern', () => {
       const res = useThen('invoke review skill with glob refs', async () => {
         // clone fixture to temp dir
         const tempDir = genTempDirForRhachet({
@@ -81,7 +92,7 @@ describe('review.refs-glob.acceptance', () => {
    * usecase.7: multiple --refs via repeated flags
    */
   given('[case2] multiple refs via repeated --refs flags', () => {
-    when('[t0] review skill invoked with --refs specified multiple times', () => {
+    when.repeatably(REPEATABLE_CONFIG)('[t0] review skill invoked with --refs specified multiple times', () => {
       const res = useThen(
         'invoke review skill with repeated refs flags',
         async () => {

--- a/blackbox/review.refs-single.acceptance.test.ts
+++ b/blackbox/review.refs-single.acceptance.test.ts
@@ -13,6 +13,14 @@ import {
 const ASSETS_DIR = path.join(__dirname, '.test/assets/codebase-mechanic');
 
 /**
+ * .what = extend jest timeout for LLM tests
+ * .why = LLM operations can take 60-120s; default 90s timeout kills test before retry
+ *
+ * @see .handoff/test-fns.timeout-for-repeatably.md
+ */
+jest.setTimeout(180_000);
+
+/**
  * .what = config for probabilistic tests that invoke LLM brains
  * .why = LLM responses can timeout or vary; retry ensures CI stability
  *

--- a/blackbox/review.representative-clean.acceptance.test.ts
+++ b/blackbox/review.representative-clean.acceptance.test.ts
@@ -12,9 +12,20 @@ import {
 
 const ASSETS_DIR = path.join(__dirname, '.test/assets/codebase-mechanic');
 
+/**
+ * .what = config for probabilistic tests that invoke LLM brains
+ * .why = LLM responses can timeout or vary; retry ensures CI stability
+ *
+ * @see .agent/repo=.this/role=any/briefs/rule.require.repeatable-for-llm-tests.md
+ */
+const REPEATABLE_CONFIG = {
+  attempts: 3,
+  criteria: process.env.CI ? 'SOME' : 'EVERY',
+} as const;
+
 describe('review.acceptance', () => {
   given('[case1] mechanic codebase with clean code', () => {
-    when('[t0] review skill on clean.ts with goal=representative', () => {
+    when.repeatably(REPEATABLE_CONFIG)('[t0] review skill on clean.ts with goal=representative', () => {
       const res = useThen('invoke review skill on clean code', async () => {
         // clone fixture to temp dir with git initialized
         const tempDir = genTempDirForRhachet({ slug: 'review-rep-clean', clone: ASSETS_DIR });

--- a/blackbox/review.representative-clean.acceptance.test.ts
+++ b/blackbox/review.representative-clean.acceptance.test.ts
@@ -13,6 +13,14 @@ import {
 const ASSETS_DIR = path.join(__dirname, '.test/assets/codebase-mechanic');
 
 /**
+ * .what = extend jest timeout for LLM tests
+ * .why = LLM operations can take 60-120s; default 90s timeout kills test before retry
+ *
+ * @see .handoff/test-fns.timeout-for-repeatably.md
+ */
+jest.setTimeout(180_000);
+
+/**
  * .what = config for probabilistic tests that invoke LLM brains
  * .why = LLM responses can timeout or vary; retry ensures CI stability
  *

--- a/blackbox/review.representative-dirty.acceptance.test.ts
+++ b/blackbox/review.representative-dirty.acceptance.test.ts
@@ -13,6 +13,14 @@ import {
 const ASSETS_DIR = path.join(__dirname, '.test/assets/codebase-mechanic');
 
 /**
+ * .what = extend jest timeout for LLM tests
+ * .why = LLM operations can take 60-120s; default 90s timeout kills test before retry
+ *
+ * @see .handoff/test-fns.timeout-for-repeatably.md
+ */
+jest.setTimeout(180_000);
+
+/**
  * .what = config for probabilistic tests that invoke LLM brains
  * .why = LLM responses can timeout or vary; retry ensures CI stability
  *

--- a/blackbox/review.rules-only-default.acceptance.test.ts
+++ b/blackbox/review.rules-only-default.acceptance.test.ts
@@ -14,6 +14,14 @@ import {
 const ASSETS_DIR = path.join(__dirname, '.test/assets/codebase-mechanic');
 
 /**
+ * .what = extend jest timeout for LLM tests
+ * .why = LLM operations can take 60-120s; default 90s timeout kills test before retry
+ *
+ * @see .handoff/test-fns.timeout-for-repeatably.md
+ */
+jest.setTimeout(180_000);
+
+/**
  * .what = config for probabilistic tests that invoke LLM brains
  * .why = LLM responses can timeout or vary; retry ensures CI stability
  *

--- a/blackbox/review.rules-only-default.acceptance.test.ts
+++ b/blackbox/review.rules-only-default.acceptance.test.ts
@@ -14,6 +14,17 @@ import {
 const ASSETS_DIR = path.join(__dirname, '.test/assets/codebase-mechanic');
 
 /**
+ * .what = config for probabilistic tests that invoke LLM brains
+ * .why = LLM responses can timeout or vary; retry ensures CI stability
+ *
+ * @see .agent/repo=.this/role=any/briefs/rule.require.repeatable-for-llm-tests.md
+ */
+const REPEATABLE_CONFIG = {
+  attempts: 3,
+  criteria: process.env.CI ? 'SOME' : 'EVERY',
+} as const;
+
+/**
  * .what = git identity env for commits
  * .why = avoids need for global git config on cicd machines
  */
@@ -27,7 +38,7 @@ const GIT_ENV = {
 
 describe('review.acceptance', () => {
   given('[case1] user specifies only --rules (default case)', () => {
-    when('[t0] review skill invoked with only --rules dirpath', () => {
+    when.repeatably(REPEATABLE_CONFIG)('[t0] review skill invoked with only --rules dirpath', () => {
       const res = useThen('invoke review skill with rules only', async () => {
         // clone fixture to temp dir with git initialized
         const tempDir = genTempDirForRhachet({
@@ -132,7 +143,7 @@ describe('review.acceptance', () => {
   });
 
   given('[case2] user excludes .behavior via negation pattern', () => {
-    when('[t0] review with --diffs since-main --paths !.behavior/**', () => {
+    when.repeatably(REPEATABLE_CONFIG)('[t0] review with --diffs since-main --paths !.behavior/**', () => {
       const res = useThen('invoke review with exclusion pattern', async () => {
         // clone fixture to temp dir with git initialized
         const tempDir = genTempDirForRhachet({

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
     "rhachet-roles-bhrain": "link:.",
     "rhachet-roles-bhuild": "0.21.9",
     "rhachet-roles-ehmpathy": "1.35.6",
-    "test-fns": "1.15.7",
+    "test-fns": "1.15.8",
     "tsc-alias": "1.8.10",
     "tsx": "4.20.6",
     "typescript": "5.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,8 +154,8 @@ importers:
         specifier: 1.35.6
         version: 1.35.6(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(rhachet@1.41.11(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(@types/node@22.15.21)(zod@4.3.4))
       test-fns:
-        specifier: 1.15.7
-        version: 1.15.7
+        specifier: 1.15.8
+        version: 1.15.8
       tsc-alias:
         specifier: 1.8.10
         version: 1.8.10
@@ -4553,8 +4553,8 @@ packages:
     resolution: {integrity: sha512-zC/qUA2lwfiXoQ00Ws8yD8LPA7p3n2a+Dl7wmI4iTXz4HbrU52riPY+AceGWgCAINs/cJ7cs9jnnASSPBwyGpg==}
     engines: {node: '>=8.0.0'}
 
-  test-fns@1.15.7:
-    resolution: {integrity: sha512-wfILa+sblkaG3QQS9MEX+ZPxKrAOAoNVqSxi2OdIdHMQ1hFyKSSHRxfgCwoRujgcH1D6H1liHE+WO8+yJuQkbg==}
+  test-fns@1.15.8:
+    resolution: {integrity: sha512-DCUZjdHJ2mNecITMry297wmR1j7XEgnFqwxuxIA+8830tuWNG3s8f/lM6iM19eMSTBMl8Sk/7AuJWJETv/4PEQ==}
     engines: {node: '>=8.0.0'}
 
   test-fns@1.4.2:
@@ -4731,6 +4731,7 @@ packages:
 
   uuid@10.0.0:
     resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   uuid@11.1.0:
@@ -10296,10 +10297,10 @@ snapshots:
       - ws
       - zod
 
-  test-fns@1.15.7:
+  test-fns@1.15.8:
     dependencies:
       domain-objects: 0.31.9
-      helpful-errors: 1.5.3
+      helpful-errors: 1.7.3
       iso-time: 1.11.3
       uuid: 10.0.0
 


### PR DESCRIPTION
fix(test): deflake acceptance tests with when.repeatably

- added REPEATABLE_CONFIG to 4 acceptance test files
- review.representative-clean.acceptance.test.ts
- review.output-mkdir.acceptance.test.ts
- review.refs-glob.acceptance.test.ts
- review.rules-only-default.acceptance.test.ts
- failfast tests not changed (validation errors before LLM)

---
🐢🌊 surfed in by seaturtle[bot]