### PR TITLE
fix(learner): register learner role in role registry

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -75,6 +75,12 @@
             "command": "./node_modules/.bin/rhachet roles boot --role dispatcher",
             "timeout": 10,
             "author": "repo=bhuild/role=dispatcher"
+          },
+          {
+            "type": "command",
+            "command": "./node_modules/.bin/rhachet roles boot --role learner",
+            "timeout": 30,
+            "author": "repo=bhrain/role=learner"
           }
         ]
       },

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "preversion": "npm run prepush",
     "postversion": "git push origin HEAD --tags --no-verify",
     "prepare:husky": "husky install && chmod ug+x .husky/*",
-    "prepare:rhachet": "npm run build && rhachet init --hooks --roles mechanic behaver driver architect ergonomist reviewer dreamer dispatcher",
+    "prepare:rhachet": "npm run build && rhachet init --hooks --roles mechanic behaver driver architect ergonomist reviewer dreamer dispatcher learner",
     "prepare": "if [ -e .git ] && [ -z $CI ]; then npm run prepare:husky && npm run prepare:rhachet; fi",
     "upgrade:rhachet": "rhachet upgrade"
   },

--- a/rhachet.repo.yml
+++ b/rhachet.repo.yml
@@ -8,20 +8,6 @@ roles:
     skills:
       dirs: dist/domain.roles/achiever/skills
     boot: dist/domain.roles/achiever/boot.yml
-  - slug: thinker
-    readme: dist/domain.roles/thinker/readme.md
-    briefs:
-      dirs: dist/domain.roles/thinker/briefs
-    skills:
-      dirs: []
-  - slug: reviewer
-    readme: dist/domain.roles/reviewer/readme.md
-    briefs:
-      dirs: dist/domain.roles/reviewer/briefs
-    skills:
-      dirs: dist/domain.roles/reviewer/skills
-    boot: dist/domain.roles/reviewer/boot.yml
-    keyrack: dist/domain.roles/reviewer/keyrack.yml
   - slug: driver
     readme: dist/domain.roles/driver/readme.md
     briefs:
@@ -29,6 +15,13 @@ roles:
     skills:
       dirs: dist/domain.roles/driver/skills
     boot: dist/domain.roles/driver/boot.yml
+  - slug: learner
+    readme: dist/domain.roles/learner/readme.md
+    briefs:
+      dirs: dist/domain.roles/learner/briefs
+    skills:
+      dirs: []
+    boot: dist/domain.roles/learner/boot.yml
   - slug: librarian
     readme: dist/domain.roles/librarian/.readme.[seed].md
     briefs:
@@ -42,3 +35,17 @@ roles:
       dirs: []
     skills:
       dirs: dist/domain.roles/reflector/skills
+  - slug: reviewer
+    readme: dist/domain.roles/reviewer/readme.md
+    briefs:
+      dirs: dist/domain.roles/reviewer/briefs
+    skills:
+      dirs: dist/domain.roles/reviewer/skills
+    boot: dist/domain.roles/reviewer/boot.yml
+    keyrack: dist/domain.roles/reviewer/keyrack.yml
+  - slug: thinker
+    readme: dist/domain.roles/thinker/readme.md
+    briefs:
+      dirs: dist/domain.roles/thinker/briefs
+    skills:
+      dirs: []

--- a/src/domain.roles/getRoleRegistry.ts
+++ b/src/domain.roles/getRoleRegistry.ts
@@ -2,6 +2,7 @@ import { RoleRegistry } from 'rhachet';
 
 import { ROLE_ACHIEVER } from '@src/domain.roles/achiever/getAchieverRole';
 import { ROLE_DRIVER } from '@src/domain.roles/driver/getDriverRole';
+import { ROLE_LEARNER } from '@src/domain.roles/learner/getLearnerRole';
 import { ROLE_LIBRARIAN } from '@src/domain.roles/librarian/getLibrarianRole';
 import { ROLE_REFLECTOR } from '@src/domain.roles/reflector/getReflectorRole';
 import { ROLE_REVIEWER } from '@src/domain.roles/reviewer/getReviewerRole';
@@ -19,10 +20,11 @@ export const getRoleRegistry = (): RoleRegistry =>
     readme: { uri: __dirname + '/readme.md' },
     roles: [
       ROLE_ACHIEVER,
-      ROLE_THINKER,
-      ROLE_REVIEWER,
       ROLE_DRIVER,
+      ROLE_LEARNER,
       ROLE_LIBRARIAN,
       ROLE_REFLECTOR,
+      ROLE_REVIEWER,
+      ROLE_THINKER,
     ],
   });

--- a/src/domain.roles/learner/getLearnerRole.ts
+++ b/src/domain.roles/learner/getLearnerRole.ts
@@ -1,0 +1,31 @@
+import { Role } from 'rhachet';
+
+/**
+ * .what = learner role definition
+ * .why = enables durable retention of knowledge via lesson externalization
+ */
+export const ROLE_LEARNER: Role = Role.build({
+  slug: 'learner',
+  name: 'Learner',
+  purpose: 'durable retention of knowledge, externalize lessons into briefs',
+  readme: { uri: __dirname + '/readme.md' },
+  boot: { uri: __dirname + '/boot.yml' },
+  traits: [],
+  skills: {
+    dirs: [],
+    refs: [],
+  },
+  briefs: {
+    dirs: [{ uri: __dirname + '/briefs' }],
+  },
+  hooks: {
+    onBrain: {
+      onBoot: [
+        {
+          command: './node_modules/.bin/rhachet roles boot --role learner',
+          timeout: 'PT30S',
+        },
+      ],
+    },
+  },
+});

--- a/src/domain.roles/readme.md
+++ b/src/domain.roles/readme.md
@@ -22,6 +22,12 @@ used to review artifacts against declared rules. designed to be composed into re
 
 ---
 
+## 📜 learner
+
+used for durable retention of knowledge. externalizes lessons into briefs and tactics into skills.
+
+---
+
 ## 🔬 architect
 
 used to document and compare architectures of replic brains (LLMs behind REPLs).


### PR DESCRIPTION
fix(learner): register learner role in role registry

- create getLearnerRole.ts with Role.build definition
- import and add ROLE_LEARNER to getRoleRegistry.ts
- add learner section to domain.roles readme
- alphabetize roles array for consistency

---
🐢🌊 surfed in by seaturtle[bot]