### PR TITLE
fix(route): persist peer reviews to .reviews/peer/ for driver access

### DIFF
--- a/.behavior/v2026_06_17.fix-review-blocker-access/.bind/vlad.fix-review-blocker-access.flag
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/.bind/vlad.fix-review-blocker-access.flag
@@ -1,0 +1,2 @@
+branch: vlad/fix-review-blocker-access
+bound_by: init.behavior skill

--- a/.behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.arch-hazards-behavior.md
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.arch-hazards-behavior.md
@@ -1,0 +1,139 @@
+🦉 needs your talons
+   ├─ logs: .log/bhrain/review/2026-06-18T14-50-21-799Z
+   ├─ review: .behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.arch-hazards-behavior.md
+   └─ summary
+      ├─ 5 blockers 🔴
+      └─ 0 nitpicks
+
+---
+# blocker.1: Race condition on shared review/meter state
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md
+
+**locations**:
+- src/domain.operations/route/guard/runStoneGuardReviews.ts
+- src/domain.operations/route/judges/runStoneGuardJudges.ts
+
+Code performs read of cached artifacts and meters, then conditionally runs review command + writes artifacts + updates meters. No locks, transactions or atomic operations protect the read-modify-write. Concurrent executions (possible on retries, parallel stones, or multiple processes) for same stone+hash can both pass cache checks before writes, causing duplicate command execution, duplicate side effects, and double budget consumption.
+
+**snippet**:
+```ts
+const priorArtifacts = await getAllStoneGuardArtifactsByHash({
+  stone: input.stone,
+  hash: input.hash,
+  route: input.route,
+});
+const cachedReviews = priorArtifacts.reviews.filter(
+  (r) => r.exitClass === 'passed',
+);
+...
+const cachedReview = cachedReviews.find((r) => r.index === pr.index);
+if (cachedReview && cachedReview.blockers === 0) {
+  ...
+  continue;
+}
+...
+if (reviewCompleted) {
+  const newMeter = new RouteStoneGuardReviewPeerMeter({ ... rounds: rounds + 1 });
+  await setRouteStoneGuardReviewPeerMeter({ meter: newMeter, route: input.route });
+  meterBySlug.set(pr.slug, newMeter);
+}
+```
+
+---
+
+# blocker.2: Non-determinism from glob file ordering
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md
+
+**locations**:
+- src/domain.operations/route/guard/getLatestReviewArtifactForIndex.ts
+
+getLatestReviewArtifactForIndex collects reviewFiles from glob + legacy append, then iterates to pick highest iteration. Glob order is not guaranteed stable or sorted by filesystem. If multiple files tie for max iteration, different runs with identical inputs can select different latestFile (and thus different hash/path in returned artifact).
+
+**snippet**:
+```ts
+let latestFile: string | null = null;
+let latestIteration = -1;
+
+for (const filePath of reviewFiles) {
+  const filename = path.basename(filePath);
+  const iterMatch = filename.match(/\.i(\d+)\./);
+  ...
+  const iteration = parseInt(iterMatch[1], 10);
+  if (iteration > latestIteration) {
+    latestIteration = iteration;
+    latestFile = filePath;
+  }
+}
+```
+
+---
+
+# blocker.3: Unexpected default exitCode=0 on parse failure
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md
+
+**locations**:
+- src/domain.operations/route/guard/getAllStoneGuardArtifactsByHash.ts
+- src/domain.operations/route/guard/getLatestReviewArtifactForIndex.ts
+- src/domain.operations/route/guard/runStoneGuardReviews.ts
+- src/domain.operations/route/judges/runStoneGuardJudges.ts
+
+Parse functions default exitCode to 0 (treated as passed) when regex fails to match. Malformed or unexpected output is silently treated as success, leading to incorrect caching, verdicts, and artifacts. Violates rule against unexpected defaults and non-obvious fallbacks.
+
+**snippet**:
+```ts
+const exitCodeMatch = content.match(/exit code:\s*(\d+)/);
+const exitCode = exitCodeMatch?.[1] ? parseInt(exitCodeMatch[1], 10) : 0;
+const exitClass = getExitCodeClass({ code: exitCode });
+```
+
+---
+
+# blocker.4: Fragile message-based git root fallback
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md
+
+**locations**:
+- src/domain.operations/route/guard/runStoneGuardReviews.ts
+- src/domain.operations/route/guard/runStoneGuardReviews.ts
+- src/domain.operations/route/judges/runStoneGuardJudges.ts
+
+Catches getGitRepoRoot errors by exact message includes('Not inside a Git') then falls back to process.cwd(). Message is brittle (lib change breaks behavior), fallback to cwd is context-dependent (tests vs prod, chdir), producing non-deterministic paths and different execution results under same logical inputs.
+
+**snippet**:
+```ts
+try {
+  repoRoot = await getGitRepoRoot({ from: input.route });
+} catch (error) {
+  const isNotInGitRepoError =
+    error instanceof Error && error.message.includes('Not inside a Git');
+  if (!isNotInGitRepoError) throw error;
+  repoRoot = process.cwd();
+}
+```
+
+---
+
+# blocker.5: Time assumption with hardcoded exec timeout
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md
+
+**locations**:
+- src/domain.operations/route/guard/runStoneGuardReviews.ts
+
+Fixed 21-minute timeout (only env override) with no backoff, max attempts, or adaptive logic. Assumes network/disk/exec latency bounds that may not hold; invalid env value yields NaN timeout. Leads to intermittent kills or hangs under load.
+
+**snippet**:
+```ts
+const REVIEW_TIMEOUT_MS =
+  process.env.RHACHET_REVIEW_TIMEOUT_MS !== undefined
+    ? parseInt(process.env.RHACHET_REVIEW_TIMEOUT_MS, 10)
+    : 21 * 60 * 1000;
+...
+const result = await execAsync(cmd, {
+  env: execEnv,
+  timeout: REVIEW_TIMEOUT_MS,
+});
+```

--- a/.behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.arch-hazards-maintenance.md
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.arch-hazards-maintenance.md
@@ -1,0 +1,309 @@
+🦉 needs your talons
+   ├─ logs: .log/bhrain/review/2026-06-18T14-49-14-696Z
+   ├─ review: .behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.arch-hazards-maintenance.md
+   └─ summary
+      ├─ 8 blockers 🔴
+      └─ 0 nitpicks
+
+---
+# blocker.1: failhide: bare catch swallows unexpected errors from getGitRepoRoot
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md
+
+**locations**:
+- src/domain.operations/route/guard/runStoneGuardJudges.ts
+
+Maintenance hazard: catch must allowlist expected errors and rethrow unexpected ones. Silent swallow hides real errors causing debug hours or silent defects. Here any error from getGitRepoRoot (not just git-missing) is ignored by falling back to cwd. This violates failhide and failfast.
+
+**snippet**:
+```ts
+let repoRoot: string;
+try {
+  repoRoot = await getGitRepoRoot({ from: input.route });
+} catch {
+  repoRoot = process.cwd();
+}
+```
+
+---
+
+# blocker.2: failhide: bare catch swallows unexpected errors from enumFilesFromGlob
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md
+
+**locations**:
+- src/domain.operations/route/guard/runStoneGuardJudges.ts
+
+Maintenance hazard: bare catch {} without allowlisting or rethrowing. Any error (not just missing dir) is silently ignored. Should use isENOENT check and rethrow others per failhide rule.
+
+**snippet**:
+```ts
+let priorJudgeFiles: string[] = [];
+try {
+  priorJudgeFiles = await enumFilesFromGlob({
+    glob: judgeGlob,
+    cwd: routeDir,
+  });
+} catch {
+  // .route/ may not exist yet
+}
+```
+
+---
+
+# blocker.3: failhide: catch does not rethrow unexpected errors in runOneStoneGuardJudge
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md
+
+**locations**:
+- src/domain.operations/route/guard/runStoneGuardJudges.ts
+
+Maintenance hazard: catch only partially handles shape, proceeds silently if error is not object (no rethrow). Unexpected errors must be rethrown per failhide and failfast. Also uses as-cast which bypasses types.
+
+**snippet**:
+```ts
+} catch (error: unknown) {
+  // capture output and exit code even on failure
+  if (error && typeof error === 'object') {
+    const errObj = error as Record<string, unknown>;
+    stdout = typeof errObj.stdout === 'string' ? errObj.stdout : '';
+    stderr = typeof errObj.stderr === 'string' ? errObj.stderr : '';
+    exitCode = typeof errObj.code === 'number' ? errObj.code : 1;
+  }
+}
+```
+
+---
+
+# blocker.4: immutability: let with reassignment for reviewFiles
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md
+
+**locations**:
+- src/domain.operations/route/guard/getAllStoneGuardArtifactsByHash.ts
+
+Maintenance hazard: use const not let; no assignment mutation. Reassigning let reviewFiles with spread creates mutable state that is hard to reason about and risks side effects on retry.
+
+**snippet**:
+```ts
+let reviewFiles: string[] = [];
+try {
+  await fs.access(reviewsDir);
+  const reviewGlob = `${input.stone.name}._.review.*.${input.hash}.*._.given.by_peer.*.md`;
+  reviewFiles = await enumFilesFromGlob({
+    glob: reviewGlob,
+    cwd: reviewsDir,
+  });
+} catch (error) {
+  if (!isENOENT(error)) throw error;
+}
+
+// check legacy .route/ for backwards compat
+try {
+  await fs.access(routeDir);
+  const legacyGlob = `${input.stone.name}.guard.review.*.${input.hash}.*.md`;
+  const legacyFiles = await enumFilesFromGlob({
+    glob: legacyGlob,
+    cwd: routeDir,
+  });
+  reviewFiles = [...reviewFiles, ...legacyFiles];
+} catch (error) {
+  if (!isENOENT(error)) throw error;
+}
+```
+
+---
+
+# blocker.5: immutability: let with reassignment for reviewFiles and iteration tracking
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md
+
+**locations**:
+- src/domain.operations/route/guard/getLatestReviewArtifactForIndex.ts
+
+Maintenance hazard: let + assignment mutation. latestFile and latestIteration are mutated in loop; reviewFiles reassigned. Violates immutability rule: use const + spread/clone instead of let/assignment.
+
+**snippet**:
+```ts
+let reviewFiles: string[] = [];
+try {
+  await fs.access(reviewsDir);
+  const reviewGlob = `${input.stone.name}._.review.*.r${input.index}._.given.by_peer.*.md`;
+  reviewFiles = await enumFilesFromGlob({
+    glob: reviewGlob,
+    cwd: reviewsDir,
+  });
+} catch (error) {
+  if (!isENOENT(error)) throw error;
+}
+
+// check legacy .route/ for backwards compat
+try {
+  await fs.access(routeDir);
+  const legacyGlob = `${input.stone.name}.guard.review.*.r${input.index}.md`;
+  const legacyFiles = await enumFilesFromGlob({
+    glob: legacyGlob,
+    cwd: routeDir,
+  });
+  reviewFiles = [...reviewFiles, ...legacyFiles];
+} catch (error) {
+  if (!isENOENT(error)) throw error;
+}
+
+if (reviewFiles.length === 0) return null;
+
+// find the file with highest iteration
+let latestFile: string | null = null;
+let latestIteration = -1;
+
+for (const filePath of reviewFiles) {
+  const filename = path.basename(filePath);
+  const iterMatch = filename.match(/\.i(\d+)\./);
+
+  if (!iterMatch?.[1])
+    UnexpectedCodePathError.throw(
+      'review file lacks iteration marker in filename',
+      { filename, filePath },
+    );
+  const iteration = parseInt(iterMatch[1], 10);
+
+  if (iteration > latestIteration) {
+    latestIteration = iteration;
+    latestFile = filePath;
+  }
+}
+```
+
+---
+
+# blocker.6: immutability: in-place mutation of const arrays with push
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md
+
+**locations**:
+- src/domain.operations/route/guard/runStoneGuardReviews.ts
+
+Maintenance hazard: const array + .push mutates state. Rule requires no in-place mutation; use spread or immutable patterns. This appears in accumulation of reviews and exhausted slugs, creating shared mutable state.
+
+**snippet**:
+```ts
+const reviews: RouteStoneGuardReviewArtifact[] = [];
+
+const exhaustedReviewerSlugs: string[] = [];
+
+// ... later in loop
+if (cachedReview && cachedReview.blockers === 0) {
+  ...
+  reviews.push(cachedReview);
+  continue;
+}
+
+if (isReviewPeerVerdictExhausted(verdict)) {
+  ...
+  if (reviewForDisplay) {
+    reviews.push(reviewForDisplay);
+  }
+  ...
+  exhaustedReviewerSlugs.push(pr.slug);
+  continue;
+}
+
+if (cachedReview && cachedReview.blockers > 0) {
+  ...
+  reviews.push(cachedReview);
+  continue;
+}
+
+...
+reviews.push(review);
+```
+
+---
+
+# blocker.7: immutability: let + push mutation in judges accumulation
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md
+
+**locations**:
+- src/domain.operations/route/guard/runStoneGuardJudges.ts
+
+Maintenance hazard: let reassignment and const array + push. priorJudgeFiles reassigned in try, judges array mutated with push. Violates immutability: prefer const + immutable updates.
+
+**snippet**:
+```ts
+let priorJudgeFiles: string[] = [];
+try {
+  priorJudgeFiles = await enumFilesFromGlob({
+    glob: judgeGlob,
+    cwd: routeDir,
+  });
+} catch {
+  // .route/ may not exist yet
+}
+
+...
+const judges: RouteStoneGuardJudgeArtifact[] = [];
+
+for (let i = 0; i < input.guard.judges.length; i++) {
+  ...
+  if (prior) {
+    ...
+    continue;
+  }
+  ...
+  const judge = await runOneStoneGuardJudge({...});
+  ...
+  judges.push(judge);
+}
+
+return judges;
+```
+
+---
+
+# blocker.8: immutability: multiple let + reassignment in delStoneGuardArtifacts
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md
+
+**locations**:
+- src/domain.operations/route/stones/delStoneGuardArtifacts.ts
+
+Maintenance hazard: several let declarations reassigned conditionally. peerReviewFiles, legacyReviewFiles, judgeFiles etc. use let + assignment instead of const + immutable construction. Compounds maintenance cost.
+
+**snippet**:
+```ts
+let peerReviewFiles: string[] = [];
+try {
+  await fs.access(reviewsDir);
+  peerReviewFiles = await enumFilesFromGlob({...});
+} catch (error) {
+  if (!isENOENT(error)) throw error;
+}
+
+let routeDirExists = false;
+try {
+  await fs.access(routeDir);
+  routeDirExists = true;
+} catch (error) {
+  if (!isENOENT(error)) throw error;
+}
+
+let legacyReviewFiles: string[] = [];
+if (routeDirExists) {
+  legacyReviewFiles = await enumFilesFromGlob({...});
+}
+
+const reviewFiles = [...peerReviewFiles, ...legacyReviewFiles];
+
+let judgeFiles: string[] = [];
+let promiseFiles: string[] = [];
+let triggerFiles: string[] = [];
+let blockedTriggerFiles: string[] = [];
+
+if (routeDirExists) {
+  judgeFiles = await enumFilesFromGlob({...});
+  promiseFiles = await enumFilesFromGlob({...});
+  triggerFiles = await enumFilesFromGlob({...});
+  blockedTriggerFiles = await enumFilesFromGlob({...});
+}
+```

--- a/.behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.arch-opport-decomposition.md
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.arch-opport-decomposition.md
@@ -1,0 +1,234 @@
+🦉 needs your talons
+   ├─ logs: .log/bhrain/review/2026-06-18T14-47-26-015Z
+   ├─ review: .behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.arch-opport-decomposition.md
+   └─ summary
+      ├─ 4 blockers 🔴
+      └─ 2 nitpicks 🟠
+
+---
+# blocker.1: orchestrator with decode-friction inline
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md
+
+**locations**:
+- src/domain.operations/route/guard/runStoneGuardReviews.ts:280
+- src/domain.operations/route/guard/runStoneGuardReviews.ts:300
+
+runStoneGuardReviews is an orchestrator but contains large amounts of inline compute logic (mapping, sorting, closures for verdicts, complex conditionals with ?? and hash checks). This violates grain clarity and narrative requirement. Each line should delegate to named leaf operations (transformers for compute, communicators for i/o). Extract maps/sorts/conditionals to transformers like getPeerReviewsWithIndex and computeVerdictsForReviews.
+
+**snippet**:
+```ts
+const peerReviewsWithIndex = peerReviews.map((review, i) => ({
+  review,
+  index: i + 1,
+  arrayIndex: i,
+  slug: getReviewPeerSlug(review),
+  level: getReviewPeerLevel(review),
+  budget: getReviewPeerBudget(review),
+}));
+peerReviewsWithIndex.sort((a, b) => a.level - b.level);
+
+const computeVerdicts = () =>
+  peerReviewsWithIndex.map((pr) => {
+    const meter = meterBySlug.get(pr.slug);
+    const rounds = meter?.rounds ?? 0;
+    const freshReview = reviews.find((r) => r.index === pr.index);
+    const cachedReview = cachedReviews.find((r) => r.index === pr.index);
+    const review = freshReview ?? cachedReview;
+    const blockers = review?.blockers ?? Infinity;
+    const hasReviewForHash = review?.hash === input.hash;
+    const wasExhausted = !hasReviewForHash && rounds >= pr.budget;
+    return {
+      slug: pr.slug,
+      level: pr.level,
+      verdict: computeReviewPeerVerdict({
+        rounds,
+        budget: pr.budget,
+        blockers,
+        nitpicks: review?.nitpicks ?? 0,
+        exitClass: review?.exitClass,
+        allowBlockers,
+        allowNitpicks,
+        wasExhausted,
+      }),
+    };
+  });
+```
+
+---
+
+# blocker.2: mixed grains in communicator operation
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md
+
+**locations**:
+- src/domain.operations/route/guard/getAllStoneGuardArtifactsByHash.ts:80
+- src/domain.operations/route/guard/getAllStoneGuardArtifactsByHash.ts:110
+
+getAllStoneGuardArtifactsByHash performs raw i/o (fs.access, enumFilesFromGlob, readFile) mixed with parsing/compute logic. Violates grain clarity (should be pure communicator for i/o only). Parsing should be extracted to separate transformers (e.g. parseReviewArtifact). Same pattern in getLatestReviewArtifactForIndex.
+
+**snippet**:
+```ts
+const reviews: RouteStoneGuardReviewArtifact[] = [];
+for (const filePath of reviewFiles) {
+  const content = await fs.readFile(filePath, 'utf-8');
+  const parsed = parseReviewMetadata(filePath, content);
+  reviews.push(
+    new RouteStoneGuardReviewArtifact({
+      stone: { path: input.stone.path },
+      hash: input.hash,
+      iteration: parsed.iteration,
+      index: parsed.index,
+      path: filePath,
+      blockers: parsed.blockers,
+      nitpicks: parsed.nitpicks,
+      exitCode: parsed.exitCode,
+      exitClass: parsed.exitClass,
+      stdout: parsed.stdout,
+      stderr: parsed.stderr,
+      durationMs: parsed.durationMs,
+    }),
+  );
+}
+```
+
+---
+
+# blocker.3: multiple operations per file violates single responsibility
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md
+
+**locations**:
+- src/domain.operations/route/guard/runStoneGuardReviews.ts:100
+- src/domain.operations/route/guard/runStoneGuardReviews.ts:250
+- src/domain.operations/route/judges/runStoneGuardJudges.ts:80
+- src/domain.operations/route/judges/runStoneGuardJudges.ts:200
+
+runStoneGuardReviews.ts exports two operations (runOneStoneGuardReview and runStoneGuardReviews). Each file must contain exactly one operation for decomposability. Same violation in runStoneGuardJudges.ts. This prevents safe recomposition.
+
+**snippet**:
+```ts
+export const runOneStoneGuardReview = async (input: {
+  stone: RouteStone;
+  reviewCmd: string;
+  index: number;
+  hash: string;
+  iteration: number;
+  route: string;
+  slug: string;
+}): Promise<RouteStoneGuardReviewArtifact> => {
+  ...
+};
+
+export const runStoneGuardReviews = async (
+  input: {
+    stone: RouteStone;
+    guard: RouteStoneGuard;
+    hash: string;
+    iteration: number;
+    route: string;
+  },
+  context: ContextCliEmit,
+): Promise<{
+  artifacts: RouteStoneGuardReviewArtifact[];
+  exhaustedReviewerSlugs: string[];
+}> => {
+```
+
+---
+
+# blocker.4: mixed grains in runOneStoneGuardReview
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md
+
+**locations**:
+- src/domain.operations/route/guard/runStoneGuardReviews.ts:150
+
+runOneStoneGuardReview mixes raw i/o (execAsync, fs.writeFile) with inline compute (artifactLines formatting, counts parsing, duration regex). Should decompose into communicator for exec/write and transformer for formatting/parsing.
+
+**snippet**:
+```ts
+const artifactLines: string[] = [];
+artifactLines.push(formatTreeBucket({ label: 'stdout', content: stdout }));
+artifactLines.push(formatTreeBucket({ label: 'stderr', content: stderr }));
+if (exitCode !== 0) {
+  const blockReason =
+    exitClass === 'constraint'
+      ? 'blocked by constraints'
+      : 'blocked by malfunction';
+  const exitEmoji = exitClass === 'constraint' ? '✋' : '💥';
+  artifactLines.push('└─ passage blocked');
+  artifactLines.push(`   ├─ ${blockReason}`);
+  artifactLines.push(`   └─ exit code: ${exitCode} ${exitEmoji}`);
+}
+const artifactContent = artifactLines.join('\n');
+await fs.writeFile(stdoutPath, artifactContent);
+const counts = getReviewCountsFromContent({ content: stdout });
+const { blockers, nitpicks } = counts;
+const durationMatch = stdout.match(/total:\s*(\d+)ms/i);
+const durationMs = durationMatch?.[1] ? parseInt(durationMatch[1], 10) : null;
+```
+
+---
+
+# nitpick.1: decode-friction in filename parsing
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md
+
+**locations**:
+- src/domain.operations/route/guard/getAllStoneGuardArtifactsByHash.ts:200
+
+parseReviewMetadata and parseJudgeMetadata contain inline regex and string manipulation that requires simulation. Although in helper functions, this decode-friction should be in dedicated named transformers for recomposability.
+
+**snippet**:
+```ts
+const filename = path.basename(filePath);
+const iterMatch = filename.match(/\.i(\d+)\./);
+if (!iterMatch?.[1])
+  UnexpectedCodePathError.throw(
+    'review file lacks iteration marker in filename',
+    { filename, filePath },
+  );
+const iteration = parseInt(iterMatch[1], 10);
+const indexMatch = filename.match(/\.r(\d+)\./);
+const indexMatchLegacy = !indexMatch ? filename.match(/\.r(\d+)\.md$/) : null;
+const indexMatchResult = indexMatch ?? indexMatchLegacy;
+if (!indexMatchResult?.[1])
+  UnexpectedCodePathError.throw(
+    'review file lacks reviewer index in filename',
+    { filename, filePath },
+  );
+const index = parseInt(indexMatchResult[1], 10);
+```
+
+---
+
+# nitpick.2: duplicated logic across operations
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md
+
+**locations**:
+- src/domain.operations/route/guard/getAllStoneGuardArtifactsByHash.ts:280
+- src/domain.operations/route/guard/getLatestReviewArtifactForIndex.ts:140
+- src/domain.operations/route/guard/runStoneGuardReviews.ts:400
+- src/domain.operations/route/judges/runStoneGuardJudges.ts:350
+
+Filename parsing, tree bucket extraction, and variable substitution logic is duplicated across getAllStoneGuardArtifactsByHash, getLatestReviewArtifactForIndex, runStoneGuardReviews, and runStoneGuardJudges. Duplication should be extracted to shared transformers after 3+ usages for recomposition.
+
+**snippet**:
+```ts
+const rhxPath = path.join(vars.repoRoot, 'node_modules', '.bin', 'rhx');
+const rhachetPath = path.join(
+  vars.repoRoot,
+  'node_modules',
+  '.bin',
+  'rhachet',
+);
+return cmd
+  .replace(/\$stone/g, vars.stone)
+  .replace(/\$route/g, vars.route)
+  .replace(/\$hash/g, vars.hash)
+  .replace(/\$output/g, vars.output)
+  .replace(/\$rhx/g, rhxPath)
+  .replace(/\$rhachet/g, rhachetPath);
+```

--- a/.behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.arch-smell-scopeleaks.md
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.arch-smell-scopeleaks.md
@@ -1,0 +1,47 @@
+🦉 needs your talons
+   ├─ logs: .log/bhrain/review/2026-06-18T14-48-17-117Z
+   ├─ review: .behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.arch-smell-scopeleaks.md
+   └─ summary
+      ├─ 2 blockers 🔴
+      └─ 0 nitpicks
+
+---
+# blocker.1: Cross-domain scope leak: domain.operations imports from domain.objects/Driver internals
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md
+
+**locations**:
+- src/domain.operations/route/guard/getAllStoneGuardArtifactsByHash.ts
+- src/domain.operations/route/guard/getLatestReviewArtifactForIndex.ts
+- src/domain.operations/route/guard/runStoneGuardReviews.ts
+- src/domain.operations/route/judges/runStoneGuardJudges.ts
+- src/domain.operations/route/guard/getLatestReviewArtifactForIndex.test.ts
+- src/domain.operations/route/guard/runStoneGuardReviews.integration.test.ts
+
+Code in domain.operations/route/guard/ and domain.operations/route/judges/ directly imports types and classes from @src/domain.objects/Driver/ (e.g. RouteStone, RouteStoneGuardReviewArtifact, RouteStoneGuard, ContextCliEmit). This violates bounded context boundaries: the Driver domain owns its models and objects. Operations in other domains (route/guard, route/judges) must not reach into another domain's internals. Use contracts, shared interfaces, or explicit exports instead of direct imports from domain.objects/Driver/. Scope leaks entangle domains and block independent evolution.
+
+**snippet**:
+```ts
+import type { RouteStone } from '@src/domain.objects/Driver/RouteStone';
+import { RouteStoneGuardReviewArtifact } from '@src/domain.objects/Driver/RouteStoneGuardReviewArtifact';
+import { RouteStoneGuardJudgeArtifact } from '@src/domain.objects/Driver/RouteStoneGuardJudgeArtifact';
+```
+
+---
+
+# blocker.2: Cross-domain scope leak: reach-in between submodules under domain.operations/route/
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md
+
+**locations**:
+- src/domain.operations/route/stones/delStoneGuardArtifacts.ts
+- src/domain.operations/route/judges/runStoneGuardJudges.ts
+
+Code in domain.operations/route/stones/ and domain.operations/route/judges/ reaches into domain.operations/route/guard/ internals (e.g. isENOENT, formatTreeBucket, getExitCodeClass). If guard/, judges/, and stones/ represent separate bounded contexts or sub-contexts, this is a directional/reach-in violation. Lower or sibling modules must not import from other domains' internals; use contracts instead of direct file imports across route/ subfolders. This creates hidden dependencies and violates the rule that each domain owns its logic and procedures.
+
+**snippet**:
+```ts
+import { isENOENT } from '@src/domain.operations/route/guard/isENOENT';
+import { formatTreeBucket } from '@src/domain.operations/route/guard/formatTreeBucket';
+import { getExitCodeClass } from '@src/domain.operations/route/guard/getExitCodeClass';
+```

--- a/.behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.behavior-intent-coverage.md
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.behavior-intent-coverage.md
@@ -1,0 +1,130 @@
+🦉 needs your talons
+   ├─ logs: .log/bhrain/review/2026-06-18T14-51-48-612Z
+   ├─ review: .behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.behavior-intent-coverage.md
+   └─ summary
+      ├─ 3 blockers 🔴
+      └─ 2 nitpicks 🟠
+
+---
+# blocker.1: stdout artifact does not contain report path
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md
+
+**locations**:
+- src/domain.operations/route/guard/runStoneGuardReviews.ts:140
+- src/domain.operations/route/guard/runStoneGuardReviews.ts:95
+
+Vision requires: 'stdout contains path to report file' and shows example content with 'report: ...report.md' so drivers can follow from the review stdout file to the detailed report. Implementation computes reportPath and substitutes $output but never inserts the report path into artifactContent. The written file only contains tree-bucket-wrapped stdout/stderr from the review command (plus optional passage blocked). Drivers reading the .md file will not see the report path unless the review command happens to print it, violating the explicit usecase and acceptance test.
+
+**snippet**:
+```ts
+  // write stdout artifact file
+  await fs.writeFile(stdoutPath, artifactContent);
+
+  // ...
+  const artifactLines: string[] = [];
+  artifactLines.push(formatTreeBucket({ label: 'stdout', content: stdout }));
+  artifactLines.push(formatTreeBucket({ label: 'stderr', content: stderr }));
+  if (exitCode !== 0) { ... }
+  const artifactContent = artifactLines.join('\n');
+```
+
+---
+
+# blocker.2: custom output path not supported
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md
+
+**locations**:
+- src/domain.operations/route/guard/runStoneGuardReviews.ts:80
+- src/domain.operations/route/guard/runStoneGuardReviews.ts:95
+
+Vision explicitly defines test 2 for custom --output paths: report goes to custom location, stdout goes to symmetric name, and stdout must contain the (custom) report path. Code always hardcodes reportPath and stdoutPath to the symmetric pattern and always substitutes $output with the symmetric reportPath. If a guard uses a custom path without $output, the substitution does not capture it, no pointer is written, and reportPath var is unused for linking.
+
+**snippet**:
+```ts
+  const stdoutPath = path.join(
+    reviewsDir,
+    `${input.stone.name}._.review.i${input.iteration}.${input.hash}.r${input.index}._.given.by_peer.${input.slug}.md`,
+  );
+  const reportPath = path.join(
+    reviewsDir,
+    `${input.stone.name}._.review.i${input.iteration}.${input.hash}.r${input.index}._.given.by_peer.${input.slug}.report.md`,
+  );
+  const cmd = substituteVars(input.reviewCmd, {
+    ...
+    output: reportPath,
+    ...
+  });
+```
+
+---
+
+# blocker.3: review glob includes .report.md files
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md
+
+**locations**:
+- src/domain.operations/route/guard/getAllStoneGuardArtifactsByHash.ts:42
+- src/domain.operations/route/guard/getLatestReviewArtifactForIndex.ts:38
+
+Vision requires separate stdout (.md) and report (.report.md) files with symmetric prefixes. getAllStoneGuardArtifactsByHash and getLatestReviewArtifactForIndex use globs that match both patterns (.*.md after by_peer matches slug.report.md). These report files are then fed to parseReviewMetadata and treated as review artifacts, causing incorrect artifacts, duplicate data, and wrong counts. No filter excludes .report.md.
+
+**snippet**:
+```ts
+  const reviewGlob = `${input.stone.name}._.review.*.${input.hash}.*._.given.by_peer.*.md`;
+  reviewFiles = await enumFilesFromGlob({
+    glob: reviewGlob,
+    cwd: reviewsDir,
+  });
+  // ...
+  for (const filePath of reviewFiles) {
+    const content = await fs.readFile(filePath, 'utf-8');
+    const parsed = parseReviewMetadata(filePath, content);
+    reviews.push(new RouteStoneGuardReviewArtifact({...}));
+```
+
+---
+
+# nitpick.1: no test coverage for $output substitution or report path
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md
+
+**locations**:
+- src/domain.operations/route/guard/runStoneGuardReviews.integration.test.ts:120
+- src/domain.operations/route/guard/runStoneGuardReviews.integration.test.ts:200
+
+Vision acceptance tests require --output $output, custom paths, and 'stdout contains path to report'. Integration tests use only echo commands with no $output, no custom paths, and never assert report path presence in written files or that report files are produced. Snapshots exist but do not cover the required user journeys.
+
+**snippet**:
+```ts
+  asPeerReview('echo "blockers: 0\nnitpicks: 1\nreview output"', 0),
+  // ...
+  const result = await runStoneGuardReviews(...);
+  expect(result.artifacts[0]?.path).toContain('.reviews/peer/...');
+  // no assertion on $output, no custom path test, no 'contains report path'
+```
+
+---
+
+# nitpick.2: stdout file format does not match vision example
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md
+
+**locations**:
+- src/domain.operations/route/guard/runStoneGuardReviews.ts:120
+
+Vision shows the stdout .md file content as a flat '🦉 needs your talons' tree containing 'report:' and summary. Implementation always wraps review command output in '├─ stdout' / '├─ stderr' tree buckets (plus passage footer on error). While tests assert the tree format, this does not produce the exact structure shown in the vision's driver UX example.
+
+**snippet**:
+```ts
+  const artifactLines: string[] = [];
+  artifactLines.push(formatTreeBucket({ label: 'stdout', content: stdout }));
+  artifactLines.push(formatTreeBucket({ label: 'stderr', content: stderr }));
+  if (exitCode !== 0) {
+    artifactLines.push('└─ passage blocked');
+    ...
+  }
+  const artifactContent = artifactLines.join('\n');
+  await fs.writeFile(stdoutPath, artifactContent);
+```

--- a/.behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.ergo-friction-hazards.md
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.ergo-friction-hazards.md
@@ -1,0 +1,139 @@
+🦉 needs your talons
+   ├─ logs: .log/bhrain/review/2026-06-18T14-53-54-964Z
+   ├─ review: .behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.ergo-friction-hazards.md
+   └─ summary
+      ├─ 5 blockers 🔴
+      └─ 1 nitpicks 🟠
+
+---
+# blocker.1: unclear malfunction error messages
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md
+
+**locations**:
+- src/domain.operations/route/guard/runStoneGuardReviews.ts:330
+- src/domain.operations/route/guard/runStoneGuardReviews.ts:290
+
+Error messages shown to users via onGuardProgress for review malfunctions (including timeouts) are generic and not actionable. They do not explain what went wrong (e.g. timeout details) or how to fix it. Per the rule, errors must tell the user what went wrong AND how to fix it. The specific timeout text is only in stderr of the artifact file, while progress uses a generic message. This degrades trust and causes support friction.
+
+**snippet**:
+```ts
+const reviewOutcome = (() => {
+      if (review.exitClass === 'malfunction')
+        return {
+          malfunction: `review command failed with exit code ${review.exitCode}`,
+        };
+```
+
+---
+
+# blocker.2: unclear error for npx usage in guards
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md
+
+**locations**:
+- src/domain.operations/route/guard/runStoneGuardReviews.ts:470
+- src/domain.operations/route/judges/runStoneGuardJudges.ts:260
+
+When a guard uses npx rhachet or npx rhx, the thrown error message does not include the actionable fix suggestion directly. The fix is buried in a 'hint' object. Per the rule, error messages must be actionable and tell the user how to fix it (see 'Invalid phone format' example). Users will see a confusing error without clear resolution steps in the primary message. Same logic duplicated in judges file.
+
+**snippet**:
+```ts
+BadRequestError.throw(
+      `guard uses ${pattern} which causes latency and cross-platform issues`,
+      {
+        pattern,
+        hint: `use ${alias} alias instead — ${alias} expands to ./node_modules/.bin/${alias.slice(1)}`,
+      },
+    );
+```
+
+---
+
+# blocker.3: unclear and inconsistent blocked state communication
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md
+
+**locations**:
+- src/domain.objects/Driver/GuardProgressEvent.ts:40
+- src/domain.operations/route/guard/runStoneGuardReviews.ts:240
+- src/domain.operations/route/judges/runStoneGuardJudges.ts:130
+
+Blocked states (cached, exhausted, queued, malfunction) are signaled inconsistently between reviews and judges via onGuardProgress events. Cached reviews emit outcome data while cached judges emit both inflight and outcome as null (per interface note this means 'cached' but contradicts review handling). Exhausted and queued use special shapes. This violates 'blocked states clearly communicated' and 'flow friction' requirements. Users cannot reliably understand progress or blocked states from live feedback without looking at artifacts.
+
+**snippet**:
+```ts
+if (prior) {
+      // emit cached event for progress output
+      context.cliEmit.onGuardProgress({
+        stone: input.stone,
+        step: { phase: 'judge', index: i },
+        inflight: null,
+        outcome: null,
+      });
+      judges.push(prior);
+      continue;
+    }
+```
+
+---
+
+# blocker.4: parsing defaults hide errors and create unclear outcomes
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md
+
+**locations**:
+- src/domain.operations/route/guard/getAllStoneGuardArtifactsByHash.ts:140
+- src/domain.operations/route/guard/getAllStoneGuardArtifactsByHash.ts:200
+
+Parsing logic for artifacts defaults exitCode to 0 (passed) and other fields to empty/false when markers are missing. This risks misclassifying failures as success or hiding blocked states, especially for legacy files or format changes. Per the rule, hidden blocked states must throw with clear message and be snapped. No clear error or drift detection for users when outputs change.
+
+**snippet**:
+```ts
+const exitCode = exitCodeMatch?.[1] ? parseInt(exitCodeMatch[1], 10) : 0;
+  const exitClass = getExitCodeClass({ code: exitCode });
+
+  // extract stdout/stderr from tree buckets
+  const { stdout, stderr } = parseTreeBuckets(content);
+```
+
+---
+
+# blocker.5: unclear internal error messages for users
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md
+
+**locations**:
+- src/domain.operations/route/guard/getAllStoneGuardArtifactsByHash.ts:80
+- src/domain.operations/route/guard/getLatestReviewArtifactForIndex.ts:70
+- src/domain.operations/route/guard/getAllStoneGuardArtifactsByHash.ts:180
+
+UnexpectedCodePathError messages like 'review file lacks iteration marker in filename' are shown for parsing failures. These are not actionable (no explanation of cause or fix) and violate 'error clarity' and 'actionable' requirements. Users hitting malformed artifacts or legacy data will see unhelpful errors instead of clear guidance.
+
+**snippet**:
+```ts
+if (!iterMatch?.[1])
+    UnexpectedCodePathError.throw(
+      'review file lacks iteration marker in filename',
+      { filename, filePath },
+    );
+```
+
+---
+
+# nitpick.1: timeout message not surfaced in progress outcome
+
+**rule**: .agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md
+
+**locations**:
+- src/domain.operations/route/guard/runStoneGuardReviews.ts:260
+
+Timeout sets a detailed message in stderr but the onGuardProgress outcome uses a generic malfunction string. This creates output inconsistency across invocations and hides details from live CLI feedback. Should surface the timeout reason directly in the outcome for smooth UX.
+
+**snippet**:
+```ts
+if (errObj.killed === true) {
+      stderr = `💥 malfunction: review timed out after ${Math.floor(REVIEW_TIMEOUT_MS / 60000)} minutes`;
+      exitCode = 1;
+    }
+```

--- a/.behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.mech-decode-friction.md
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.mech-decode-friction.md
@@ -1,0 +1,142 @@
+🦉 needs your talons
+   ├─ logs: .log/bhrain/review/2026-06-18T14-46-22-903Z
+   ├─ review: .behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.mech-decode-friction.md
+   └─ summary
+      ├─ 5 blockers 🔴
+      └─ 0 nitpicks
+
+---
+# blocker.1: Inline regex filename parsing in getLatestReviewArtifactForIndex
+
+**rule**: rule.forbid.inline-decode-friction.md
+
+**locations**:
+- src/domain.operations/route/guard/getLatestReviewArtifactForIndex.ts
+
+The orchestrator function getLatestReviewArtifactForIndex performs inline decode-friction using regex matches and positional array access (e.g. match[1]) to extract iteration and hash from filenames. This requires mental simulation of regex patterns and fallback logic to understand what is produced. Per the rule, decode-friction must be extracted to named transformers so orchestrators read as narrative.
+
+**snippet**:
+```ts
+    const filename = path.basename(latestFile);
+
+    // extract hash from filename (works for both old and new patterns)
+    // - old: .i$iter.$hash.r$n.md (hash followed by .rN.md)
+    // - new: .i$iter.$hash.r$n._.given... (hash followed by .rN. then more segments)
+    const hashMatch = filename.match(/\.i\d+\.([a-f0-9]+)\.r\d+[._]/);
+
+    // hash is required - file matched our glob, must have hash
+    if (!hashMatch?.[1])
+      UnexpectedCodePathError.throw('review file lacks hash in filename', {
+        filename,
+        filePath: latestFile,
+      });
+    const hash = hashMatch[1];
+```
+
+---
+
+# blocker.2: Inline complex conditionals and IIFE for review outcome in runStoneGuardReviews
+
+**rule**: rule.forbid.inline-decode-friction.md
+
+**locations**:
+- src/domain.operations/route/guard/runStoneGuardReviews.ts
+
+The orchestrator runStoneGuardReviews contains inline decode-friction via complex boolean expressions (isGenuineConstraint, reviewCompleted) and an immediately-invoked function expression to determine reviewOutcome shape based on exitClass and blockers. Readers must mentally simulate the conditions to understand the produced outcome object. This logic must be extracted to a named transformer (e.g. asReviewOutcome or computeReviewVerdictOutcome).
+
+**snippet**:
+```ts
+    const isGenuineConstraint =
+      review.exitClass === 'constraint' && review.blockers === 0;
+    const reviewCompleted =
+      review.exitClass === 'passed' ||
+      (review.exitClass === 'constraint' && review.blockers > 0);
+
+    // increment meter only when review actually completed
+    if (reviewCompleted) {
+      ...
+    }
+
+    const reviewOutcome = (() => {
+      if (review.exitClass === 'malfunction')
+        return {
+          malfunction: `review command failed with exit code ${review.exitCode}`,
+        };
+      if (isGenuineConstraint)
+        return {
+          constraint: `review returned constraint (exit code ${review.exitCode}) without blockers`,
+        };
+      return { blockers: review.blockers, nitpicks: review.nitpicks };
+    })();
+```
+
+---
+
+# blocker.3: Inline regex parsing of prior judge files in runStoneGuardJudges
+
+**rule**: rule.forbid.inline-decode-friction.md
+
+**locations**:
+- src/domain.operations/route/guard/runStoneGuardJudges.ts
+
+The orchestrator runStoneGuardJudges contains inline decode-friction using regex matches with positional [1] access and ternaries to extract index and reviewIteration directly from file paths inside the main loop. This forces mental simulation of filename patterns instead of delegating to a named transformer. Such logic must be extracted.
+
+**snippet**:
+```ts
+      // parse index from filename: $stone.guard.judge.i$rp$j.$reviewHash.$judgeHash.j$index.md
+      const indexMatch = filePath.match(/\.j(\d+)\.md$/);
+      const index = indexMatch?.[1] ? parseInt(indexMatch[1], 10) : 0;
+
+      // parse review iteration from filename (the first number in i$rp$j)
+      const reviewIterMatch = filePath.match(/\.i(\d+)p/);
+      const reviewIteration = reviewIterMatch?.[1]
+        ? parseInt(reviewIterMatch[1], 10)
+        : 0;
+```
+
+---
+
+# blocker.4: Inline regex extraction for duration in runOneStoneGuardReview
+
+**rule**: rule.forbid.inline-decode-friction.md
+
+**locations**:
+- src/domain.operations/route/guard/runStoneGuardReviews.ts
+
+Inside the review execution flow (called by orchestrator runStoneGuardReviews), runOneStoneGuardReview has inline decode-friction via regex match and positional access to extract durationMs. This is classic decode-friction that should be extracted to a named transformer like extractDurationMsFromContent.
+
+**snippet**:
+```ts
+  // parse duration from stdout
+  // format: "└─ total: 51455ms" under metrics.realized > time
+  const durationMatch = stdout.match(/total:\s*(\d+)ms/i);
+  const durationMs = durationMatch?.[1] ? parseInt(durationMatch[1], 10) : null;
+```
+
+---
+
+# blocker.5: Inline regex extractions in parseReviewMetadata and parseJudgeMetadata
+
+**rule**: rule.forbid.inline-decode-friction.md
+
+**locations**:
+- src/domain.operations/route/guard/getAllStoneGuardArtifactsByHash.ts
+
+The functions parseReviewMetadata and parseJudgeMetadata (used by orchestrator getAllStoneGuardArtifactsByHash) contain inline decode-friction with multiple regex matches, fallback logic, and positional [1] access for iteration, index, duration, exitCode, passed, and reason. Even though named, the decode-friction is not extracted to dedicated transformer modules and remains co-located in the operation file.
+
+**snippet**:
+```ts
+  const iterMatch = filename.match(/\.i(\d+)\./);
+  // match .r$n. (works for both old and new patterns)
+  const indexMatch = filename.match(/\.r(\d+)\./);
+  // fallback to old pattern if new pattern didn't match
+  const indexMatchLegacy = !indexMatch ? filename.match(/\.r(\d+)\.md$/) : null;
+
+  // iteration is required - file matched our glob, must have iteration marker
+  if (!iterMatch?.[1])
+    UnexpectedCodePathError.throw(
+      'review file lacks iteration marker in filename',
+      { filename, filePath },
+    );
+  const iteration = parseInt(iterMatch[1], 10);
+```

--- a/.behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.mech-failhides.md
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.mech-failhides.md
@@ -1,0 +1,116 @@
+🦉 needs your talons
+   ├─ logs: .log/bhrain/review/2026-06-18T14-45-03-473Z
+   ├─ review: .behavior/v2026_06_17.fix-review-blocker-access/.reviews/5.1.execution.from_vision.peer-review.mech-failhides.md
+   └─ summary
+      ├─ 5 blockers 🔴
+      └─ 0 nitpicks
+
+---
+# blocker.1: Empty catch hides unexpected errors from getGitRepoRoot
+
+**rule**: .agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/rule.forbid.failhide.md.pt1.md
+
+**locations**:
+- src/domain.operations/route/judges/runStoneGuardJudges.ts
+
+Bare catch {} swallows ALL errors from getGitRepoRoot (including unexpected malfunctions) and defaults to cwd. Rules require try/catch to only handle allowlisted errors (e.g. specific 'not in git' condition) and rethrow the rest. This failhide can mask real defects and lead to silent incorrect behavior.
+
+**snippet**:
+```ts
+  try {
+    repoRoot = await getGitRepoRoot({ from: input.route });
+  } catch {
+    repoRoot = process.cwd();
+  }
+```
+
+---
+
+# blocker.2: Empty catch hides errors from enumFilesFromGlob
+
+**rule**: .agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/rule.forbid.failhide.md.pt1.md
+
+**locations**:
+- src/domain.operations/route/judges/runStoneGuardJudges.ts
+
+Bare catch {} on enumFilesFromGlob treats any error (not just missing dir) as 'may not exist' and proceeds with empty list. This hides unexpected errors instead of rethrowing them, violating failfast and failhide rules.
+
+**snippet**:
+```ts
+  try {
+    priorJudgeFiles = await enumFilesFromGlob({
+      glob: judgeGlob,
+      cwd: routeDir,
+    });
+  } catch {
+    // .route/ may not exist yet
+  }
+```
+
+---
+
+# blocker.3: Exec catch does not rethrow unexpected errors
+
+**rule**: .agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/rule.forbid.failhide.md.pt2.md
+
+**locations**:
+- src/domain.operations/route/judges/runStoneGuardJudges.ts
+
+The catch for execAsync only handles if error is object, otherwise silently continues with exitCode=0 (treating error as success). No rethrow for non-matching errors, hiding real failures instead of failing fast. Contrast with correct pattern in runStoneGuardReviews.ts which rethrows non-shape errors.
+
+**snippet**:
+```ts
+  } catch (error: unknown) {
+    if (error && typeof error === 'object') {
+      const errObj = error as Record<string, unknown>;
+      stdout = typeof errObj.stdout === 'string' ? errObj.stdout : '';
+      stderr = typeof errObj.stderr === 'string' ? errObj.stderr : '';
+      exitCode = typeof errObj.code === 'number' ? errObj.code : 1;
+    }
+  }
+```
+
+---
+
+# blocker.4: Raw new Error instead of proper error class with context
+
+**rule**: .agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/rule.require.failloud.md
+
+**locations**:
+- src/domain.operations/route/judges/runStoneGuardJudges.ts
+
+validateNoNpx throws plain new Error with no class (should be BadRequestError) and no metadata object. Rules require ConstraintError/BadRequestError for caller errors with context. The reviews equivalent correctly uses BadRequestError.throw(msg, {pattern, hint}). This is a blocker for failloud.
+
+**snippet**:
+```ts
+  if (cmd.includes('npx rhachet') || cmd.includes('npx rhx')) {
+    const pattern = cmd.includes('npx rhachet') ? 'npx rhachet' : 'npx rhx';
+    const alias = cmd.includes('npx rhachet') ? '$rhachet' : '$rhx';
+    throw new Error(
+      `guard uses ${pattern} which causes latency and cross-platform issues\n\n` +
+        `fix: use ${alias} alias instead\n` +
+        `  - ${alias} expands to ./node_modules/.bin/${alias.slice(1)}\n`,
+    );
+  }
+```
+
+---
+
+# blocker.5: Bare catch in isFilePresent swallows all errors
+
+**rule**: .agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/rule.forbid.failhide.md.pt1.md
+
+**locations**:
+- src/domain.operations/route/judges/runStoneGuardJudges.ts
+
+isFilePresent catches every error (not just ENOENT) and returns false. This hides unexpected errors (e.g. permission, IO) instead of rethrowing. The equivalent in runStoneGuardReviews.ts correctly checks isENOENT and rethrows others.
+
+**snippet**:
+```ts
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+```

--- a/.behavior/v2026_06_17.fix-review-blocker-access/.route/.bind.vlad.fix-review-blocker-access.flag
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/.route/.bind.vlad.fix-review-blocker-access.flag
@@ -1,0 +1,2 @@
+branch: vlad/fix-review-blocker-access
+bound_by: route.bind skill

--- a/.behavior/v2026_06_17.fix-review-blocker-access/.route/.gitignore
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/.route/.gitignore
@@ -1,0 +1,5 @@
+# ignore all except passage.jsonl and .bind flags
+*
+!.gitignore
+!passage.jsonl
+!.bind.*

--- a/.behavior/v2026_06_17.fix-review-blocker-access/.route/passage.jsonl
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/.route/passage.jsonl
@@ -1,0 +1,17 @@
+{"stone":"1.vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-grounded-in-reality"}
+{"stone":"1.vision","status":"blocked","blocker":"approval","reason":"wait for human approval"}
+{"stone":"1.vision","status":"approved"}
+{"stone":"1.vision","status":"passed"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-pruned-yagni"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-consistent-conventions"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer","reason":"no review files found for hash 06cc10ad"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer","reason":"blockers exceed threshold (33 > 0)"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer","reason":"blockers exceed threshold (30 > 0)"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer","reason":"no review files found for hash 0e7ab9b4"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer","reason":"no review files found for hash 01c7dfcd"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer","reason":"blockers exceed threshold (5 > 0)"}
+{"stone":"5.1.execution.from_vision","status":"blocked"}
+{"stone":"5.1.execution.from_vision","status":"malfunction"}
+{"stone":"5.1.execution.from_vision","status":"malfunction"}
+{"stone":"5.1.execution.from_vision","status":"blocked"}
+{"stone":"5.1.execution.from_vision","status":"malfunction"}

--- a/.behavior/v2026_06_17.fix-review-blocker-access/0.wish.md
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/0.wish.md
@@ -1,0 +1,99 @@
+wish =
+
+
+we need to ensure that drivers can access the review outputs that they're told to look at from stdout
+
+specifically
+
+                                          
+                                                                                             
+● Stone marked as blocked. The blocker articulation is at                                    
+  .behavior/v2026_06_16.fix-vpc-infra/blocker/3.3.1.blueprint.product.md.                 
+                                                                                             
+✻ Baked for 1m 28s                                                                           
+                                                                                          
+❯ what are the blockers ?                                                                    
+                                                                                             
+  Read 1 file (ctrl+o to expand)                                                             
+                                                                                             
+● The route system seals access to the peer review files from me. You'll need to view them   
+  directly:
+                                                                                             
+  cat .behavior/v2026_06_16.fix-vpc-infra/.route/3.3.1.blueprint.product.guard.review.*.r*.md
+                                                                                             
+  This will show all 11 peer reviews with the 13 blockers they found.                        
+                                                                                             
+❯ no, they're in this dir; .behavior/v2026_06_16.fix-vpc-infra/.reviews/3.3.1.blueprint.prod 
+uct.peer-review.arch-opport-decomposition.md                                                 
+
+
+
+
+----
+
+they're told upon --as passed this stdout
+
+sdk-aws-lambda.vlad.blend-priors on vlad/blend-priors [✘!+?] is v0.0.0 via  v22.21.0 at 13:21:35 
+➜ rhx route.stone.set --stone 5.1.execution.phase0_to_phaseN --as passed
+
+🪨 run solid skill repo=bhrain/role=driver/skill=route.stone.set
+
+🦉 the way speaks for itself
+   │
+   ├─ r1: $rhx (l1, 38/∞)
+   │   ├─ rejected 61.9s    
+   │   ├─ 2 blockers 🔴
+   │   ├─ 4 nitpicks 🟠
+   │   └─ review: .behavior/v2026_05_09.blend-priors/.route/5.1.execution.phase0_to_phaseN.guard.review.i8.9c7e85ce5d3e736c80.r1.md
+
+
+
+---
+
+maybe we should allow reads into the .route/reviews/ dir? 
+
+and persist reviews into .route/reviews instead ? 
+
+also, the actualy review output file is written into $route/.review , only the stdout of the review command is written into $route/.route/*
+
+so maybe the actual update is
+
+1. keep the whole history of reviews in
+
+$route/.review/xyz and just have them have the names of `[feedback].iN.[given].by_peer.md`
+
+where the iN matches the iteration
+
+and that way they can see the whole review history too?
+
+
+---
+
+
+for more context
+
+you misunderstood. there's two files                                                       
+                                                                                             
+  the review content                                                                         
+  the review stdout                                                                          
+                                                                                             
+  the review stdout is rurrently in the $route/.route dir                                    
+                                                                                             
+  the review content is currently in the $route/.review dir already (emited by the review    
+  skill)                                                                                     
+                                                                                             
+  but the route guard --as passed shares only the relative path in $route/.route , which is  
+  the stdout of running the review skill                                                     
+                                                                                             
+  but the review skill itself emits the content into $route/.review ;                        
+                                                                                             
+  the stdout which is in $route/.route/ curently is just the spot that declares where the    
+  $route/.review is emitted to                                                               
+                                                                                             
+  so we want both to be available in $route/.review                                          
+                                                                                             
+  and we want both the stdout and the content of the review moved over ;                     
+                                                                                             
+  ground yourself into how the `review` skill works today and how the typical reviewers      
+  compose with the routes in guards                                                          
+────────────────────────────────────────

--- a/.behavior/v2026_06_17.fix-review-blocker-access/1.vision.guard
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/1.vision.guard
@@ -1,0 +1,89 @@
+# guard for vision stone
+#
+# requires human approval before stone can be marked as passed
+# because the self-review prompts require human feedback,
+# the process needs to halt here for human review
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism approved? --stone $stone --route $route
+
+reviews:
+  self:
+    - slug: has-grounded-in-reality
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        did the junior ground the vision in reality, or make things up?
+
+        check the groundwork section:
+
+        for external references (APIs, services, docs):
+        - did they actually verify these exist?
+        - did they cite what they checked?
+        - or did they assume without sanity check?
+
+        for internal references (extant behavior, patterns, code):
+        - did they actually verify what that behavior is?
+        - did they verify extant contracts to conform to? (interfaces, types, signatures)
+        - did they verify extant vocab to reuse? (domain terms, name patterns)
+        - did they verify extant stdouts to match? (CLI output patterns, error formats)
+        - did they cite specific files/lines?
+        - or did they assume the code works a certain way without verification?
+
+        this is NOT about exhaustive research — just sanity checks.
+        the question is: is this vision coherent with reality, or built on assumptions?
+
+    - slug: has-questioned-requirements
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any requirements that should be questioned?
+
+        for each requirement, ask:
+        - who said this was needed? when? why?
+        - what evidence supports this requirement?
+        - what if we didn't do this — what would happen?
+        - is the scope too large, too small, or misdirected?
+        - could we achieve the goal in a simpler way?
+
+        challenge each requirement and justify why it belongs.
+
+    - slug: has-questioned-assumptions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any hidden assumptions the junior took as requirements?
+
+        for each assumption, ask:
+        - what do we assume here without evidence?
+        - what evidence supports this assumption?
+        - what if the opposite were true?
+        - did the wisher actually say this, or did we infer it?
+        - what exceptions or counterexamples exist?
+
+        surface all hidden assumptions and question each one.
+
+    - slug: has-questioned-questions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any open questions? triage them:
+
+        for each question, ask:
+        - can this be answered via logic now? if so, answer it now.
+        - can this be answered via extant docs or code now? if so, answer it now.
+        - should this be answered via external research later? if so, mark it for research.
+        - does only the wisher know the answer? if so, ask the wisher.
+
+        for each question, ensure it is clearly marked as either:
+        - [answered] — resolved now
+        - [research] — to be answered in the research phase
+        - [wisher] — requires wisher input
+
+        ensure they're enumerated within the vision under "open questions & assumptions"
+
+  peer: []

--- a/.behavior/v2026_06_17.fix-review-blocker-access/1.vision.stone
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/1.vision.stone
@@ -1,0 +1,70 @@
+illustrate the vision implied in the wish .behavior/v2026_06_17.fix-review-blocker-access/0.wish.md
+
+emit into .behavior/v2026_06_17.fix-review-blocker-access/1.vision.yield.md
+
+---
+
+paint a picture of what the world looks like when this wish is fulfilled
+
+testdrive the contract we propose via realworld examples
+
+specifically,
+
+## the outcome world
+
+- what does a day-in-the-life look like with this in place?
+- what's the before/after contrast?
+- what's the "aha" moment where the value clicks?
+
+## user experience
+
+- what usecases do folks fulfill? what goals?
+- what contract inputs & outputs do they leverage?
+- what would it look like to leverage them?
+- what timelines do they go through?
+
+## mental model
+
+- how would users describe this to a friend?
+- what analogies or metaphors fit?
+- what terms would they use vs what terms would we use?
+
+## evaluation
+
+- how well does it solve the goals?
+- what are the pros? the cons?
+- what edgecases exist and how do our contracts keep users in a pit of success?
+
+## open questions & assumptions
+
+- what assumptions have we made?
+- what questions remain unanswered?
+- what must we validate with the wisher before we proceed?
+- what must we research externally?
+
+## groundwork
+
+sanity check the vision against reality. NOT exhaustive research — just enough to know the vision isn't built on false assumptions.
+
+### external research
+
+if the wish references external APIs, services, or docs:
+- did you verify they exist and work the way you assume?
+- cite what you checked (links, key constraints noted)
+- if none referenced, say "none — no external dependencies"
+
+### internal research
+
+if the wish references extant behavior, patterns, or code:
+- did you verify what that behavior actually is?
+- contracts: interfaces, types, signatures to conform to
+- vocab: domain terms, name patterns to reuse
+- stdouts: CLI output patterns, error formats to match
+- cite what you checked (file paths, line numbers)
+- if none referenced, say "none — no extant behavior extended"
+
+## what is awkward?
+
+- what feels off or forced?
+- where does the design fight the user's mental model?
+- what tradeoffs feel uncomfortable?

--- a/.behavior/v2026_06_17.fix-review-blocker-access/1.vision.yield.md
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/1.vision.yield.md
@@ -1,0 +1,443 @@
+# vision: fix review blocker access
+
+## clarification: two files
+
+peer reviews produce TWO files:
+
+| file | who writes | current location | content |
+|------|------------|------------------|---------|
+| **stdout** | guard (`runStoneGuardReviews.ts`) | `$route/.route/` (blocked) | reviewer stdout (some reviewers output full content here) |
+| **report** | review skill (optional) | `$route/.reviews/peer/` (readable) | detailed report (when review skill writes one) |
+
+the stdout file is blocked. but the driver needs to read it.
+
+**fix:** move stdout from `.route/` to `.reviews/peer/` with symmetric names:
+
+```
+# stdout file (guard captures reviewer stdout)
+${stone}._.review.i${iter}.${hash}.r${reviewerIndex}._.given.by_peer.${reviewerSlug}.md
+
+# report file (review skill writes detailed report)
+${stone}._.review.i${iter}.${hash}.r${reviewerIndex}._.given.by_peer.${reviewerSlug}.report.md
+```
+
+same prefix, only `.report.md` vs `.md` suffix differs.
+
+---
+
+## architecture: `$output` envvar
+
+the guard exports envvars that the review skill can use:
+
+```bash
+export route="$route"
+export stone="$stone"
+export output="$route/.reviews/peer/${stone}._.review.i${iter}.${hash}.r${idx}._.given.by_peer.${reviewerSlug}.report.md"
+```
+
+the review skill uses `--output` flag:
+
+```bash
+# use recommended symmetric path
+run: $rhx review ... --output '$output'
+
+# or use custom path
+run: $rhx review ... --output '$route/.reviews/peer/$stone.peer-review.custom-name.report.md'
+```
+
+**why this matters:**
+
+- review skill stays decoupled from routes — it just writes to whatever `--output` path is given
+- guard controls the name convention via `$output` envvar
+- authors can override with custom paths if needed
+- review skill works outside route system (standalone usage)
+- the guard stdout always shows the stdout file path, which points to the report file — so custom paths still work
+
+---
+
+## the outcome world
+
+### before
+
+a driver marks a stone as passed. the guard runs peer reviews. blockers are found.
+
+```
+🦉 the way speaks for itself
+   │
+   ├─ r1: $rhx (l1, 38/∞)
+   │   ├─ rejected 61.9s
+   │   ├─ 2 blockers 🔴
+   │   ├─ 4 nitpicks 🟠
+   │   └─ review: .behavior/v2026_05_09.blend-priors/.route/5.1.execution.guard.review.i8.9c7e85ce5d3e736c80.r1.md
+```
+
+the driver asks: "what are the blockers?"
+
+the driver tries to read the stdout wrapper:
+
+```
+❯ Read .behavior/v2026_05_09.blend-priors/.route/5.1.execution.guard.review.i8.9c7e85ce5d3e736c80.r1.md
+
+✋ blocked: route.mutate.guard
+
+the route system seals access to .route/** metadata.
+```
+
+the driver is stuck. the stdout wrapper would tell them where the report is, but they can't read it.
+
+### after
+
+the driver marks a stone as passed. the guard runs peer reviews. blockers are found.
+
+```
+🦉 the way speaks for itself
+   │
+   ├─ r1: $rhx (l1, 38/∞)
+   │   ├─ rejected 61.9s
+   │   ├─ 2 blockers 🔴
+   │   ├─ 4 nitpicks 🟠
+   │   └─ review: .behavior/v2026_05_09.blend-priors/.reviews/peer/5.1.execution._.review.i8.9c7e85ce5d3e736c80.r1._.given.by_peer.mech-failhides.md
+```
+
+the driver reads the stdout file:
+
+```
+❯ Read .behavior/v2026_05_09.blend-priors/.reviews/peer/5.1.execution._.review.i8.9c7e85ce5d3e736c80.r1._.given.by_peer.mech-failhides.md
+
+🦉 needs your talons
+   ├─ report: .behavior/v2026_05_09.blend-priors/.reviews/peer/5.1.execution._.review.i8.9c7e85ce5d3e736c80.r1._.given.by_peer.mech-failhides.report.md
+   └─ summary
+      ├─ 2 blockers 🔴
+      └─ 4 nitpicks 🟠
+```
+
+the driver reads the report file (symmetric path, add `.report`):
+
+```
+❯ Read .behavior/v2026_05_09.blend-priors/.reviews/peer/5.1.execution._.review.i8.9c7e85ce5d3e736c80.r1._.given.by_peer.mech-failhides.report.md
+
+# blocker.1
+orchestrator contains inline decode-friction...
+
+# blocker.2
+test coverage absent for edge case...
+```
+
+the driver can now address the blockers without human intervention.
+
+### the "aha" moment
+
+the value clicks when a driver sees blockers in stdout, reads them immediately, fixes them, and re-runs — all without human handholding. the feedback loop becomes tight and autonomous.
+
+---
+
+## user experience
+
+### usecases
+
+| actor | goal | contract |
+|-------|------|----------|
+| driver | read peer review stdout | `Read $route/.reviews/peer/*._.review.*.md` |
+| driver | read peer review report | `Read $route/.reviews/peer/*._.review.*.report.md` |
+| driver | see review history across iterations | `Glob $route/.reviews/peer/*._.review.*` |
+| human | review what feedback was given | `cat $route/.reviews/peer/*._.review.*` |
+| guard | write stdout | writes to `$route/.reviews/peer/*.md` |
+| review skill | write report | writes to `$route/.reviews/peer/*.report.md` |
+
+### contract inputs & outputs
+
+**guard exports envvars:**
+```bash
+export route="$route"
+export stone="$stone"
+export output="$route/.reviews/peer/${stone}._.review.i${iter}.${hash}.r${idx}._.given.by_peer.${reviewerSlug}.report.md"
+```
+
+**review skill writes report to `--output`:**
+```bash
+# recommended: use $output for symmetric path
+run: $rhx review ... --output '$output'
+
+# custom: author chooses their own path
+run: $rhx review ... --output '$route/.reviews/peer/$stone.peer-review.custom-name.report.md'
+```
+
+**guard writes stdout:**
+```
+# always at: same path as $output but without .report suffix
+$route/.reviews/peer/${stone}._.review.i${iter}.${hash}.r${idx}._.given.by_peer.${reviewerSlug}.md
+```
+
+**example files:**
+```
+.reviews/peer/5.1.execution._.review.i8.9c7e85ce5d3e736c80.r1._.given.by_peer.mech-failhides.md         # stdout
+.reviews/peer/5.1.execution._.review.i8.9c7e85ce5d3e736c80.r1._.given.by_peer.mech-failhides.report.md  # report
+```
+
+note: hash is required for cache lookup compatibility with `getAllStoneGuardArtifactsByHash.ts`.
+
+**read pattern (driver input):**
+```
+$route/.reviews/peer/*._.review.*.md         # stdout files
+$route/.reviews/peer/*._.review.*.report.md  # report files
+```
+
+### timeline
+
+1. driver marks `--as passed` or `--as arrived`
+2. guard runs peer reviews
+3. reviews written to `$route/.reviews/peer/` (readable by driver)
+4. stdout shows path to reviews
+5. if blockers: driver reads, fixes, re-runs
+6. if passed: stone advances
+
+### history visibility
+
+each iteration creates new review files with incrementing `iN`:
+
+```
+.reviews/peer/
+├── 1.vision._.review.i1.abc123.r1._.given.by_peer.arch-decomp.md             # first attempt stdout
+├── 1.vision._.review.i1.abc123.r1._.given.by_peer.arch-decomp.report.md      # first attempt report
+├── 1.vision._.review.i2.def456.r1._.given.by_peer.arch-decomp.md             # second attempt stdout
+├── 1.vision._.review.i2.def456.r1._.given.by_peer.arch-decomp.report.md      # second attempt report
+├── 5.1.execution._.review.i1.xyz000.r1._.given.by_peer.mech-failhides.md
+└── 5.1.execution._.review.i1.xyz000.r1._.given.by_peer.mech-failhides.report.md
+```
+
+note: with `r${idx}` before `._.given`, files sort alphabetically by reviewer index. future `taken.by_self` will sort next to `given.by_peer` for the same reviewer.
+
+the driver can see the full journey of feedback across iterations.
+
+---
+
+## mental model
+
+### how users describe it
+
+> "peer reviews go in `.reviews/peer/` so you can actually read them. the `.route/` folder is still locked — that's for system metadata — but the feedback is accessible."
+
+### analogies
+
+| concept | analogy |
+|---------|---------|
+| `.route/` | teacher's answer key (locked) |
+| `.reviews/peer/` | graded homework (returned to student) |
+| `._.given.by_peer` | comments in the margin |
+| iteration `iN` | submission attempt number |
+
+### terms
+
+| user term | system term |
+|-----------|-------------|
+| "the review" | `*._.review.*.given.by_peer.*.md` |
+| "the blockers" | findings with severity=blocker in review |
+| "attempt N" | iteration marker `iN` |
+| "reviewer 1" | reviewer index `r1` |
+
+---
+
+## evaluation
+
+### how well does it solve the goals?
+
+| goal | status | notes |
+|------|--------|-------|
+| drivers can read review blockers | **solved** | `.reviews/peer/` not protected by guard |
+| review history visible | **solved** | all iterations preserved with `iN` marker |
+| route metadata still protected | **preserved** | `.route/**` remains sealed |
+| symmetric stdout/report paths | **solved** | uses `._.review.*.given.by_peer` with `.md` / `.report.md` suffix |
+| review skill decoupled from routes | **solved** | `$output` envvar; custom paths work via stdout pointer |
+
+### pros
+
+- drivers become self-sufficient
+- feedback loop tightens (no human in the loop)
+- history visible for debug and learn
+- symmetric stdout/report paths (same prefix, `.md` vs `.report.md` suffix)
+- review skill decoupled from routes via `$output` envvar
+- custom output paths still work — stdout always points to report
+- minimal change to guard logic (just different write path)
+
+### cons
+
+- `.reviews/peer/` folder is a new artifact directory to track
+- review files now visible in git diffs (could be noisy)
+- breaking change if extant routes have reviews in `.route/`
+
+### acceptance tests
+
+**test 1: `--output $output` symmetric path**
+
+```
+given: a guard file with `run: $rhx review ... --output '$output'`
+when: driver marks `--as passed`
+then:
+  - report file at: $route/.reviews/peer/${stone}._.review.i${iter}.${hash}.r${idx}._.given.by_peer.${slug}.report.md
+  - stdout file at: $route/.reviews/peer/${stone}._.review.i${iter}.${hash}.r${idx}._.given.by_peer.${slug}.md
+  - stdout contains path to report file
+  - both files are readable by driver (not blocked by route.mutate.guard)
+  - paths are symmetric (same prefix, only .report.md vs .md suffix differs)
+```
+
+**test 2: `--output` custom path override**
+
+```
+given: a guard file with `run: $rhx review ... --output '$route/.reviews/peer/$stone.peer-review.custom-name.report.md'`
+when: driver marks `--as passed`
+then:
+  - report file at: $route/.reviews/peer/${stone}.peer-review.custom-name.report.md
+  - stdout file at: $route/.reviews/peer/${stone}._.review.i${iter}.${hash}.r${idx}._.given.by_peer.${slug}.md
+  - stdout contains path to report file (the custom path)
+  - both files are readable by driver
+  - driver can follow stdout pointer to find report at custom location
+```
+
+**test 3: multiple reviewers**
+
+```
+given: a guard file with 3 reviewers (r1, r2, r3)
+when: driver marks `--as passed`
+then:
+  - 6 files created (3 stdout + 3 report)
+  - files sort together by reviewer index (r1._.given..., r2._.given..., r3._.given...)
+  - each reviewer has separate stdout + report pair
+```
+
+**test 4: multiple iterations**
+
+```
+given: a route with prior review at i1
+when: driver modifies stone and marks `--as passed` again (i2)
+then:
+  - new files created at i2 (not overwrite i1)
+  - both i1 and i2 files visible
+  - driver sees full history across attempts
+```
+
+**test 5: cache reuse**
+
+```
+given: a route with prior review at i1 for hash abc123
+when: driver marks `--as passed` with same hash abc123
+then:
+  - no new review run (cache hit)
+  - extant files in `.reviews/peer/` are reused
+```
+
+**test 6: cleanup on rewind**
+
+```
+given: a route with reviews at i1, i2, i3
+when: stone is rewound to i1
+then:
+  - i2 and i3 report files removed from `.reviews/peer/`
+  - i2 and i3 stdout files removed from `.reviews/peer/`
+  - i1 files preserved
+```
+
+### edgecases & pit of success
+
+| edgecase | handling |
+|----------|----------|
+| driver modifies reviews | allowed; changes are tracked in git |
+| multiple reviewers | each gets unique `r${index}` suffix |
+| hash collision | hash is 20 chars, collision negligible |
+| migration of old routes | old reviews remain in `.route/`; new reviews go to `.reviews/peer/` |
+
+---
+
+## open questions & assumptions
+
+### assumptions (verified)
+
+1. **`.reviews/peer/` is tracked in git** — peer reviews are checked in, visible in PRs
+2. **`.reviews/peer/` is not a protected pattern** — guard blocks `.route/**` only, verified at lines 157-160
+3. **`._.review` delimiter pattern** — avoids bracket issues, symmetric stdout/report paths
+4. **iteration count comes from artifact hash change** — extant behavior
+5. **no migration of old reviews** — forward-only fix; old reviews stay in `.route/`
+6. **`by_peer` is the correct suffix** — matches extant "peer review" vocabulary in codebase
+
+### questions for wisher
+
+none — all questions answered via code research
+
+### external research needed
+
+none — no external dependencies
+
+---
+
+## groundwork
+
+### external research
+
+none — no external dependencies
+
+### internal research
+
+**guard protection logic:**
+- file: `src/domain.roles/driver/skills/route.mutate.guard.sh`
+- lines 157-160: blocks `$route/.route/**` pattern
+- does NOT block `$route/.reviews/peer/**` — this is the fix
+
+**current review path generation:**
+- file: `src/domain.operations/route/guard/runStoneGuardReviews.ts`
+- line 94-97: writes stdout to `.route/${stone}.guard.review.i${iter}.${hash}.r${idx}.md`
+- change: export `$output` envvar for review skill, write stdout to `${output}` path (drop `.report` suffix)
+
+**review skill output:**
+- review skill receives `--output` flag
+- writes report to `--output` path (uses `$output` envvar or custom path)
+- guard writes stdout to same path but without `.report` suffix
+
+**cache lookup for review reuse:**
+- file: `src/domain.operations/route/guard/getAllStoneGuardArtifactsByHash.ts`
+- line 24: reads from `.route/`
+- line 34: glob pattern uses hash for lookup
+- change: read from `.reviews/peer/`, update glob pattern
+
+**cleanup on rewind:**
+- file: `src/domain.operations/route/stones/delStoneGuardArtifacts.ts`
+- line 22: targets `.route/` for deletion
+- line 39: glob pattern for review files
+- change: also target `.reviews/peer/` for peer review deletion
+
+**stdout format:**
+- file: `src/domain.operations/route/guard/formatGuardReviewerTree.ts`
+- lines 91, 97, 131: `review: ${state.path}` — path comes from review artifact
+- change: no change needed — path will automatically reflect new location
+
+**peer review name pattern:**
+- stdout: `${stone}._.review.i${iter}.${hash}.r${idx}._.given.by_peer.${reviewerSlug}.md`
+- report: `${stone}._.review.i${iter}.${hash}.r${idx}._.given.by_peer.${reviewerSlug}.report.md`
+- symmetric: stdout and report share identical prefix
+- alphabetical: `r${idx}` before `._.given` so same reviewer's files sort together
+
+**gitignore:**
+- `.reviews/peer/` is NOT gitignored — peer reviews are tracked in git, visible in PRs
+- `.reviews/self/` IS gitignored — self reviews are ephemeral (extant pattern)
+- this separation: `peer/` (trackable) vs `self/` (ephemeral)
+
+---
+
+## what is awkward?
+
+### the `.reviews/peer/` vs `.route/` split
+
+two artifact directories is more cognitive load than one. but the tradeoff is necessary — `.route/` must remain sealed to prevent abuse, while `.reviews/peer/` must be readable to close the feedback loop.
+
+### the `.reviews/peer/` vs `.reviews/self/` split
+
+peer reviews are tracked in git (visible in PRs), while self reviews are gitignored (ephemeral). this matches extant behavior where self reviews are ephemeral artifacts.
+
+### `._.` delimiter pattern
+
+the `._.review` and `._.given` patterns use `._.` as a visual delimiter:
+- avoids bracket issues on windows (no `[` or `]`)
+- reads naturally: "5.1.execution._.review" = "this stone's review"
+- enables alphabetical sort: `r1._.given.by_peer` and `r1._.taken.by_self` sort together
+
+### `by_peer` vs `by_guard` vs `by_robot`
+
+"peer" implies another agent reviewed. "guard" implies the guard mechanism. "robot" is generic. the wish uses "peer" which matches the extant "peer review" terminology in the codebase.

--- a/.behavior/v2026_06_17.fix-review-blocker-access/5.1.execution.from_vision.guard
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/5.1.execution.from_vision.guard
@@ -1,0 +1,213 @@
+# guard for execution stone (from vision - nano size)
+# includes standardized self-review frame
+
+artifacts:
+  # track execution progress
+  - "$route/5.1.execution.from_vision.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    # 1. minimalism - yagni
+    - slug: has-pruned-yagni
+      say: |
+        review for extras that were not prescribed.
+
+        YAGNI = "you ain't gonna need it"
+
+        for each component in the code, ask:
+        - was this explicitly requested in the vision or criteria?
+        - is this the minimum viable way to satisfy the requirement?
+        - did we add abstraction "for future flexibility"?
+        - did we add features "while we're here"?
+        - did we optimize before we knew it was needed?
+
+        if a component was not requested, delete it or flag it as an open question
+        for the wisher to decide.
+
+    # 2. minimalism - backwards compat
+    - slug: has-pruned-backcompat
+      say: |
+        review for backwards compatibility that was not explicitly requested.
+
+        for each backwards-compat concern in the code, ask:
+        - did the wisher explicitly say to maintain this compatibility?
+        - is there evidence this backwards compat is needed?
+        - or did we assume it "to be safe"?
+
+        if backwards compat was not explicitly requested:
+        1. flag it as an open question for the wisher
+        2. eliminate it if not confirmed as required
+        3. make the open question very clearly reported
+
+    # 3. consistency - mechanisms
+    - slug: has-consistent-mechanisms
+      say: |
+        review for new mechanisms that duplicate extant functionality.
+
+        unless the ask was to refactor, be consistent with extant mechanisms.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). look for extant utilities and patterns.
+
+        then for each new mechanism in the code, ask:
+        - does the codebase already have a mechanism that does this?
+        - do we duplicate extant utilities or patterns?
+        - could we reuse an extant component instead of a new one?
+
+        if a new mechanism duplicates extant functionality:
+        1. replace with the extant mechanism
+        2. or flag as an open question if unsure
+
+    # 4. consistency - conventions
+    - slug: has-consistent-conventions
+      say: |
+        review for divergence from extant names and patterns.
+
+        unless the ask was to refactor, be consistent with extant conventions.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). identify extant name conventions and patterns.
+
+        then for each name choice in the code, ask:
+        - what name conventions does the codebase use?
+        - do we use a different namespace, prefix, or suffix pattern?
+        - do we introduce new terms when extant terms exist?
+        - does our structure match extant patterns?
+
+        if we diverge from extant conventions:
+        1. align with the extant convention
+        2. or flag as an open question if the extant convention seems wrong
+
+    # 5. review against behavior declaration - coverage
+    - slug: behavior-declaration-coverage
+      say: |
+        review for coverage of the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have omitted
+        requirements or left features unimplemented.
+
+        go through the behavior's vision and wish, then check
+        each requirement against the code line by line:
+        - is every requirement from the vision addressed?
+        - did the junior skip or forget any part of the spec?
+
+        fix all gaps before you continue.
+
+    # 6. review against behavior declaration - adherance
+    - slug: behavior-declaration-adherance
+      say: |
+        review for adherance to the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have drifted
+        from the spec or implemented items incorrectly.
+
+        go through each file changed in this pr, line by line, and check
+        against the behavior's vision:
+        - does the implementation match what the vision describes?
+        - did the junior misinterpret or deviate from the spec?
+
+        fix all gaps before you continue.
+
+    # 7. review against role standards - adherance
+    - slug: role-standards-adherance
+      say: |
+        review for adherance to mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have introduced
+        bad practices or violated patterns that we require.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - does the code follow mechanic standards correctly?
+        - are there violations of required patterns?
+        - did the junior introduce anti-patterns, bad practices, or deviations from our conventions?
+
+        fix all gaps before you continue.
+
+    # 8. review against role standards - coverage
+    - slug: role-standards-coverage
+      say: |
+        review for coverage of mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have forgotten
+        best practices or omitted patterns that should be present.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - are all relevant mechanic standards applied?
+        - are there patterns that should be present but are absent?
+        - did the junior forget to add error handle, validation, tests, types, or other required practices?
+
+        fix all gaps before you continue.
+
+  peer:
+    # --- level 1: cheap reviewers (run first, in parallel) ---
+
+    - slug: mech-failhides
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.mech-failhides.md'
+      budget: 5
+      level: 1
+
+    - slug: mech-decode-friction
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.{forbid.decode-friction-in-orchestrators,require.orchestrators-as-narrative}.md' --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transforms}.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/{define.domain-operation-grains,philosophy.transform-orchestrator-separation.[philosophy]}.md' --diffs since-main --paths-with '**/*.ts' --paths-without '**/*.test.ts' --join intersect --output '$route/.reviews/$stone.peer-review.mech-decode-friction.md'
+      budget: 5
+      level: 1
+
+    # --- architect reviews (level 1) ---
+
+    - slug: arch-opport-decomposition
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.arch-opport-decomposition.md'
+      budget: 5
+      level: 1
+
+    - slug: arch-smell-scopeleaks
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.arch-smell-scopeleaks.md'
+      budget: 5
+      level: 1
+
+    - slug: arch-hazards-maintenance
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.require.solve-at-cause.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.typedefs/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.comments/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.arch-hazards-maintenance.md'
+      budget: 5
+      level: 1
+
+    - slug: arch-hazards-behavior
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.arch-hazards-behavior.md'
+      budget: 5
+      level: 1
+
+    - slug: behavior-intent-coverage
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md' --refs '$route/0.wish.md' --refs '$route/1.vision.yield.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.criteria/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.behavior-intent-coverage.md'
+      budget: 5
+      level: 1
+
+    - slug: ergo-friction-hazards
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.ts' --join intersect --output '$route/.reviews/$stone.peer-review.ergo-friction-hazards.md'
+      budget: 5
+      level: 1
+
+    # --- level 3: expensive reviewers (run after level 1 is terminal) ---
+
+    - slug: enroll-impl-behavior-intent
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current implementation for omissions or divergences from the wished and envisioned behavioral intent. in particular flag any ergonomic friction that is unaddressed or friction hazards that are not clearly covered with acceptance tests and snaps'
+      budget: 3
+      level: 3
+
+    - slug: enroll-impl-arch-defects
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current implementation for architectural defects and omissions; opports to decompose for recompose, prevent scope leaks, and eliminate maintenance and behavior hazards structurally'
+      budget: 3
+      level: 3
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3

--- a/.behavior/v2026_06_17.fix-review-blocker-access/5.1.execution.from_vision.stone
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/5.1.execution.from_vision.stone
@@ -1,0 +1,15 @@
+bootup your mechanic's role via `./node_modules/.bin/rhachet roles boot --repo ehmpathy --role mechanic`
+
+then, execute the vision directly
+- .behavior/v2026_06_17.fix-review-blocker-access/1.vision.md
+
+ref:
+- .behavior/v2026_06_17.fix-review-blocker-access/0.wish.md
+
+
+---
+
+track your progress
+
+emit todos and check them off into
+- .behavior/v2026_06_17.fix-review-blocker-access/5.1.execution.from_vision.yield.md

--- a/.behavior/v2026_06_17.fix-review-blocker-access/5.1.execution.from_vision.yield.md
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/5.1.execution.from_vision.yield.md
@@ -1,0 +1,33 @@
+# execution progress
+
+## completed
+
+- [x] update `runStoneGuardReviews.ts` to write stdout to `.reviews/peer/`
+  - changed output directory from `.route/` to `.reviews/peer/`
+  - added `slug` parameter for symmetric file names
+  - exports `$output` envvar that points to report path
+  - stdout file: `${stone}._.review.i${iter}.${hash}.r${idx}._.given.by_peer.${slug}.md`
+  - report file: `${stone}._.review.i${iter}.${hash}.r${idx}._.given.by_peer.${slug}.report.md`
+
+- [x] update `getAllStoneGuardArtifactsByHash.ts` to read from `.reviews/peer/`
+  - searches both `.reviews/peer/` (new) and `.route/` (legacy)
+  - supports both old and new filename patterns
+  - backwards compatible with extant routes
+
+- [x] update `getLatestReviewArtifactForIndex.ts` to read from `.reviews/peer/`
+  - searches both `.reviews/peer/` (new) and `.route/` (legacy)
+  - updated hash extraction regex to work for both patterns
+
+- [x] update `delStoneGuardArtifacts.ts` to clean `.reviews/peer/`
+  - collects peer review files from `.reviews/peer/` with new glob pattern
+  - still collects legacy review files from `.route/` if directory exists
+  - wrapped all `.route/` lookups in conditional check
+
+- [x] update test assertions in `runStoneGuardReviews.integration.test.ts`
+  - updated expected path pattern from old to new format
+
+## verification
+
+- types: passed
+- unit tests (guard): 210 passed
+- integration tests (route): 299 passed

--- a/.behavior/v2026_06_17.fix-review-blocker-access/5.3.verification.guard
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/5.3.verification.guard
@@ -1,0 +1,286 @@
+artifacts:
+  # track verification progress
+  - "$route/5.3.verification.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    - slug: has-behavior-coverage
+      say: |
+        double-check: does the verification checklist show every behavior from wish/vision has a test?
+
+        - is every behavior in 0.wish.md covered?
+        - is every behavior in 1.vision.md covered?
+        - can you point to each test file in the checklist?
+
+        **if any behavior lacks a test, write the test NOW.** do not pass this gate with gaps.
+
+    - slug: has-zero-test-skips
+      say: |
+        double-check: did you verify zero skips — and REMOVE any you found?
+
+        - no .skip() or .only() found?
+        - no silent credential bypasses?
+        - no prior failures carried forward?
+
+        **if you found skips, did you remove them and make those tests pass?**
+
+        this is buttonup. skips are gaps. gaps get fixed, not noted.
+
+    - slug: has-all-tests-passed
+      say: |
+        double-check: did all tests pass? prove it.
+
+        **zero unproven claims.** you must cite the exact command and output.
+
+        for each test suite:
+        - what command did you run?
+        - what was the exit code?
+        - how many tests passed?
+
+        example proof:
+        ```
+        $ npm run test:unit
+        > exit 0
+        > 47 tests passed
+        ```
+
+        if you cannot cite the command and output, you did not prove it.
+
+        zero tolerance for extant failures:
+        - "it was already broken" is not an excuse — fix it
+        - "it's unrelated to my changes" is not an excuse — fix it
+        - flaky tests must be stabilized, not tolerated
+        - every failure is your responsibility now
+
+        zero tolerance for fake tests:
+        - tests that always pass are fraud
+        - tests that mock the system under test prove nothingness
+        - tests must verify real behavior
+
+        zero tolerance for credential excuses:
+        - "i don't have creds" means get them or mock them
+        - silent bypasses are forbidden
+        - if creds block tests, that is a BLOCKER — not a deferral
+
+    - slug: has-preserved-test-intentions
+      say: |
+        double-check: did you preserve test intentions?
+
+        for every test you touched:
+        - what did this test verify before?
+        - does it still verify the same behavior after?
+        - did you change what the test asserts, or fix why it failed?
+
+        forbidden:
+        - weaken assertions to make tests pass
+        - remove test cases that "no longer apply"
+        - change expected values to match broken output
+        - delete tests that fail instead of fix code
+
+        the test knew a truth. if it failed, either:
+        - the code is wrong — fix the code
+        - the test has a bug — fix the bug, keep the intention
+        - requirements changed — document why, get approval
+
+        to "fix tests" via changed intent is not a fix — it is at worst
+        malicious deception, at best reckless negligence. unacceptable.
+
+    - slug: has-journey-tests-from-repros
+      say: |
+        double-check: did you implement each journey sketched in repros?
+
+        look back at the repros artifact:
+        - .behavior/v2026_06_17.fix-review-blocker-access/3.2.distill.repros.experience.*.md
+
+        for each journey test sketch in repros:
+        - is there a test file for it?
+        - does the test follow the BDD given/when/then structure?
+        - does each `when([tN])` step exist?
+
+        **if any journey was planned but not implemented, go back and add it NOW.**
+
+        this is buttonup. absent journey tests = incomplete implementation.
+        test coverage proves prod coverage. no test = no proof = not done.
+
+    - slug: has-contract-output-variants-snapped
+      say: |
+        double-check: does each public contract have EXHAUSTIVE snapshots?
+
+        **zero gaps in caller experience.** every contract must snap every output variant.
+
+        for each new or modified public contract:
+
+        | contract type | what to snap | required variants |
+        |---------------|--------------|-------------------|
+        | cli command | stdout + stderr | success, error, --help, edge cases |
+        | api endpoint | response body | 2xx, 4xx, 5xx, edge cases |
+        | sdk method | return value | success, error, edge cases |
+
+        checklist per contract:
+        - [ ] positive path (success) is snapped
+        - [ ] negative path (error) is snapped
+        - [ ] help/usage is snapped (for cli)
+        - [ ] edge cases are snapped (empty, invalid, boundary)
+        - [ ] snapshot shows actual output, not placeholder
+
+        why this matters:
+        - snapshots enable vibecheck in prs — reviewers see actual output without execute
+        - snapshots detect drift over time — output changes surface in diffs
+        - absent variants mean blind spots in review
+        - exhaustive coverage proves the contract works for all callers
+
+        **zero leniency.** if a contract lacks any variant, add the test case NOW.
+
+        if you find yourself about to say "this variant isn't worth a snapshot" — stop.
+        that is the variant that will break in prod. snap it.
+
+        this is buttonup. absent snapshots = absent proof. add them or fail this gate.
+
+    - slug: has-snap-changes-rationalized
+      say: |
+        double-check: is every `.snap` file change intentional and justified?
+
+        for each `.snap` file in git diff:
+        1. what changed? (added, modified, deleted)
+        2. was this change intended or accidental?
+        3. if intended: what is the rationale?
+        4. if accidental: revert it or explain why the new output is an improvement
+
+        common regressions caught here:
+        - output format degraded (lost alignment, lost structure)
+        - error messages became less helpful
+        - timestamps or ids leaked into snapshots (flaky)
+        - extra output added unintentionally
+
+        forbidden:
+        - "updated snapshots" without per-file rationale
+        - bulk snapshot updates without review
+        - regressions accepted without justification
+
+        every snap change tells a story. make sure the story is intentional.
+
+    - slug: has-critical-paths-frictionless
+      say: |
+        double-check: are the critical paths frictionless in practice?
+
+        look back at the repros artifact for critical paths:
+        - .behavior/v2026_06_17.fix-review-blocker-access/3.2.distill.repros.experience.*.md
+
+        for each critical path:
+        - run through it manually — is it smooth?
+        - are there unexpected errors?
+        - does it feel effortless to the user?
+
+        critical paths must "just work." if there's friction, fix it now.
+
+    - slug: has-ergonomics-validated
+      say: |
+        double-check: does the actual input/output match what felt right at repros?
+
+        compare the implemented input/output to what was sketched in repros:
+        - does the actual input match the planned input?
+        - does the actual output match the planned output?
+        - did the design change between repros and implementation?
+
+        if the ergonomics drifted, either:
+        - update repros to reflect the better design, or
+        - fix the implementation to match the planned ergonomics
+
+    - slug: has-play-test-convention
+      say: |
+        double-check: are journey test files named correctly?
+
+        journey tests should use `.play.test.ts` suffix:
+        - `feature.play.test.ts` — journey test
+        - `feature.play.integration.test.ts` — if repo requires integration runner
+        - `feature.play.acceptance.test.ts` — if repo requires acceptance runner
+
+        verify:
+        - are journey tests in the right location?
+        - do they have the `.play.` suffix?
+        - if not supported, is the fallback convention used?
+
+    - slug: has-fixed-all-gaps
+      say: |
+        final buttonup check: did you FIX every gap you found, or just detect it?
+
+        **this is the buttonup phase. detection is not enough — you must fix.**
+
+        look back at all the reviews above. for every gap you identified:
+        - absent test coverage → did you WRITE the test?
+        - absent prod coverage → did you IMPLEMENT the behavior?
+        - failed test → did you FIX the code or test?
+        - skipped test → did you REMOVE the skip and make it pass?
+
+        **zero omissions.** if any review above surfaced a gap, that gap must be fixed before you pass this gate.
+
+        ask yourself:
+        - did i just note the gap, or did i actually fix it?
+        - is there any item marked "todo" or "later"? (forbidden)
+        - is there any coverage marked incomplete? (forbidden)
+
+        **if you detected it, you fixed it.** prove it with citations.
+
+        this is the final self-review. you are about to hand off to peer review.
+        prove that all items above were addressed — not deferred.
+
+  peer:
+    # --- level 1: cheap reviewers (run first, in parallel) ---
+
+    - slug: ergo-contract-snapshots
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.ergo-contract-snapshots.md'
+      budget: 5
+      level: 1
+
+    - slug: mech-external-contracts
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.external-contract-integration-tests.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.remote-boundaries.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.mech-external-contracts.md'
+      budget: 5
+      level: 1
+
+    - slug: ergo-acceptance-journey-coverage
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.require.acceptance-journey-coverage.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.ergo-acceptance-journey-coverage.md'
+      budget: 5
+      level: 1
+
+    - slug: ergo-snapshot-visual-blemishes
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.forbid.snapshot-visual-blemishes.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --diffs since-main --paths-with '**/*.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.ergo-snapshot-visual-blemishes.md'
+      budget: 5
+      level: 1
+
+    - slug: mech-given-when-then
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/rule.require.given-when-then.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/criteria.given_when_then.[seed].v3.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/lessons.howto/*.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.mech-given-when-then.md'
+      budget: 5
+      level: 1
+
+    - slug: mech-test-intent
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.forbid.test-intent-violations.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/work.flow/refactor/rule.require.review-test-changes.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --output '$route/.reviews/$stone.peer-review.mech-test-intent.md'
+      budget: 5
+      level: 1
+
+    - slug: mech-test-scope-purity
+      run: $rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/rule.require.test-coverage-by-grain.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.unit.remote-boundaries.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.integration/rule.forbid.integration.mocks.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.acceptance/rule.forbid.acceptance.mocks.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.acceptance/rule.require.acceptance.blackbox.md' --diffs since-main --paths-with '{src,blackbox}/**/*.test.ts' --join intersect --output '$route/.reviews/$stone.peer-review.test-scope-purity.md' --mode hard
+      budget: 5
+      level: 1
+
+    # --- level 3: expensive reviewers (run after level 1 is terminal) ---
+
+    - slug: enroll-verif-snapshot-coverage
+      run: $rhx enroll claude --model sonnet --roles behaver,ergonomist,mechanic -p 'review the diff for snapshot coverage on contract endpoints and acceptance test user journey coverage'
+      budget: 3
+      level: 3
+
+    - slug: enroll-verif-snapshot-blemishes
+      run: $rhx enroll claude --model sonnet --roles behaver,ergonomist,mechanic -p 'review the diff for experiential and visual blemishes in snapshotted acceptance test journeys'
+      budget: 3
+      level: 3
+
+    - slug: enroll-verif-test-intent
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current implementation for test intent violation diffs. if any of the diffs related to tests loosened assertions or changed the criteria, this is a blocker. tests were added for a reason. we have to maintain the behavior they locked in'
+      budget: 3
+      level: 3
+
+judges:
+  # enforce peer reviews pass with zero blockers
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0

--- a/.behavior/v2026_06_17.fix-review-blocker-access/5.3.verification.stone
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/5.3.verification.stone
@@ -1,0 +1,304 @@
+prove the deliverable works via test verification — fix all gaps
+
+---
+
+## .what
+
+this is the verification gate — the **buttonup phase**.
+
+you cannot pass execution without proof that all tests pass. more importantly: **test coverage enforces prod coverage**. if tests are absent, prod is incomplete. if prod is incomplete, fix it.
+
+## .the buttonup mandate: zero omissions
+
+**this is not a detection phase. this is a completion phase.**
+
+when you find a gap, you do not note it and move on. you **fix it**.
+
+| gap type | action |
+|----------|--------|
+| absent test coverage | write the test NOW |
+| absent prod coverage | implement the behavior NOW |
+| failed test | fix the code or fix the test NOW |
+| skipped test | remove the skip and make it pass NOW |
+
+**if you detect it, you fix it. no exceptions.**
+
+## .strictness: zero tolerance, zero exceptions
+
+**this gate enforces absolute standards. there is no leniency.**
+
+| constraint | definition |
+|------------|------------|
+| zero deferrals | you cannot defer any test to later. all tests pass now or you fail. |
+| zero fake tests | tests must verify real behavior. assertions that always pass are fraud. |
+| zero unproven claims | every claim of "test passes" must cite the exact command run and output. |
+| zero credential excuses | "i don't have creds" is not an excuse. get them, mock them, or fail. |
+| zero skips | .skip() and .only() are forbidden. silent bypasses are forbidden. |
+| zero exceptions | there are no special cases. the rules apply to all. |
+| zero omissions | if you find a gap in coverage, you fix it — test or prod. |
+
+**if a blocker prevents tests from run, that is a BLOCKER. full stop.**
+
+you do not proceed. you do not defer. you fix it or you fail the gate.
+
+## .why
+
+**why does this gate exist?**
+
+your crew is about to review a pr you wrote. they need proof it works — not words, proof. tests are that proof.
+
+**test coverage drives prod coverage.** if a behavior lacks a test, that behavior is unproven. unproven behaviors are incomplete deliverables. the test proves the implementation exists and works.
+
+without this gate:
+- tests might fail and nobody notices
+- tests might be skipped and nobody notices
+- behaviors might lack coverage and nobody notices
+- broken code ships to peers
+- incomplete implementations slip through
+
+with this gate:
+- every test passes or you fix it
+- every behavior has coverage or you add it
+- every skip is removed or justified
+- proven code ships to peers
+- **gaps get fixed, not deferred**
+
+**the cardinal rules**:
+1. never leave behavior without true, dependable test coverage
+2. never offload work onto your crew unless there is truly, fundamentally no other option
+3. never claim a test passes without cite of the exact command and output
+
+you fix it yourself. you exhaust every option: debug, research, try alternatives. only when you hit a wall that is physically impossible to climb alone — credentials only the foreman possesses, access only they can grant — only then may you ask for help.
+
+## .how
+
+reference the below for full context
+- .behavior/v2026_06_17.fix-review-blocker-access/0.wish.md
+- .behavior/v2026_06_17.fix-review-blocker-access/1.vision.md
+- .behavior/v2026_06_17.fix-review-blocker-access/2.1.criteria.blackbox.md (if declared)
+- .behavior/v2026_06_17.fix-review-blocker-access/3.2.distill.repros.experience.*.md (if declared) ← **repros artifact**
+
+---
+
+### step 1: emit verification checklist
+
+emit to
+- .behavior/v2026_06_17.fix-review-blocker-access/5.3.verification.yield.md
+
+this is your roadmap. emit it first, then work through it step by step.
+
+**checklist structure:**
+
+```
+## verification checklist
+
+### behavior coverage (with reference to repros)
+
+for each journey sketched in repros, verify it was implemented with snapshots.
+
+| journey (from repros) | test file | snapshots? | critical path? | ergonomics ok? | status |
+|-----------------------|-----------|------------|----------------|----------------|--------|
+| {journey 1}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+| {journey 2}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+...
+
+### zero skips verified
+- [ ] no .skip() or .only() found
+- [ ] no silent credential bypasses
+- [ ] no prior failures carried forward
+
+### snapshot coverage for contract outputs
+
+each public contract needs dedicated snapshots that demonstrate its stdout for:
+- **vibechecks in prs** — reviewers see actual output without executing code
+- **drift detection** — changes to output surface in diffs over time
+
+| contract | output variants | snapshot file | status |
+|----------|-----------------|---------------|--------|
+| {command 1} | success, error, help | {path.snap} | ⏳ |
+| {command 2} | success, error, help | {path.snap} | ⏳ |
+...
+
+checklist:
+- [ ] every new cli command has `.snap` snapshots for stdout/stderr
+- [ ] every new app screen has `.snap` snapshots for screenshots
+- [ ] every new sdk method has `.snap` snapshots for responses
+- [ ] each output variant is exercised (success, error, edge cases)
+- [ ] snapshots demonstrate actual output, not just "it ran"
+
+### snapshot change rationalization
+
+for each `.snap` file changed, rationalize whether the change was intended or accidental:
+
+| snap file | change type | intended? | rationale |
+|-----------|-------------|-----------|-----------|
+| {path.snap} | added / modified / deleted | yes / no | {why this change is correct} |
+...
+
+checklist:
+- [ ] every `.snap` change has been reviewed
+- [ ] intended changes have clear rationale
+- [ ] accidental changes have been reverted or justified as improvements
+
+### tests executed — with proof
+
+**every test run must be proven with exact command and output.**
+
+| test suite | command run | result | proof (exit code + summary) |
+|------------|-------------|--------|----------------------------|
+| types | `npm run test:types` | ✓ / ✗ | exit 0, no errors |
+| lint | `npm run test:lint` | ✓ / ✗ | exit 0, no errors |
+| format | `npm run test:format` | ✓ / ✗ | exit 0, no errors |
+| unit | `npm run test:unit` | ✓ / ✗ | exit 0, N tests passed |
+| integration | `npm run test:integration` | ✓ / ✗ | exit 0, N tests passed |
+| acceptance | `npm run test:acceptance` | ✓ / ✗ | exit 0, N tests passed |
+
+checklist:
+- [ ] every test command was run (not "i think it passed")
+- [ ] every test command output was observed (not assumed)
+- [ ] the exact exit code was verified (0 = pass, non-zero = fail)
+- [ ] no tests were skipped, mocked, or faked
+
+**zero unproven claims.** if you claim a test passes, cite the command and output.
+
+### contract output snapshot exhaustiveness
+
+**every user-faced contract must have exhaustive snapshot coverage.**
+
+| contract type | contract | positive path snapped? | negative path snapped? | edge cases snapped? |
+|---------------|----------|------------------------|------------------------|---------------------|
+| cli | {command} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| api | {endpoint} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| sdk | {method} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+
+checklist:
+- [ ] every cli command has stdout/stderr snapshots for success, error, and help
+- [ ] every api endpoint has response snapshots for success and error codes
+- [ ] every sdk method has return value snapshots for success and error
+- [ ] every contract has edge case snapshots (empty input, invalid input, boundary)
+
+**zero gaps in caller experience.** the reviewer must see exactly what callers see.
+
+### blockers
+- none (or list handoff references)
+```
+
+update the checklist as you complete each step below.
+
+---
+
+### step 2: verify AND FIX behavior coverage
+
+walk through wish and vision:
+- every behavior promised must have an acceptance test
+- for each behavior, you can point to the test file
+- no behavior left untested
+
+**why?** your crew trusts the test suite. if a behavior isn't tested, it isn't proven. untested behaviors are unverified promises.
+
+**test coverage enforces prod coverage.** if a test is absent, either:
+1. the behavior was not implemented → IMPLEMENT IT NOW
+2. the behavior was implemented without a test → WRITE THE TEST NOW
+
+if a behavior lacks a test, **write one NOW**. do not move on with gaps. update your checklist when done.
+
+---
+
+### step 3: verify AND FIX zero skips
+
+scan for forbidden patterns:
+- `.skip()` or `.only()` in test files
+- `if (!credentials) return` or similar silent bypasses
+- prior failures carried forward (known-broken tests)
+
+**why?** failures are better than skips. skips hide problems. failures expose them. a skipped test is a lie — it pretends coverage exists when it doesn't.
+
+**this is buttonup.** if you find skips:
+1. REMOVE the skip
+2. MAKE the test pass (fix the code or fix the test)
+3. update your checklist
+
+do not note skips and move on. fix them. all tests must run.
+
+---
+
+### step 4: run all tests AND FIX all failures
+
+run each test suite and **cite the exact command and output**.
+
+```bash
+npm run test:types      # cite exit code
+npm run test:lint       # cite exit code
+npm run test:format     # cite exit code
+npm run test:unit       # cite exit code + test count
+npm run test:integration # cite exit code + test count
+npm run test:acceptance  # cite exit code + test count
+```
+
+all must pass — no exceptions. no deferrals. no "i'll fix it later."
+
+**this is buttonup.** if tests fail, fix them. that is the job.
+
+failures indicate one of:
+1. prod code is broken → FIX THE PROD CODE
+2. test has a bug → FIX THE TEST BUG (preserve intention)
+3. coverage gap exists → FILL THE GAP
+
+**consider all failures as defects from this pr.** there are no "prior failures."
+
+if a test was broken before you started — fix it. if a test is flaky — fix it. if a test fails for reasons unrelated to your changes — fix it anyway. you do not get to say "that was already broken." you are here now. you fix it.
+
+**take initiative. take ownership.**
+
+**preserve test intentions.** when you fix a test, you fix why it failed — not what it tests. to change what a test verifies is not a fix. it is at worst malicious deception, at best reckless negligence. the test knew a truth. if it fails, either the code is wrong or the test has a bug. fix the cause, not the assertion.
+
+**zero fake tests.** a test that always passes is fraud. a test that skips is a lie. a test that mocks the system under test proves nothingness. tests must verify real behavior against real code.
+
+**escalation path:**
+1. debug the failure — read the error, understand the cause
+2. research — search for similar issues, read docs
+3. try alternatives — different approach, different tool
+4. ask for help — other resources, other clones
+5. deeper research — exhaust every option
+6. only if insurmountable — emit handoff (see step 5)
+
+**ask yourself at each level:**
+- did i read the error message carefully?
+- did i search for similar issues?
+- did i try a different approach?
+- did i isolate the problem?
+- did i ask for help?
+- did i exhaust every option?
+
+you move to handoff only when you can answer "yes" to all of the above and still cannot proceed.
+
+update your checklist when all tests pass.
+
+---
+
+### step 5: handoff (only if insurmountable)
+
+a handoff is a document that transfers work to your foreman because you hit a wall that is physically impossible to climb alone.
+
+**foreman-only blockers:**
+- credentials only the foreman possesses
+- external access only the foreman can grant
+- approval that requires foreman authority
+
+handoff is the absolute last resort. you must exhaust every option before you consider it.
+
+if you need to emit a handoff:
+
+emit to
+- .behavior/v2026_06_17.fix-review-blocker-access/5.3.verification.handoff.v$N.to_foreman.md
+
+**handoff must include:**
+1. what you tried (list every approach you attempted)
+2. why each approach failed (be specific)
+3. what makes this fundamentally impossible without foreman intervention
+4. is this truly a "foreman possesses the key" situation?
+5. rewind instruction: `rhx route.stone.set --stone 5.3.verification --as rewound`
+
+your crew should read your handoff and think: "yes, there was truly no other way."
+
+update your checklist to reference the handoff.

--- a/.behavior/v2026_06_17.fix-review-blocker-access/blocker/5.1.execution.from_vision.md
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/blocker/5.1.execution.from_vision.md
@@ -1,0 +1,49 @@
+# blocker articulation
+
+## what blocks you
+
+the guard is blocked due to exhausted L1 reviewers with stale cached blockers.
+
+**the situation:**
+- L1 reviewers (r1-r8) are all exhausted (5/5 budget)
+- their cached blockers are from iteration i5 with hash `a3e73e6d8c2edb860e` (old code)
+- current code is at iteration i7 with hash `fccbfbd750bfb7b471` (new code)
+- reviewers cannot re-review the fixed code because budgets are exhausted
+- L3 r9 malfunctioned (timed out after 21 minutes)
+- L3 r10 was still active when this articulation was written
+
+**the mismatch:**
+- the code has changed significantly since iteration i5
+- the cached blockers point to issues that may have been fixed
+- but exhausted reviewers cannot verify the fixes
+
+## what you tried
+
+1. **implementation complete**: implemented all changes per the vision
+   - reviews now write to `.reviews/peer/` instead of `.route/`
+   - lookup functions search both new and legacy locations
+   - backwards compatible with extant routes
+
+2. **tests pass**: verified implementation is correct
+   - 210 unit tests pass
+   - 299 integration tests pass
+
+3. **attempted passage**: ran `--as arrived` multiple times
+   - iteration i5, i6, i7 all blocked by exhausted reviewers
+   - code hash changed between iterations but reviewers can't re-check
+
+4. **waited for L3 reviewers**:
+   - r9 (enroll-impl-behavior-intent) malfunctioned (21 min timeout) - twice
+   - r10 (enroll-impl-arch-defects) malfunctioned (21 min timeout) - twice
+
+## what you need
+
+human intervention to unblock the guard. options:
+
+1. **add review budget**: run `rhx route.guard.budget --for review --add N --stone 5.1.execution.from_vision` to give exhausted reviewers more attempts
+
+2. **reset reviewer meters**: clear the exhaustion state so reviewers can re-review the current code
+
+3. **override guard**: if the implementation is acceptable, bypass the guard and mark stone as passed
+
+**recommendation**: option 1 or 2 preferred, as they allow proper re-review of the fixed code. the L1 cached blockers are from old code and likely no longer valid.

--- a/.behavior/v2026_06_17.fix-review-blocker-access/refs/template.[feedback].v1.[given].by_human.md
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/refs/template.[feedback].v1.[given].by_human.md
@@ -1,0 +1,27 @@
+emit your response to the feedback into
+- .behavior/v2026_06_17.fix-review-blocker-access/$BEHAVIOR_REF_NAME.[feedback].v$FEEDBACK_VERSION.[taken].by_robot.md
+
+1. emit your response checklist
+2. exec your response plan
+3. emit your response checkoffs into the checklist
+
+---
+
+first, bootup your mechanics briefs again
+
+./node_modules/.bin/rhachet roles boot --repo ehmpathy --role mechanic
+
+---
+---
+---
+
+
+# blocker.1
+
+---
+
+# nitpick.2
+
+---
+
+# blocker.3

--- a/.behavior/v2026_06_17.fix-review-blocker-access/review/self/.gitignore
+++ b/.behavior/v2026_06_17.fix-review-blocker-access/review/self/.gitignore
@@ -1,0 +1,3 @@
+# ignore all self-review files
+*
+!.gitignore

--- a/blackbox/.test/assets/route-peer-review-output/.test/mock-review-with-output.sh
+++ b/blackbox/.test/assets/route-peer-review-output/.test/mock-review-with-output.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+######################################################################
+# .what = mock review that writes to --output path
+# .why = tests that $output variable substitution works in guards
+#
+# behavior:
+#   - emits blockers/nitpicks to stdout (for guard to parse)
+#   - writes detailed report to --output path (for driver to read)
+######################################################################
+set -euo pipefail
+
+# parse --output flag
+OUTPUT_PATH=""
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --output)
+      OUTPUT_PATH="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+# emit to stdout (guard parses this)
+echo "---"
+echo "blockers: 0"
+echo "nitpicks: 1"
+echo "---"
+echo "review passed (mock with output)"
+echo ""
+echo "## nitpicks"
+echo "- consider more comments"
+
+# write to output file if specified
+if [[ -n "$OUTPUT_PATH" ]]; then
+  mkdir -p "$(dirname "$OUTPUT_PATH")"
+  cat > "$OUTPUT_PATH" << 'EOF'
+# detailed review report
+
+this is the detailed review report that was written to the $output path.
+
+## summary
+
+the review found no blockers but 1 nitpick.
+
+## nitpicks
+
+1. consider more comments to improve code readability
+
+## notes
+
+this file proves that the --output $output variable substitution works correctly.
+EOF
+fi

--- a/blackbox/.test/assets/route-peer-review-output/0.wish.md
+++ b/blackbox/.test/assets/route-peer-review-output/0.wish.md
@@ -1,0 +1,3 @@
+# wish
+
+test peer review output

--- a/blackbox/.test/assets/route-peer-review-output/1.execute.guard
+++ b/blackbox/.test/assets/route-peer-review-output/1.execute.guard
@@ -1,0 +1,12 @@
+artifacts:
+  - 1.execute*.md
+
+reviews:
+  peer:
+    - slug: mock-output
+      budget: 3
+      level: 1
+      run: bash $route/.test/mock-review-with-output.sh --output $output
+
+judges:
+  - rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1

--- a/blackbox/.test/assets/route-peer-review-output/1.execute.stone
+++ b/blackbox/.test/assets/route-peer-review-output/1.execute.stone
@@ -1,0 +1,3 @@
+# 1.execute
+
+execute the test

--- a/blackbox/.test/assets/route-peer-review-output/package.json
+++ b/blackbox/.test/assets/route-peer-review-output/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "route-peer-review-output-fixture",
+  "private": true,
+  "description": "fixture for peer review output acceptance test",
+  "dependencies": {
+    "rhachet-roles-bhrain": "link:."
+  }
+}

--- a/blackbox/__snapshots__/achiever.goal.onTalk.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/achiever.goal.onTalk.acceptance.test.ts.snap
@@ -196,8 +196,8 @@ exports[`achiever.goal.onTalk.integration given: [case9] invalid scope argument 
 {
   "scope": "invalid"
 }
-    at parseArgsForTriage (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-route-breakout/dist/contract/cli/goal.js:542:23)
-    at async Module.goalTriageInfer (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-route-breakout/dist/contract/cli/goal.js:1117:29)
+    at parseArgsForTriage (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-review-blocker-access/dist/contract/cli/goal.js:542:23)
+    at async Module.goalTriageInfer (/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-review-blocker-access/dist/contract/cli/goal.js:1117:29)
 "
 `;
 

--- a/blackbox/__snapshots__/driver.route.failsafe.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.failsafe.acceptance.test.ts.snap
@@ -7,7 +7,7 @@ exports[`driver.route.failsafe.acceptance given: [case1] reviewer exits with cod
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.review-pass.guard.review.i1.02a05f3dadac64ddd2.r1.md
+   │   └─ review: .reviews/peer/1.review-pass._.review.i1.02a05f3dadac64ddd2.r1._.given.by_peer.bash.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -22,7 +22,7 @@ exports[`driver.route.failsafe.acceptance given: [case1] reviewer exits with cod
    │  │       ├─ approved [TIME]
    │  │       ├─ 0 blockers ✓
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .route/1.review-pass.guard.review.i1.02a05f3dadac64ddd2.r1.md
+   │  │       └─ review: .reviews/peer/1.review-pass._.review.i1.02a05f3dadac64ddd2.r1._.given.by_peer.bash.md
    │  └─ judges
    │      └─ j1: bash $route/.test/mock-judge-exit-0.sh
    │          └─ finished [TIME] ✓
@@ -59,7 +59,7 @@ exports[`driver.route.failsafe.acceptance given: [case2] reviewer exits with cod
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/2.review-constraint.guard.review.i1.c090dd3895c99e392c.r1.md
+   │   └─ review: .reviews/peer/2.review-constraint._.review.i1.c090dd3895c99e392c.r1._.given.by_peer.bash.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -75,7 +75,7 @@ exports[`driver.route.failsafe.acceptance given: [case2] reviewer exits with cod
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/2.review-constraint.guard.review.i1.c090dd3895c99e392c.r1.md
+      │       └─ review: .reviews/peer/2.review-constraint._.review.i1.c090dd3895c99e392c.r1._.given.by_peer.bash.md
       └─ judges
           └─ j1: bash $route/.test/mock-judge-exit-2.sh
               ├─ finished [TIME] ✗
@@ -109,7 +109,7 @@ exports[`driver.route.failsafe.acceptance given: [case3] reviewer exits with cod
    │
    ├─ r1: bash (l1, 1/∞)
    │   ├─ 💥 malfunction
-   │   └─ review: .route/3.review-malfunction.guard.review.i1.b6fcd55294fe610638.r1.md
+   │   └─ review: .reviews/peer/3.review-malfunction._.review.i1.b6fcd55294fe610638.r1._.given.by_peer.bash.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -123,7 +123,7 @@ exports[`driver.route.failsafe.acceptance given: [case3] reviewer exits with cod
       ├─ reviews
       │   └─ r1: bash (l1, 0/∞)
       │       ├─ 💥 malfunction
-      │       └─ review: .route/3.review-malfunction.guard.review.i1.b6fcd55294fe610638.r1.md
+      │       └─ review: .reviews/peer/3.review-malfunction._.review.i1.b6fcd55294fe610638.r1._.given.by_peer.bash.md
       └─ judges
           └─ j1: bash $route/.test/mock-judge-exit-0.sh
               └─ finished [TIME] ✓
@@ -298,7 +298,7 @@ exports[`driver.route.failsafe.acceptance given: [case7] both reviewer and judge
    │
    ├─ r1: bash (l1, 1/∞)
    │   ├─ 💥 malfunction
-   │   └─ review: .route/7.both-malfunction.guard.review.i1.a4c505990c8a7a5349.r1.md
+   │   └─ review: .reviews/peer/7.both-malfunction._.review.i1.a4c505990c8a7a5349.r1._.given.by_peer.bash.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -311,7 +311,7 @@ exports[`driver.route.failsafe.acceptance given: [case7] both reviewer and judge
       ├─ reviews
       │   └─ r1: bash (l1, 0/∞)
       │       ├─ 💥 malfunction
-      │       └─ review: .route/7.both-malfunction.guard.review.i1.a4c505990c8a7a5349.r1.md
+      │       └─ review: .reviews/peer/7.both-malfunction._.review.i1.a4c505990c8a7a5349.r1._.given.by_peer.bash.md
       └─ judges
           └─ j1: bash $route/.test/mock-judge-exit-1.sh
               ├─ finished [TIME] ✗

--- a/blackbox/__snapshots__/driver.route.journey.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.journey.acceptance.test.ts.snap
@@ -220,8 +220,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
    │   ├─ approved, cached
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/3.blueprint.guard.review.i2.79ce73effeb06a18dd.r1.md
-   ├─ ✓ judge.1 - allowed (cached)
+   │   └─ review: .reviews/peer/3.blueprint._.review.i2.79ce73effeb06a18dd.r1._.given.by_peer.bash.md
    │
    └─ ✗ judge.2 - blocked [TIME]
 
@@ -237,7 +236,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
       │       ├─ approved, cached
       │       ├─ 0 blockers ✓
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/3.blueprint.guard.review.i2.79ce73effeb06a18dd.r1.md
+      │       └─ review: .reviews/peer/3.blueprint._.review.i2.79ce73effeb06a18dd.r1._.given.by_peer.bash.md
       └─ judges
           ├─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 2
           │   └─ · cached
@@ -255,7 +254,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/3.blueprint.guard.review.i1.3e91961a538c3c8774.r1.md
+   │   └─ review: .reviews/peer/3.blueprint._.review.i1.3e91961a538c3c8774.r1._.given.by_peer.bash.md
    │
    ├─ ✗ judge.1 - blocked [TIME]
    │
@@ -273,7 +272,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/3.blueprint.guard.review.i1.3e91961a538c3c8774.r1.md
+      │       └─ review: .reviews/peer/3.blueprint._.review.i1.3e91961a538c3c8774.r1._.given.by_peer.bash.md
       └─ judges
           ├─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 2
           │   ├─ finished [TIME] ✗
@@ -291,7 +290,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
    │   ├─ approved, cached
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/3.blueprint.guard.review.i2.79ce73effeb06a18dd.r1.md
+   │   └─ review: .reviews/peer/3.blueprint._.review.i2.79ce73effeb06a18dd.r1._.given.by_peer.bash.md
    │
    ├─ ✓ judge.1 - allowed [TIME]
    │
@@ -308,7 +307,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
    │  │       ├─ approved, cached
    │  │       ├─ 0 blockers ✓
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .route/3.blueprint.guard.review.i2.79ce73effeb06a18dd.r1.md
+   │  │       └─ review: .reviews/peer/3.blueprint._.review.i2.79ce73effeb06a18dd.r1._.given.by_peer.bash.md
    │  └─ judges
    │      ├─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 2
    │      │   └─ finished [TIME] ✓
@@ -336,7 +335,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/5.execute.guard.review.i1.cfd13790ea94701543.r1.md
+   │   └─ review: .reviews/peer/5.execute._.review.i1.cfd13790ea94701543.r1._.given.by_peer.bash.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -351,7 +350,7 @@ exports[`driver.route.journey.acceptance given: [journey] weather api route when
    │  │       ├─ approved [TIME]
    │  │       ├─ 0 blockers ✓
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .route/5.execute.guard.review.i1.cfd13790ea94701543.r1.md
+   │  │       └─ review: .reviews/peer/5.execute._.review.i1.cfd13790ea94701543.r1._.given.by_peer.bash.md
    │  └─ judges
    │      └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
    │          └─ finished [TIME] ✓

--- a/blackbox/__snapshots__/driver.route.overrule.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.overrule.acceptance.test.ts.snap
@@ -16,7 +16,7 @@ exports[`driver.route.overrule.acceptance given: [case1] human overrules blocked
    │   ├─ rejected, cached
    │   ├─ 3 blockers 🔴
    │   ├─ 7 nitpicks 🟠
-   │   └─ review: .route/1.plan.guard.review.i1.ec6c3f2f9d5189084f.r1.md
+   │   └─ review: .reviews/peer/1.plan._.review.i1.ec6c3f2f9d5189084f.r1._.given.by_peer.bash.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -31,7 +31,7 @@ exports[`driver.route.overrule.acceptance given: [case1] human overrules blocked
    │  │       ├─ rejected, cached
    │  │       ├─ 3 blockers 🔴
    │  │       ├─ 7 nitpicks 🟠
-   │  │       └─ review: .route/1.plan.guard.review.i1.ec6c3f2f9d5189084f.r1.md
+   │  │       └─ review: .reviews/peer/1.plan._.review.i1.ec6c3f2f9d5189084f.r1._.given.by_peer.bash.md
    │  └─ judges
    │      └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0
    │          └─ finished [TIME] ✓

--- a/blackbox/__snapshots__/driver.route.peer-budget-3level.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.peer-budget-3level.acceptance.test.ts.snap
@@ -7,7 +7,7 @@ exports[`driver.route.peer-budget-3level.acceptance given: [journey] 3-level hie
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i1.8739656801d5e77f22.r1.md
+   │   └─ review: .reviews/peer/1.vision._.review.i1.8739656801d5e77f22.r1._.given.by_peer.basic-checker.md
    │
    ├─ r2: advanced-checker (l2, 0/5)
    │   └─ awaits arrival
@@ -29,7 +29,7 @@ exports[`driver.route.peer-budget-3level.acceptance given: [journey] 3-level hie
       │   │   ├─ rejected [TIME]
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i1.8739656801d5e77f22.r1.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i1.8739656801d5e77f22.r1._.given.by_peer.basic-checker.md
       │   ├─ r2: advanced-checker (l2, 0/5)
       │   │   └─ awaits l1 terminal
       │   └─ r3: premium-checker (l3, 0/5)
@@ -48,13 +48,13 @@ exports[`driver.route.peer-budget-3level.acceptance given: [journey] 3-level hie
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.basic-checker.md
    │
    ├─ r2: advanced-checker (l2, 1/5)
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r2.md
+   │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r2._.given.by_peer.advanced-checker.md
    │
    ├─ r3: premium-checker (l3, 0/5)
    │   └─ awaits arrival
@@ -73,12 +73,12 @@ exports[`driver.route.peer-budget-3level.acceptance given: [journey] 3-level hie
       │   │   ├─ approved [TIME]
       │   │   ├─ 0 blockers ✓
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.basic-checker.md
       │   ├─ r2: advanced-checker (l2, 1/5)
       │   │   ├─ rejected [TIME]
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r2.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r2._.given.by_peer.advanced-checker.md
       │   └─ r3: premium-checker (l3, 0/5)
       │       └─ awaits l2 terminal
       └─ judges
@@ -95,19 +95,19 @@ exports[`driver.route.peer-budget-3level.acceptance given: [journey] 3-level hie
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r1.md
+   │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r1._.given.by_peer.basic-checker.md
    │
    ├─ r2: advanced-checker (l2, 2/5)
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r2.md
+   │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.advanced-checker.md
    │
    ├─ r3: premium-checker (l3, 1/5)
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r3.md
+   │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r3._.given.by_peer.premium-checker.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -123,17 +123,17 @@ exports[`driver.route.peer-budget-3level.acceptance given: [journey] 3-level hie
       │   │   ├─ approved [TIME]
       │   │   ├─ 0 blockers ✓
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r1.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r1._.given.by_peer.basic-checker.md
       │   ├─ r2: advanced-checker (l2, 2/5)
       │   │   ├─ approved [TIME]
       │   │   ├─ 0 blockers ✓
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r2.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.advanced-checker.md
       │   └─ r3: premium-checker (l3, 1/5)
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r3.md
+      │       └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r3._.given.by_peer.premium-checker.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗
@@ -148,19 +148,19 @@ exports[`driver.route.peer-budget-3level.acceptance given: [journey] 3-level hie
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i4.d1bd0b8547352e6396.r1.md
+   │   └─ review: .reviews/peer/1.vision._.review.i4.d1bd0b8547352e6396.r1._.given.by_peer.basic-checker.md
    │
    ├─ r2: advanced-checker (l2, 3/5)
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i4.d1bd0b8547352e6396.r2.md
+   │   └─ review: .reviews/peer/1.vision._.review.i4.d1bd0b8547352e6396.r2._.given.by_peer.advanced-checker.md
    │
    ├─ r3: premium-checker (l3, 2/5)
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i4.d1bd0b8547352e6396.r3.md
+   │   └─ review: .reviews/peer/1.vision._.review.i4.d1bd0b8547352e6396.r3._.given.by_peer.premium-checker.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -175,17 +175,17 @@ exports[`driver.route.peer-budget-3level.acceptance given: [journey] 3-level hie
    │  │   │   ├─ approved [TIME]
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .route/1.vision.guard.review.i4.d1bd0b8547352e6396.r1.md
+   │  │   │   └─ review: .reviews/peer/1.vision._.review.i4.d1bd0b8547352e6396.r1._.given.by_peer.basic-checker.md
    │  │   ├─ r2: advanced-checker (l2, 3/5)
    │  │   │   ├─ approved [TIME]
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .route/1.vision.guard.review.i4.d1bd0b8547352e6396.r2.md
+   │  │   │   └─ review: .reviews/peer/1.vision._.review.i4.d1bd0b8547352e6396.r2._.given.by_peer.advanced-checker.md
    │  │   └─ r3: premium-checker (l3, 2/5)
    │  │       ├─ approved [TIME]
    │  │       ├─ 0 blockers ✓
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .route/1.vision.guard.review.i4.d1bd0b8547352e6396.r3.md
+   │  │       └─ review: .reviews/peer/1.vision._.review.i4.d1bd0b8547352e6396.r3._.given.by_peer.premium-checker.md
    │  └─ judges
    │      └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
    │          └─ finished [TIME] ✓

--- a/blackbox/__snapshots__/driver.route.peer-budget-all-terminal-halt.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.peer-budget-all-terminal-halt.acceptance.test.ts.snap
@@ -7,7 +7,7 @@ exports[`driver.route.peer-budget-all-terminal-halt.acceptance given: [case1] le
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i1.8739656801d5e77f22.r1.md
+   │   └─ review: .reviews/peer/1.vision._.review.i1.8739656801d5e77f22.r1._.given.by_peer.quick-fail.md
    │
    ├─ r2: thorough (l2, 0/2)
    │   └─ awaits arrival
@@ -26,7 +26,7 @@ exports[`driver.route.peer-budget-all-terminal-halt.acceptance given: [case1] le
       │   │   ├─ rejected [TIME]
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i1.8739656801d5e77f22.r1.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i1.8739656801d5e77f22.r1._.given.by_peer.quick-fail.md
       │   └─ r2: thorough (l2, 0/2)
       │       └─ awaits l1 terminal
       └─ judges
@@ -43,13 +43,13 @@ exports[`driver.route.peer-budget-all-terminal-halt.acceptance given: [case1] le
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i1.8739656801d5e77f22.r1.md
+   │   └─ review: .reviews/peer/1.vision._.review.i1.8739656801d5e77f22.r1._.given.by_peer.quick-fail.md
    │
    ├─ r2: thorough (l2, 1/2)
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r2.md
+   │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r2._.given.by_peer.thorough.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -65,12 +65,12 @@ exports[`driver.route.peer-budget-all-terminal-halt.acceptance given: [case1] le
       │   │   ├─ exhausted, cached
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i1.8739656801d5e77f22.r1.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i1.8739656801d5e77f22.r1._.given.by_peer.quick-fail.md
       │   └─ r2: thorough (l2, 1/2)
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r2.md
+      │       └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r2._.given.by_peer.thorough.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗
@@ -85,13 +85,13 @@ exports[`driver.route.peer-budget-all-terminal-halt.acceptance given: [case1] le
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i1.8739656801d5e77f22.r1.md
+   │   └─ review: .reviews/peer/1.vision._.review.i1.8739656801d5e77f22.r1._.given.by_peer.quick-fail.md
    │
    ├─ r2: thorough (l2, 2/2)
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r2.md
+   │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.thorough.md
    │
    └─ halted: peer reviewer budget exhausted
 
@@ -112,12 +112,12 @@ exports[`driver.route.peer-budget-all-terminal-halt.acceptance given: [case1] le
           │   ├─ exhausted, cached
           │   ├─ 1 blocker 🔴
           │   ├─ 0 nitpicks ✓
-          │   └─ review: .route/1.vision.guard.review.i1.8739656801d5e77f22.r1.md
+          │   └─ review: .reviews/peer/1.vision._.review.i1.8739656801d5e77f22.r1._.given.by_peer.quick-fail.md
           └─ r2: thorough (l2, 2/2)
               ├─ exhausted, cached
               ├─ 1 blocker 🔴
               ├─ 0 nitpicks ✓
-              └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r2.md
+              └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.thorough.md
 "
 `;
 
@@ -128,13 +128,13 @@ exports[`driver.route.peer-budget-all-terminal-halt.acceptance given: [case1] le
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i1.8739656801d5e77f22.r1.md
+   │   └─ review: .reviews/peer/1.vision._.review.i1.8739656801d5e77f22.r1._.given.by_peer.quick-fail.md
    │
    ├─ r2: thorough (l2, 2/2)
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r2.md
+   │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.thorough.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -150,12 +150,12 @@ exports[`driver.route.peer-budget-all-terminal-halt.acceptance given: [case1] le
       │   │   ├─ exhausted, cached
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i1.8739656801d5e77f22.r1.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i1.8739656801d5e77f22.r1._.given.by_peer.quick-fail.md
       │   └─ r2: thorough (l2, 2/2)
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r2.md
+      │       └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.thorough.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗

--- a/blackbox/__snapshots__/driver.route.peer-budget-approval-persistence.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.peer-budget-approval-persistence.acceptance.test.ts.snap
@@ -7,7 +7,7 @@ exports[`driver.route.peer-budget-approval-persistence.acceptance given: [journe
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i1.8739656801d5e77f22.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i1.8739656801d5e77f22.r1._.given.by_peer.mock-reviewer.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -23,7 +23,7 @@ exports[`driver.route.peer-budget-approval-persistence.acceptance given: [journe
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.execute.guard.review.i1.8739656801d5e77f22.r1.md
+      │       └─ review: .reviews/peer/1.execute._.review.i1.8739656801d5e77f22.r1._.given.by_peer.mock-reviewer.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗
@@ -38,7 +38,7 @@ exports[`driver.route.peer-budget-approval-persistence.acceptance given: [journe
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.mock-reviewer.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -54,7 +54,7 @@ exports[`driver.route.peer-budget-approval-persistence.acceptance given: [journe
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+      │       └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.mock-reviewer.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗
@@ -78,7 +78,7 @@ exports[`driver.route.peer-budget-approval-persistence.acceptance given: [journe
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.mock-reviewer.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -93,7 +93,7 @@ exports[`driver.route.peer-budget-approval-persistence.acceptance given: [journe
    │  │       ├─ exhausted, cached
    │  │       ├─ 1 blocker 🔴
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │  │       └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.mock-reviewer.md
    │  └─ judges
    │      └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
    │          └─ finished [TIME] ✓
@@ -110,7 +110,7 @@ exports[`driver.route.peer-budget-approval-persistence.acceptance given: [journe
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.mock-reviewer.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -125,7 +125,7 @@ exports[`driver.route.peer-budget-approval-persistence.acceptance given: [journe
    │  │       ├─ exhausted, cached
    │  │       ├─ 1 blocker 🔴
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │  │       └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.mock-reviewer.md
    │  └─ judges
    │      └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
    │          └─ finished [TIME] ✓

--- a/blackbox/__snapshots__/driver.route.peer-budget-approval-unification.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.peer-budget-approval-unification.acceptance.test.ts.snap
@@ -7,7 +7,7 @@ exports[`driver.route.peer-budget-approval-unification.acceptance given: [usecas
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i1.8739656801d5e77f22.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i1.8739656801d5e77f22.r1._.given.by_peer.strict-checker.md
    │
    ├─ ✗ judge.1 - blocked [TIME]
    │
@@ -25,7 +25,7 @@ exports[`driver.route.peer-budget-approval-unification.acceptance given: [usecas
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.execute.guard.review.i1.8739656801d5e77f22.r1.md
+      │       └─ review: .reviews/peer/1.execute._.review.i1.8739656801d5e77f22.r1._.given.by_peer.strict-checker.md
       └─ judges
           ├─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
           │   ├─ finished [TIME] ✗
@@ -43,7 +43,7 @@ exports[`driver.route.peer-budget-approval-unification.acceptance given: [usecas
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.strict-checker.md
    │
    └─ halted: peer reviewer budget exhausted
 
@@ -64,7 +64,7 @@ exports[`driver.route.peer-budget-approval-unification.acceptance given: [usecas
               ├─ exhausted, cached
               ├─ 1 blocker 🔴
               ├─ 0 nitpicks ✓
-              └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+              └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.strict-checker.md
 "
 `;
 
@@ -75,7 +75,7 @@ exports[`driver.route.peer-budget-approval-unification.acceptance given: [usecas
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.strict-checker.md
    │
    ├─ ✗ judge.1 - blocked [TIME]
    │
@@ -93,7 +93,7 @@ exports[`driver.route.peer-budget-approval-unification.acceptance given: [usecas
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+      │       └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.strict-checker.md
       └─ judges
           ├─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
           │   ├─ finished [TIME] ✗
@@ -120,7 +120,7 @@ exports[`driver.route.peer-budget-approval-unification.acceptance given: [usecas
       │       ├─ exhausted
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: /tmp/test-fns/rhachet-roles-bhrain.vlad.fix-route-breakout/.temp/2026-06-19T10-11-32.289Z.peer-budget-approval-unification.015f5289/.route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+      │       └─ review: /tmp/test-fns/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/2026-06-19T12-15-40.398Z.peer-budget-approval-unification.7be10513/.reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.strict-checker.md
       │
       ├─ please ask a human to either
       │  ├─ approve as-is
@@ -150,7 +150,7 @@ exports[`driver.route.peer-budget-approval-unification.acceptance given: [usecas
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.strict-checker.md
    │
    ├─ ✓ judge.1 - allowed [TIME]
    │
@@ -167,7 +167,7 @@ exports[`driver.route.peer-budget-approval-unification.acceptance given: [usecas
    │  │       ├─ exhausted, cached
    │  │       ├─ 1 blocker 🔴
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │  │       └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.strict-checker.md
    │  └─ judges
    │      ├─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
    │      │   └─ finished [TIME] ✓

--- a/blackbox/__snapshots__/driver.route.peer-budget-bulk.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.peer-budget-bulk.acceptance.test.ts.snap
@@ -22,13 +22,13 @@ exports[`driver.route.peer-budget-bulk.acceptance given: [case1] bulk budget ext
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i6.deec084a9ead287f47.r1.md
+   │   └─ review: .reviews/peer/1.vision._.review.i6.deec084a9ead287f47.r1._.given.by_peer.linter.md
    │
    ├─ r2: spellcheck (l1, 4/5)
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i6.deec084a9ead287f47.r2.md
+   │   └─ review: .reviews/peer/1.vision._.review.i6.deec084a9ead287f47.r2._.given.by_peer.spellcheck.md
    │
    ├─ r3: architect (l2, 2/4)
    │   └─ awaits arrival
@@ -47,12 +47,12 @@ exports[`driver.route.peer-budget-bulk.acceptance given: [case1] bulk budget ext
       │   │   ├─ rejected [TIME]
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i6.deec084a9ead287f47.r1.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i6.deec084a9ead287f47.r1._.given.by_peer.linter.md
       │   ├─ r2: spellcheck (l1, 4/5)
       │   │   ├─ rejected [TIME]
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i6.deec084a9ead287f47.r2.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i6.deec084a9ead287f47.r2._.given.by_peer.spellcheck.md
       │   └─ r3: architect (l2, 2/4)
       │       └─ awaits l1 terminal
       └─ judges

--- a/blackbox/__snapshots__/driver.route.peer-budget-defaults.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.peer-budget-defaults.acceptance.test.ts.snap
@@ -7,7 +7,7 @@ exports[`driver.route.peer-budget-defaults.acceptance given: [journey] peer revi
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i1.8739656801d5e77f22.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i1.8739656801d5e77f22.r1._.given.by_peer.legacy-reviewer.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -23,7 +23,7 @@ exports[`driver.route.peer-budget-defaults.acceptance given: [journey] peer revi
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.execute.guard.review.i1.8739656801d5e77f22.r1.md
+      │       └─ review: .reviews/peer/1.execute._.review.i1.8739656801d5e77f22.r1._.given.by_peer.legacy-reviewer.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗
@@ -38,7 +38,7 @@ exports[`driver.route.peer-budget-defaults.acceptance given: [journey] peer revi
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i6.f3f272257af6779ffe.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i6.f3f272257af6779ffe.r1._.given.by_peer.legacy-reviewer.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -54,7 +54,7 @@ exports[`driver.route.peer-budget-defaults.acceptance given: [journey] peer revi
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.execute.guard.review.i6.f3f272257af6779ffe.r1.md
+      │       └─ review: .reviews/peer/1.execute._.review.i6.f3f272257af6779ffe.r1._.given.by_peer.legacy-reviewer.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗
@@ -69,7 +69,7 @@ exports[`driver.route.peer-budget-defaults.acceptance given: [journey] peer revi
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i7.f349fccd9ea124b5ab.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i7.f349fccd9ea124b5ab.r1._.given.by_peer.legacy-reviewer.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -84,7 +84,7 @@ exports[`driver.route.peer-budget-defaults.acceptance given: [journey] peer revi
    │  │       ├─ approved [TIME]
    │  │       ├─ 0 blockers ✓
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .route/1.execute.guard.review.i7.f349fccd9ea124b5ab.r1.md
+   │  │       └─ review: .reviews/peer/1.execute._.review.i7.f349fccd9ea124b5ab.r1._.given.by_peer.legacy-reviewer.md
    │  └─ judges
    │      └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
    │          └─ finished [TIME] ✓

--- a/blackbox/__snapshots__/driver.route.peer-budget-exhausted-hash-change.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.peer-budget-exhausted-hash-change.acceptance.test.ts.snap
@@ -7,7 +7,7 @@ exports[`driver.route.peer-budget-exhausted-hash-change.acceptance given: [matri
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.580b7bfdddc2b7279d.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.580b7bfdddc2b7279d.r1._.given.by_peer.mock-reviewer.md
    │
    └─ halted: peer reviewer budget exhausted
 
@@ -28,7 +28,7 @@ exports[`driver.route.peer-budget-exhausted-hash-change.acceptance given: [matri
               ├─ exhausted, cached
               ├─ 1 blocker 🔴
               ├─ 0 nitpicks ✓
-              └─ review: .route/1.execute.guard.review.i2.580b7bfdddc2b7279d.r1.md
+              └─ review: .reviews/peer/1.execute._.review.i2.580b7bfdddc2b7279d.r1._.given.by_peer.mock-reviewer.md
 "
 `;
 
@@ -39,7 +39,7 @@ exports[`driver.route.peer-budget-exhausted-hash-change.acceptance given: [matri
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.580b7bfdddc2b7279d.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.580b7bfdddc2b7279d.r1._.given.by_peer.mock-reviewer.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -55,7 +55,7 @@ exports[`driver.route.peer-budget-exhausted-hash-change.acceptance given: [matri
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.execute.guard.review.i2.580b7bfdddc2b7279d.r1.md
+      │       └─ review: .reviews/peer/1.execute._.review.i2.580b7bfdddc2b7279d.r1._.given.by_peer.mock-reviewer.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗
@@ -70,7 +70,7 @@ exports[`driver.route.peer-budget-exhausted-hash-change.acceptance given: [matri
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.580b7bfdddc2b7279d.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.580b7bfdddc2b7279d.r1._.given.by_peer.mock-reviewer.md
    │
    └─ halted: peer reviewer budget exhausted
 
@@ -91,7 +91,7 @@ exports[`driver.route.peer-budget-exhausted-hash-change.acceptance given: [matri
               ├─ exhausted, cached
               ├─ 1 blocker 🔴
               ├─ 0 nitpicks ✓
-              └─ review: .route/1.execute.guard.review.i2.580b7bfdddc2b7279d.r1.md
+              └─ review: .reviews/peer/1.execute._.review.i2.580b7bfdddc2b7279d.r1._.given.by_peer.mock-reviewer.md
 "
 `;
 
@@ -102,7 +102,7 @@ exports[`driver.route.peer-budget-exhausted-hash-change.acceptance given: [matri
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.580b7bfdddc2b7279d.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.580b7bfdddc2b7279d.r1._.given.by_peer.mock-reviewer.md
    │
    └─ halted: peer reviewer budget exhausted
 
@@ -123,6 +123,6 @@ exports[`driver.route.peer-budget-exhausted-hash-change.acceptance given: [matri
               ├─ exhausted, cached
               ├─ 1 blocker 🔴
               ├─ 0 nitpicks ✓
-              └─ review: .route/1.execute.guard.review.i2.580b7bfdddc2b7279d.r1.md
+              └─ review: .reviews/peer/1.execute._.review.i2.580b7bfdddc2b7279d.r1._.given.by_peer.mock-reviewer.md
 "
 `;

--- a/blackbox/__snapshots__/driver.route.peer-budget-exhaustion-unlocks-level.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.peer-budget-exhaustion-unlocks-level.acceptance.test.ts.snap
@@ -7,7 +7,7 @@ exports[`driver.route.peer-budget-exhaustion-unlocks-level.acceptance given: [jo
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i1.8739656801d5e77f22.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i1.8739656801d5e77f22.r1._.given.by_peer.l1-reviewer.md
    │
    ├─ r2: l3-reviewer (l3, 0/5)
    │   └─ awaits arrival
@@ -26,7 +26,7 @@ exports[`driver.route.peer-budget-exhaustion-unlocks-level.acceptance given: [jo
       │   │   ├─ rejected [TIME]
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.execute.guard.review.i1.8739656801d5e77f22.r1.md
+      │   │   └─ review: .reviews/peer/1.execute._.review.i1.8739656801d5e77f22.r1._.given.by_peer.l1-reviewer.md
       │   └─ r2: l3-reviewer (l3, 0/5)
       │       └─ awaits l1 terminal
       └─ judges
@@ -43,7 +43,7 @@ exports[`driver.route.peer-budget-exhaustion-unlocks-level.acceptance given: [jo
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.l1-reviewer.md
    │
    ├─ r2: l3-reviewer (l3, 0/5)
    │   └─ awaits arrival
@@ -62,7 +62,7 @@ exports[`driver.route.peer-budget-exhaustion-unlocks-level.acceptance given: [jo
       │   │   ├─ rejected [TIME]
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+      │   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.l1-reviewer.md
       │   └─ r2: l3-reviewer (l3, 0/5)
       │       └─ awaits l1 terminal
       └─ judges
@@ -79,13 +79,13 @@ exports[`driver.route.peer-budget-exhaustion-unlocks-level.acceptance given: [jo
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.l1-reviewer.md
    │
    ├─ r2: l3-reviewer (l3, 1/5)
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i3.457fd5ef46e053a35e.r2.md
+   │   └─ review: .reviews/peer/1.execute._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.l3-reviewer.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -101,12 +101,12 @@ exports[`driver.route.peer-budget-exhaustion-unlocks-level.acceptance given: [jo
       │   │   ├─ exhausted, cached
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+      │   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.l1-reviewer.md
       │   └─ r2: l3-reviewer (l3, 1/5)
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.execute.guard.review.i3.457fd5ef46e053a35e.r2.md
+      │       └─ review: .reviews/peer/1.execute._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.l3-reviewer.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗
@@ -121,13 +121,13 @@ exports[`driver.route.peer-budget-exhaustion-unlocks-level.acceptance given: [jo
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.l1-reviewer.md
    │
    ├─ r2: l3-reviewer (l3, 2/5)
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i4.06fcb8d2e60f371042.r2.md
+   │   └─ review: .reviews/peer/1.execute._.review.i4.06fcb8d2e60f371042.r2._.given.by_peer.l3-reviewer.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -143,12 +143,12 @@ exports[`driver.route.peer-budget-exhaustion-unlocks-level.acceptance given: [jo
       │   │   ├─ exhausted, cached
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+      │   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.l1-reviewer.md
       │   └─ r2: l3-reviewer (l3, 2/5)
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.execute.guard.review.i4.06fcb8d2e60f371042.r2.md
+      │       └─ review: .reviews/peer/1.execute._.review.i4.06fcb8d2e60f371042.r2._.given.by_peer.l3-reviewer.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗

--- a/blackbox/__snapshots__/driver.route.peer-budget-isolation.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.peer-budget-isolation.acceptance.test.ts.snap
@@ -7,7 +7,7 @@ exports[`driver.route.peer-budget-isolation.acceptance given: [journey] per-ston
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.alpha.guard.review.i2.7b0642204fa64344b4.r1.md
+   │   └─ review: .reviews/peer/1.alpha._.review.i2.7b0642204fa64344b4.r1._.given.by_peer.shared-reviewer.md
    │
    └─ halted: peer reviewer budget exhausted
 
@@ -28,7 +28,7 @@ exports[`driver.route.peer-budget-isolation.acceptance given: [journey] per-ston
               ├─ exhausted, cached
               ├─ 1 blocker 🔴
               ├─ 0 nitpicks ✓
-              └─ review: .route/1.alpha.guard.review.i2.7b0642204fa64344b4.r1.md
+              └─ review: .reviews/peer/1.alpha._.review.i2.7b0642204fa64344b4.r1._.given.by_peer.shared-reviewer.md
 "
 `;
 
@@ -39,7 +39,7 @@ exports[`driver.route.peer-budget-isolation.acceptance given: [journey] per-ston
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.alpha.guard.review.i2.7b0642204fa64344b4.r1.md
+   │   └─ review: .reviews/peer/1.alpha._.review.i2.7b0642204fa64344b4.r1._.given.by_peer.shared-reviewer.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -55,7 +55,7 @@ exports[`driver.route.peer-budget-isolation.acceptance given: [journey] per-ston
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.alpha.guard.review.i2.7b0642204fa64344b4.r1.md
+      │       └─ review: .reviews/peer/1.alpha._.review.i2.7b0642204fa64344b4.r1._.given.by_peer.shared-reviewer.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗
@@ -70,7 +70,7 @@ exports[`driver.route.peer-budget-isolation.acceptance given: [journey] per-ston
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/2.beta.guard.review.i1.e4d78222654bf1beda.r1.md
+   │   └─ review: .reviews/peer/2.beta._.review.i1.e4d78222654bf1beda.r1._.given.by_peer.shared-reviewer.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -86,7 +86,7 @@ exports[`driver.route.peer-budget-isolation.acceptance given: [journey] per-ston
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/2.beta.guard.review.i1.e4d78222654bf1beda.r1.md
+      │       └─ review: .reviews/peer/2.beta._.review.i1.e4d78222654bf1beda.r1._.given.by_peer.shared-reviewer.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗
@@ -101,7 +101,7 @@ exports[`driver.route.peer-budget-isolation.acceptance given: [journey] per-ston
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/2.beta.guard.review.i2.891c50a3c7d474cdf4.r1.md
+   │   └─ review: .reviews/peer/2.beta._.review.i2.891c50a3c7d474cdf4.r1._.given.by_peer.shared-reviewer.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -116,7 +116,7 @@ exports[`driver.route.peer-budget-isolation.acceptance given: [journey] per-ston
    │  │       ├─ approved [TIME]
    │  │       ├─ 0 blockers ✓
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .route/2.beta.guard.review.i2.891c50a3c7d474cdf4.r1.md
+   │  │       └─ review: .reviews/peer/2.beta._.review.i2.891c50a3c7d474cdf4.r1._.given.by_peer.shared-reviewer.md
    │  └─ judges
    │      └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
    │          └─ finished [TIME] ✓

--- a/blackbox/__snapshots__/driver.route.peer-budget-levels.journey.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.peer-budget-levels.journey.acceptance.test.ts.snap
@@ -7,7 +7,7 @@ exports[`driver.route.peer-budget-levels.journey.acceptance given: [journey] sto
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i1.8739656801d5e77f22.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i1.8739656801d5e77f22.r1._.given.by_peer.cheapo.md
    │
    ├─ r2: primo (l2, 0/2)
    │   └─ awaits arrival
@@ -26,7 +26,7 @@ exports[`driver.route.peer-budget-levels.journey.acceptance given: [journey] sto
       │   │   ├─ rejected [TIME]
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.execute.guard.review.i1.8739656801d5e77f22.r1.md
+      │   │   └─ review: .reviews/peer/1.execute._.review.i1.8739656801d5e77f22.r1._.given.by_peer.cheapo.md
       │   └─ r2: primo (l2, 0/2)
       │       └─ awaits l1 terminal
       └─ judges
@@ -43,7 +43,7 @@ exports[`driver.route.peer-budget-levels.journey.acceptance given: [journey] sto
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.cheapo.md
    │
    ├─ r2: primo (l2, 0/2)
    │   └─ awaits arrival
@@ -62,7 +62,7 @@ exports[`driver.route.peer-budget-levels.journey.acceptance given: [journey] sto
       │   │   ├─ rejected [TIME]
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+      │   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.cheapo.md
       │   └─ r2: primo (l2, 0/2)
       │       └─ awaits l1 terminal
       └─ judges
@@ -79,13 +79,13 @@ exports[`driver.route.peer-budget-levels.journey.acceptance given: [journey] sto
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.cheapo.md
    │
    ├─ r2: primo (l2, 1/2)
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i3.457fd5ef46e053a35e.r2.md
+   │   └─ review: .reviews/peer/1.execute._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.primo.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -101,12 +101,12 @@ exports[`driver.route.peer-budget-levels.journey.acceptance given: [journey] sto
       │   │   ├─ exhausted, cached
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+      │   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.cheapo.md
       │   └─ r2: primo (l2, 1/2)
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.execute.guard.review.i3.457fd5ef46e053a35e.r2.md
+      │       └─ review: .reviews/peer/1.execute._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.primo.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗
@@ -121,13 +121,13 @@ exports[`driver.route.peer-budget-levels.journey.acceptance given: [journey] sto
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.cheapo.md
    │
    ├─ r2: primo (l2, 2/2)
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i4.6dddc53e1de2efc1da.r2.md
+   │   └─ review: .reviews/peer/1.execute._.review.i4.6dddc53e1de2efc1da.r2._.given.by_peer.primo.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -143,12 +143,12 @@ exports[`driver.route.peer-budget-levels.journey.acceptance given: [journey] sto
       │   │   ├─ exhausted, cached
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+      │   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.cheapo.md
       │   └─ r2: primo (l2, 2/2)
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.execute.guard.review.i4.6dddc53e1de2efc1da.r2.md
+      │       └─ review: .reviews/peer/1.execute._.review.i4.6dddc53e1de2efc1da.r2._.given.by_peer.primo.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗
@@ -163,13 +163,13 @@ exports[`driver.route.peer-budget-levels.journey.acceptance given: [journey] sto
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.cheapo.md
    │
    ├─ r2: primo (l2, 2/2)
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i4.6dddc53e1de2efc1da.r2.md
+   │   └─ review: .reviews/peer/1.execute._.review.i4.6dddc53e1de2efc1da.r2._.given.by_peer.primo.md
    │
    └─ halted: peer reviewer budget exhausted
 
@@ -190,12 +190,12 @@ exports[`driver.route.peer-budget-levels.journey.acceptance given: [journey] sto
           │   ├─ exhausted, cached
           │   ├─ 1 blocker 🔴
           │   ├─ 0 nitpicks ✓
-          │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+          │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.cheapo.md
           └─ r2: primo (l2, 2/2)
               ├─ exhausted, cached
               ├─ 1 blocker 🔴
               ├─ 0 nitpicks ✓
-              └─ review: .route/1.execute.guard.review.i4.6dddc53e1de2efc1da.r2.md
+              └─ review: .reviews/peer/1.execute._.review.i4.6dddc53e1de2efc1da.r2._.given.by_peer.primo.md
 "
 `;
 
@@ -215,13 +215,13 @@ exports[`driver.route.peer-budget-levels.journey.acceptance given: [journey] sto
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.cheapo.md
    │
    ├─ r2: primo (l2, 2/2)
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i4.6dddc53e1de2efc1da.r2.md
+   │   └─ review: .reviews/peer/1.execute._.review.i4.6dddc53e1de2efc1da.r2._.given.by_peer.primo.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -236,12 +236,12 @@ exports[`driver.route.peer-budget-levels.journey.acceptance given: [journey] sto
    │  │   │   ├─ exhausted, cached
    │  │   │   ├─ 1 blocker 🔴
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │  │   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.cheapo.md
    │  │   └─ r2: primo (l2, 2/2)
    │  │       ├─ exhausted, cached
    │  │       ├─ 1 blocker 🔴
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .route/1.execute.guard.review.i4.6dddc53e1de2efc1da.r2.md
+   │  │       └─ review: .reviews/peer/1.execute._.review.i4.6dddc53e1de2efc1da.r2._.given.by_peer.primo.md
    │  └─ judges
    │      └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
    │          └─ finished [TIME] ✓
@@ -258,7 +258,7 @@ exports[`driver.route.peer-budget-levels.journey.acceptance given: [journey] sto
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/2.deploy.guard.review.i1.345d6c58ae9529da69.r1.md
+   │   └─ review: .reviews/peer/2.deploy._.review.i1.345d6c58ae9529da69.r1._.given.by_peer.deployer.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -273,7 +273,7 @@ exports[`driver.route.peer-budget-levels.journey.acceptance given: [journey] sto
    │  │       ├─ approved [TIME]
    │  │       ├─ 0 blockers ✓
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .route/2.deploy.guard.review.i1.345d6c58ae9529da69.r1.md
+   │  │       └─ review: .reviews/peer/2.deploy._.review.i1.345d6c58ae9529da69.r1._.given.by_peer.deployer.md
    │  └─ judges
    │      └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
    │          └─ finished [TIME] ✓
@@ -290,7 +290,7 @@ exports[`driver.route.peer-budget-levels.journey.acceptance given: [journey] sto
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/3.release.guard.review.i1.40f6892fa1e51b0694.r1.md
+   │   └─ review: .reviews/peer/3.release._.review.i1.40f6892fa1e51b0694.r1._.given.by_peer.releaser.md
    │
    ├─ ✓ judge.1 - allowed [TIME]
    │
@@ -308,7 +308,7 @@ exports[`driver.route.peer-budget-levels.journey.acceptance given: [journey] sto
       │       ├─ approved [TIME]
       │       ├─ 0 blockers ✓
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/3.release.guard.review.i1.40f6892fa1e51b0694.r1.md
+      │       └─ review: .reviews/peer/3.release._.review.i1.40f6892fa1e51b0694.r1._.given.by_peer.releaser.md
       └─ judges
           ├─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
           │   └─ finished [TIME] ✓
@@ -334,7 +334,7 @@ exports[`driver.route.peer-budget-levels.journey.acceptance given: [journey] sto
    │   ├─ approved, cached
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/3.release.guard.review.i1.40f6892fa1e51b0694.r1.md
+   │   └─ review: .reviews/peer/3.release._.review.i1.40f6892fa1e51b0694.r1._.given.by_peer.releaser.md
    │
    ├─ ✓ judge.1 - allowed [TIME]
    │
@@ -351,7 +351,7 @@ exports[`driver.route.peer-budget-levels.journey.acceptance given: [journey] sto
    │  │       ├─ approved, cached
    │  │       ├─ 0 blockers ✓
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .route/3.release.guard.review.i1.40f6892fa1e51b0694.r1.md
+   │  │       └─ review: .reviews/peer/3.release._.review.i1.40f6892fa1e51b0694.r1._.given.by_peer.releaser.md
    │  └─ judges
    │      ├─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
    │      │   └─ finished [TIME] ✓

--- a/blackbox/__snapshots__/driver.route.peer-budget-malfunction.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.peer-budget-malfunction.acceptance.test.ts.snap
@@ -5,7 +5,7 @@ exports[`driver.route.peer-budget-malfunction.acceptance given: [journey] review
    │
    ├─ r1: flaky-reviewer (l1, 1/2)
    │   ├─ 💥 malfunction
-   │   └─ review: .route/1.execute.guard.review.i1.8739656801d5e77f22.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i1.8739656801d5e77f22.r1._.given.by_peer.flaky-reviewer.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -19,7 +19,7 @@ exports[`driver.route.peer-budget-malfunction.acceptance given: [journey] review
       ├─ reviews
       │   └─ r1: flaky-reviewer (l1, 0/2)
       │       ├─ 💥 malfunction
-      │       └─ review: .route/1.execute.guard.review.i1.8739656801d5e77f22.r1.md
+      │       └─ review: .reviews/peer/1.execute._.review.i1.8739656801d5e77f22.r1._.given.by_peer.flaky-reviewer.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               └─ finished [TIME] ✓
@@ -33,7 +33,7 @@ exports[`driver.route.peer-budget-malfunction.acceptance given: [journey] review
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.flaky-reviewer.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -49,7 +49,7 @@ exports[`driver.route.peer-budget-malfunction.acceptance given: [journey] review
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+      │       └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.flaky-reviewer.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗
@@ -64,7 +64,7 @@ exports[`driver.route.peer-budget-malfunction.acceptance given: [journey] review
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i3.457fd5ef46e053a35e.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i3.457fd5ef46e053a35e.r1._.given.by_peer.flaky-reviewer.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -80,7 +80,7 @@ exports[`driver.route.peer-budget-malfunction.acceptance given: [journey] review
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.execute.guard.review.i3.457fd5ef46e053a35e.r1.md
+      │       └─ review: .reviews/peer/1.execute._.review.i3.457fd5ef46e053a35e.r1._.given.by_peer.flaky-reviewer.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗
@@ -95,7 +95,7 @@ exports[`driver.route.peer-budget-malfunction.acceptance given: [journey] review
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i3.457fd5ef46e053a35e.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i3.457fd5ef46e053a35e.r1._.given.by_peer.flaky-reviewer.md
    │
    └─ halted: peer reviewer budget exhausted
 
@@ -116,7 +116,7 @@ exports[`driver.route.peer-budget-malfunction.acceptance given: [journey] review
               ├─ exhausted, cached
               ├─ 1 blocker 🔴
               ├─ 0 nitpicks ✓
-              └─ review: .route/1.execute.guard.review.i3.457fd5ef46e053a35e.r1.md
+              └─ review: .reviews/peer/1.execute._.review.i3.457fd5ef46e053a35e.r1._.given.by_peer.flaky-reviewer.md
 "
 `;
 
@@ -125,7 +125,7 @@ exports[`driver.route.peer-budget-malfunction.acceptance given: [journey] review
    │
    ├─ r1: flaky-reviewer (l1, 3/3)
    │   ├─ 💥 malfunction
-   │   └─ review: .route/1.execute.guard.review.i4.0997a4c5910ffe05d0.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i4.0997a4c5910ffe05d0.r1._.given.by_peer.flaky-reviewer.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -139,7 +139,7 @@ exports[`driver.route.peer-budget-malfunction.acceptance given: [journey] review
       ├─ reviews
       │   └─ r1: flaky-reviewer (l1, 2/3)
       │       ├─ 💥 malfunction
-      │       └─ review: .route/1.execute.guard.review.i4.0997a4c5910ffe05d0.r1.md
+      │       └─ review: .reviews/peer/1.execute._.review.i4.0997a4c5910ffe05d0.r1._.given.by_peer.flaky-reviewer.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               └─ finished [TIME] ✓
@@ -153,7 +153,7 @@ exports[`driver.route.peer-budget-malfunction.acceptance given: [journey] review
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i5.ae29d35593838b9619.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i5.ae29d35593838b9619.r1._.given.by_peer.flaky-reviewer.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -168,7 +168,7 @@ exports[`driver.route.peer-budget-malfunction.acceptance given: [journey] review
    │  │       ├─ approved [TIME]
    │  │       ├─ 0 blockers ✓
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .route/1.execute.guard.review.i5.ae29d35593838b9619.r1.md
+   │  │       └─ review: .reviews/peer/1.execute._.review.i5.ae29d35593838b9619.r1._.given.by_peer.flaky-reviewer.md
    │  └─ judges
    │      └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
    │          └─ finished [TIME] ✓

--- a/blackbox/__snapshots__/driver.route.peer-budget-multilevel.journey.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.peer-budget-multilevel.journey.acceptance.test.ts.snap
@@ -7,13 +7,13 @@ exports[`driver.route.peer-budget-multilevel.journey.acceptance given: [journey 
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i1.8739656801d5e77f22.r1.md
+   │   └─ review: .reviews/peer/1.vision._.review.i1.8739656801d5e77f22.r1._.given.by_peer.linter.md
    │
    ├─ r2: spellcheck (l1, 1/3)
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i1.8739656801d5e77f22.r2.md
+   │   └─ review: .reviews/peer/1.vision._.review.i1.8739656801d5e77f22.r2._.given.by_peer.spellcheck.md
    │
    ├─ r3: architect (l2, 0/2)
    │   └─ awaits arrival
@@ -32,12 +32,12 @@ exports[`driver.route.peer-budget-multilevel.journey.acceptance given: [journey 
       │   │   ├─ rejected [TIME]
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i1.8739656801d5e77f22.r1.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i1.8739656801d5e77f22.r1._.given.by_peer.linter.md
       │   ├─ r2: spellcheck (l1, 1/3)
       │   │   ├─ rejected [TIME]
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i1.8739656801d5e77f22.r2.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i1.8739656801d5e77f22.r2._.given.by_peer.spellcheck.md
       │   └─ r3: architect (l2, 0/2)
       │       └─ awaits l1 terminal
       └─ judges
@@ -54,13 +54,13 @@ exports[`driver.route.peer-budget-multilevel.journey.acceptance given: [journey 
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.linter.md
    │
    ├─ r2: spellcheck (l1, 2/3)
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r2.md
+   │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r2._.given.by_peer.spellcheck.md
    │
    ├─ r3: architect (l2, 0/2)
    │   └─ awaits arrival
@@ -79,12 +79,12 @@ exports[`driver.route.peer-budget-multilevel.journey.acceptance given: [journey 
       │   │   ├─ rejected [TIME]
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.linter.md
       │   ├─ r2: spellcheck (l1, 2/3)
       │   │   ├─ rejected [TIME]
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r2.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r2._.given.by_peer.spellcheck.md
       │   └─ r3: architect (l2, 0/2)
       │       └─ awaits l1 terminal
       └─ judges
@@ -101,19 +101,19 @@ exports[`driver.route.peer-budget-multilevel.journey.acceptance given: [journey 
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.linter.md
    │
    ├─ r2: spellcheck (l1, 3/3)
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r2.md
+   │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.spellcheck.md
    │
    ├─ r3: architect (l2, 1/2)
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r3.md
+   │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r3._.given.by_peer.architect.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -129,17 +129,17 @@ exports[`driver.route.peer-budget-multilevel.journey.acceptance given: [journey 
       │   │   ├─ exhausted, cached
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.linter.md
       │   ├─ r2: spellcheck (l1, 3/3)
       │   │   ├─ approved [TIME]
       │   │   ├─ 0 blockers ✓
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r2.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.spellcheck.md
       │   └─ r3: architect (l2, 1/2)
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r3.md
+      │       └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r3._.given.by_peer.architect.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗
@@ -154,19 +154,19 @@ exports[`driver.route.peer-budget-multilevel.journey.acceptance given: [journey 
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.linter.md
    │
    ├─ r2: spellcheck (l1, 3/3)
    │   ├─ exhausted, cached
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r2.md
+   │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.spellcheck.md
    │
    ├─ r3: architect (l2, 2/2)
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i4.6dddc53e1de2efc1da.r3.md
+   │   └─ review: .reviews/peer/1.vision._.review.i4.6dddc53e1de2efc1da.r3._.given.by_peer.architect.md
    │
    └─ halted: peer reviewer budget exhausted
 
@@ -187,17 +187,17 @@ exports[`driver.route.peer-budget-multilevel.journey.acceptance given: [journey 
           │   ├─ exhausted, cached
           │   ├─ 1 blocker 🔴
           │   ├─ 0 nitpicks ✓
-          │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+          │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.linter.md
           ├─ r2: spellcheck (l1, 3/3)
           │   ├─ approved, cached
           │   ├─ 0 blockers ✓
           │   ├─ 0 nitpicks ✓
-          │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r2.md
+          │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.spellcheck.md
           └─ r3: architect (l2, 2/2)
               ├─ exhausted, cached
               ├─ 1 blocker 🔴
               ├─ 0 nitpicks ✓
-              └─ review: .route/1.vision.guard.review.i4.6dddc53e1de2efc1da.r3.md
+              └─ review: .reviews/peer/1.vision._.review.i4.6dddc53e1de2efc1da.r3._.given.by_peer.architect.md
 "
 `;
 
@@ -208,19 +208,19 @@ exports[`driver.route.peer-budget-multilevel.journey.acceptance given: [journey 
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.linter.md
    │
    ├─ r2: spellcheck (l1, 3/3)
    │   ├─ exhausted, cached
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r2.md
+   │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.spellcheck.md
    │
    ├─ r3: architect (l2, 2/2)
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i4.6dddc53e1de2efc1da.r3.md
+   │   └─ review: .reviews/peer/1.vision._.review.i4.6dddc53e1de2efc1da.r3._.given.by_peer.architect.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -236,17 +236,17 @@ exports[`driver.route.peer-budget-multilevel.journey.acceptance given: [journey 
       │   │   ├─ exhausted, cached
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.linter.md
       │   ├─ r2: spellcheck (l1, 3/3)
       │   │   ├─ approved, cached
       │   │   ├─ 0 blockers ✓
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r2.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.spellcheck.md
       │   └─ r3: architect (l2, 2/2)
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.vision.guard.review.i4.6dddc53e1de2efc1da.r3.md
+      │       └─ review: .reviews/peer/1.vision._.review.i4.6dddc53e1de2efc1da.r3._.given.by_peer.architect.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗
@@ -270,17 +270,17 @@ exports[`driver.route.peer-budget-multilevel.journey.acceptance given: [journey 
       │   │   ├─ exhausted
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: /tmp/test-fns/rhachet-roles-bhrain.vlad.fix-route-breakout/.temp/2026-06-19T10-01-14.836Z.peer-budget-multilevel.d19df7c3/.route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+      │   │   └─ review: /tmp/test-fns/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/2026-06-19T12-14-33.582Z.peer-budget-multilevel.2f853f03/.reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.linter.md
       │   ├─ r2: spellcheck (l1, 3/3)
       │   │   ├─ approved
       │   │   ├─ 0 blockers ✓
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: /tmp/test-fns/rhachet-roles-bhrain.vlad.fix-route-breakout/.temp/2026-06-19T10-01-14.836Z.peer-budget-multilevel.d19df7c3/.route/1.vision.guard.review.i3.457fd5ef46e053a35e.r2.md
+      │   │   └─ review: /tmp/test-fns/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/2026-06-19T12-14-33.582Z.peer-budget-multilevel.2f853f03/.reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.spellcheck.md
       │   └─ r3: architect (l2, 2/2)
       │       ├─ exhausted
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: /tmp/test-fns/rhachet-roles-bhrain.vlad.fix-route-breakout/.temp/2026-06-19T10-01-14.836Z.peer-budget-multilevel.d19df7c3/.route/1.vision.guard.review.i4.6dddc53e1de2efc1da.r3.md
+      │       └─ review: /tmp/test-fns/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/2026-06-19T12-14-33.582Z.peer-budget-multilevel.2f853f03/.reviews/peer/1.vision._.review.i4.6dddc53e1de2efc1da.r3._.given.by_peer.architect.md
       │
       ├─ please ask a human to either
       │  ├─ approve as-is
@@ -324,17 +324,17 @@ exports[`driver.route.peer-budget-multilevel.journey.acceptance given: [journey 
       │   │   ├─ exhausted
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: /tmp/test-fns/rhachet-roles-bhrain.vlad.fix-route-breakout/.temp/2026-06-19T10-01-14.836Z.peer-budget-multilevel.d19df7c3/.route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+      │   │   └─ review: /tmp/test-fns/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/2026-06-19T12-14-33.582Z.peer-budget-multilevel.2f853f03/.reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.linter.md
       │   ├─ r2: spellcheck (l1, 3/3)
       │   │   ├─ approved
       │   │   ├─ 0 blockers ✓
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: /tmp/test-fns/rhachet-roles-bhrain.vlad.fix-route-breakout/.temp/2026-06-19T10-01-14.836Z.peer-budget-multilevel.d19df7c3/.route/1.vision.guard.review.i3.457fd5ef46e053a35e.r2.md
+      │   │   └─ review: /tmp/test-fns/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/2026-06-19T12-14-33.582Z.peer-budget-multilevel.2f853f03/.reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.spellcheck.md
       │   └─ r3: architect (l2, 2/4)
       │       ├─ rejected
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: /tmp/test-fns/rhachet-roles-bhrain.vlad.fix-route-breakout/.temp/2026-06-19T10-01-14.836Z.peer-budget-multilevel.d19df7c3/.route/1.vision.guard.review.i4.6dddc53e1de2efc1da.r3.md
+      │       └─ review: /tmp/test-fns/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/2026-06-19T12-14-33.582Z.peer-budget-multilevel.2f853f03/.reviews/peer/1.vision._.review.i4.6dddc53e1de2efc1da.r3._.given.by_peer.architect.md
       │
       ├─ please ask a human to either
       │  ├─ approve as-is
@@ -355,19 +355,19 @@ exports[`driver.route.peer-budget-multilevel.journey.acceptance given: [journey 
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.linter.md
    │
    ├─ r2: spellcheck (l1, 3/3)
    │   ├─ exhausted, cached
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r2.md
+   │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.spellcheck.md
    │
    ├─ r3: architect (l2, 3/4)
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i5.0997a4c5910ffe05d0.r3.md
+   │   └─ review: .reviews/peer/1.vision._.review.i5.0997a4c5910ffe05d0.r3._.given.by_peer.architect.md
    │
    └─ halted: peer reviewer budget exhausted
 
@@ -388,17 +388,17 @@ exports[`driver.route.peer-budget-multilevel.journey.acceptance given: [journey 
           │   ├─ exhausted, cached
           │   ├─ 1 blocker 🔴
           │   ├─ 0 nitpicks ✓
-          │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+          │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.linter.md
           ├─ r2: spellcheck (l1, 3/3)
           │   ├─ approved, cached
           │   ├─ 0 blockers ✓
           │   ├─ 0 nitpicks ✓
-          │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r2.md
+          │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.spellcheck.md
           └─ r3: architect (l2, 3/4)
               ├─ approved [TIME]
               ├─ 0 blockers ✓
               ├─ 0 nitpicks ✓
-              └─ review: .route/1.vision.guard.review.i5.0997a4c5910ffe05d0.r3.md
+              └─ review: .reviews/peer/1.vision._.review.i5.0997a4c5910ffe05d0.r3._.given.by_peer.architect.md
 "
 `;
 
@@ -418,17 +418,17 @@ exports[`driver.route.peer-budget-multilevel.journey.acceptance given: [journey 
       │   │   ├─ exhausted
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: /tmp/test-fns/rhachet-roles-bhrain.vlad.fix-route-breakout/.temp/2026-06-19T10-01-14.836Z.peer-budget-multilevel.d19df7c3/.route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+      │   │   └─ review: /tmp/test-fns/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/2026-06-19T12-14-33.582Z.peer-budget-multilevel.2f853f03/.reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.linter.md
       │   ├─ r2: spellcheck (l1, 3/3)
       │   │   ├─ approved
       │   │   ├─ 0 blockers ✓
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: /tmp/test-fns/rhachet-roles-bhrain.vlad.fix-route-breakout/.temp/2026-06-19T10-01-14.836Z.peer-budget-multilevel.d19df7c3/.route/1.vision.guard.review.i3.457fd5ef46e053a35e.r2.md
+      │   │   └─ review: /tmp/test-fns/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/2026-06-19T12-14-33.582Z.peer-budget-multilevel.2f853f03/.reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.spellcheck.md
       │   └─ r3: architect (l2, 3/4)
       │       ├─ approved
       │       ├─ 0 blockers ✓
       │       ├─ 0 nitpicks ✓
-      │       └─ review: /tmp/test-fns/rhachet-roles-bhrain.vlad.fix-route-breakout/.temp/2026-06-19T10-01-14.836Z.peer-budget-multilevel.d19df7c3/.route/1.vision.guard.review.i5.0997a4c5910ffe05d0.r3.md
+      │       └─ review: /tmp/test-fns/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/2026-06-19T12-14-33.582Z.peer-budget-multilevel.2f853f03/.reviews/peer/1.vision._.review.i5.0997a4c5910ffe05d0.r3._.given.by_peer.architect.md
       │
       ├─ please ask a human to either
       │  ├─ approve as-is
@@ -458,19 +458,19 @@ exports[`driver.route.peer-budget-multilevel.journey.acceptance given: [journey 
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.linter.md
    │
    ├─ r2: spellcheck (l1, 3/3)
    │   ├─ exhausted, cached
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r2.md
+   │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.spellcheck.md
    │
    ├─ r3: architect (l2, 3/4)
    │   ├─ approved, cached
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i5.0997a4c5910ffe05d0.r3.md
+   │   └─ review: .reviews/peer/1.vision._.review.i5.0997a4c5910ffe05d0.r3._.given.by_peer.architect.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -485,17 +485,17 @@ exports[`driver.route.peer-budget-multilevel.journey.acceptance given: [journey 
    │  │   │   ├─ exhausted, cached
    │  │   │   ├─ 1 blocker 🔴
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │  │   │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.linter.md
    │  │   ├─ r2: spellcheck (l1, 3/3)
    │  │   │   ├─ approved, cached
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r2.md
+   │  │   │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.spellcheck.md
    │  │   └─ r3: architect (l2, 3/4)
    │  │       ├─ approved, cached
    │  │       ├─ 0 blockers ✓
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .route/1.vision.guard.review.i5.0997a4c5910ffe05d0.r3.md
+   │  │       └─ review: .reviews/peer/1.vision._.review.i5.0997a4c5910ffe05d0.r3._.given.by_peer.architect.md
    │  └─ judges
    │      └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
    │          └─ finished [TIME] ✓

--- a/blackbox/__snapshots__/driver.route.peer-budget-parallel-l1.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.peer-budget-parallel-l1.acceptance.test.ts.snap
@@ -7,13 +7,13 @@ exports[`driver.route.peer-budget-parallel-l1.acceptance given: [journey] parall
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i1.8739656801d5e77f22.r1.md
+   │   └─ review: .reviews/peer/1.vision._.review.i1.8739656801d5e77f22.r1._.given.by_peer.alpha-checker.md
    │
    ├─ r2: beta-checker (l1, 1/5)
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i1.8739656801d5e77f22.r2.md
+   │   └─ review: .reviews/peer/1.vision._.review.i1.8739656801d5e77f22.r2._.given.by_peer.beta-checker.md
    │
    ├─ r3: final-checker (l2, 0/5)
    │   └─ awaits arrival
@@ -32,12 +32,12 @@ exports[`driver.route.peer-budget-parallel-l1.acceptance given: [journey] parall
       │   │   ├─ rejected [TIME]
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i1.8739656801d5e77f22.r1.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i1.8739656801d5e77f22.r1._.given.by_peer.alpha-checker.md
       │   ├─ r2: beta-checker (l1, 1/5)
       │   │   ├─ rejected [TIME]
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i1.8739656801d5e77f22.r2.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i1.8739656801d5e77f22.r2._.given.by_peer.beta-checker.md
       │   └─ r3: final-checker (l2, 0/5)
       │       └─ awaits l1 terminal
       └─ judges
@@ -54,13 +54,13 @@ exports[`driver.route.peer-budget-parallel-l1.acceptance given: [journey] parall
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.alpha-checker.md
    │
    ├─ r2: beta-checker (l1, 2/5)
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r2.md
+   │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r2._.given.by_peer.beta-checker.md
    │
    ├─ r3: final-checker (l2, 0/5)
    │   └─ awaits arrival
@@ -79,12 +79,12 @@ exports[`driver.route.peer-budget-parallel-l1.acceptance given: [journey] parall
       │   │   ├─ approved [TIME]
       │   │   ├─ 0 blockers ✓
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.alpha-checker.md
       │   ├─ r2: beta-checker (l1, 2/5)
       │   │   ├─ rejected [TIME]
       │   │   ├─ 1 blocker 🔴
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i2.dfc5faff83ea2fcb55.r2.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i2.dfc5faff83ea2fcb55.r2._.given.by_peer.beta-checker.md
       │   └─ r3: final-checker (l2, 0/5)
       │       └─ awaits l1 terminal
       └─ judges
@@ -101,19 +101,19 @@ exports[`driver.route.peer-budget-parallel-l1.acceptance given: [journey] parall
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r1.md
+   │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r1._.given.by_peer.alpha-checker.md
    │
    ├─ r2: beta-checker (l1, 3/5)
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r2.md
+   │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.beta-checker.md
    │
    ├─ r3: final-checker (l2, 1/5)
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r3.md
+   │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r3._.given.by_peer.final-checker.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -129,17 +129,17 @@ exports[`driver.route.peer-budget-parallel-l1.acceptance given: [journey] parall
       │   │   ├─ approved [TIME]
       │   │   ├─ 0 blockers ✓
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r1.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r1._.given.by_peer.alpha-checker.md
       │   ├─ r2: beta-checker (l1, 3/5)
       │   │   ├─ approved [TIME]
       │   │   ├─ 0 blockers ✓
       │   │   ├─ 0 nitpicks ✓
-      │   │   └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r2.md
+      │   │   └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r2._.given.by_peer.beta-checker.md
       │   └─ r3: final-checker (l2, 1/5)
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.vision.guard.review.i3.457fd5ef46e053a35e.r3.md
+      │       └─ review: .reviews/peer/1.vision._.review.i3.457fd5ef46e053a35e.r3._.given.by_peer.final-checker.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗
@@ -154,19 +154,19 @@ exports[`driver.route.peer-budget-parallel-l1.acceptance given: [journey] parall
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i4.d1bd0b8547352e6396.r1.md
+   │   └─ review: .reviews/peer/1.vision._.review.i4.d1bd0b8547352e6396.r1._.given.by_peer.alpha-checker.md
    │
    ├─ r2: beta-checker (l1, 4/5)
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i4.d1bd0b8547352e6396.r2.md
+   │   └─ review: .reviews/peer/1.vision._.review.i4.d1bd0b8547352e6396.r2._.given.by_peer.beta-checker.md
    │
    ├─ r3: final-checker (l2, 2/5)
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.vision.guard.review.i4.d1bd0b8547352e6396.r3.md
+   │   └─ review: .reviews/peer/1.vision._.review.i4.d1bd0b8547352e6396.r3._.given.by_peer.final-checker.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -181,17 +181,17 @@ exports[`driver.route.peer-budget-parallel-l1.acceptance given: [journey] parall
    │  │   │   ├─ approved [TIME]
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .route/1.vision.guard.review.i4.d1bd0b8547352e6396.r1.md
+   │  │   │   └─ review: .reviews/peer/1.vision._.review.i4.d1bd0b8547352e6396.r1._.given.by_peer.alpha-checker.md
    │  │   ├─ r2: beta-checker (l1, 4/5)
    │  │   │   ├─ approved [TIME]
    │  │   │   ├─ 0 blockers ✓
    │  │   │   ├─ 0 nitpicks ✓
-   │  │   │   └─ review: .route/1.vision.guard.review.i4.d1bd0b8547352e6396.r2.md
+   │  │   │   └─ review: .reviews/peer/1.vision._.review.i4.d1bd0b8547352e6396.r2._.given.by_peer.beta-checker.md
    │  │   └─ r3: final-checker (l2, 2/5)
    │  │       ├─ approved [TIME]
    │  │       ├─ 0 blockers ✓
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .route/1.vision.guard.review.i4.d1bd0b8547352e6396.r3.md
+   │  │       └─ review: .reviews/peer/1.vision._.review.i4.d1bd0b8547352e6396.r3._.given.by_peer.final-checker.md
    │  └─ judges
    │      └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
    │          └─ finished [TIME] ✓

--- a/blackbox/__snapshots__/driver.route.peer-budget-rewound.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.peer-budget-rewound.acceptance.test.ts.snap
@@ -7,7 +7,7 @@ exports[`driver.route.peer-budget-rewound.acceptance given: [journey] rewound re
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.mock-reviewer.md
    │
    └─ halted: peer reviewer budget exhausted
 
@@ -28,7 +28,7 @@ exports[`driver.route.peer-budget-rewound.acceptance given: [journey] rewound re
               ├─ exhausted, cached
               ├─ 1 blocker 🔴
               ├─ 0 nitpicks ✓
-              └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+              └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.mock-reviewer.md
 "
 `;
 
@@ -39,7 +39,7 @@ exports[`driver.route.peer-budget-rewound.acceptance given: [journey] rewound re
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.mock-reviewer.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -55,7 +55,7 @@ exports[`driver.route.peer-budget-rewound.acceptance given: [journey] rewound re
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+      │       └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.mock-reviewer.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗
@@ -83,7 +83,7 @@ exports[`driver.route.peer-budget-rewound.acceptance given: [journey] rewound re
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i1.457fd5ef46e053a35e.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i1.457fd5ef46e053a35e.r1._.given.by_peer.mock-reviewer.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -99,7 +99,7 @@ exports[`driver.route.peer-budget-rewound.acceptance given: [journey] rewound re
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.execute.guard.review.i1.457fd5ef46e053a35e.r1.md
+      │       └─ review: .reviews/peer/1.execute._.review.i1.457fd5ef46e053a35e.r1._.given.by_peer.mock-reviewer.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗
@@ -114,7 +114,7 @@ exports[`driver.route.peer-budget-rewound.acceptance given: [journey] rewound re
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.8f7cfd245244bc91e6.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.8f7cfd245244bc91e6.r1._.given.by_peer.mock-reviewer.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -129,7 +129,7 @@ exports[`driver.route.peer-budget-rewound.acceptance given: [journey] rewound re
    │  │       ├─ approved [TIME]
    │  │       ├─ 0 blockers ✓
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .route/1.execute.guard.review.i2.8f7cfd245244bc91e6.r1.md
+   │  │       └─ review: .reviews/peer/1.execute._.review.i2.8f7cfd245244bc91e6.r1._.given.by_peer.mock-reviewer.md
    │  └─ judges
    │      └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
    │          └─ finished [TIME] ✓

--- a/blackbox/__snapshots__/driver.route.peer-budget.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.peer-budget.acceptance.test.ts.snap
@@ -7,7 +7,7 @@ exports[`driver.route.peer-budget.acceptance given: [journey] peer review budget
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i1.8739656801d5e77f22.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i1.8739656801d5e77f22.r1._.given.by_peer.mock-reviewer.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -23,7 +23,7 @@ exports[`driver.route.peer-budget.acceptance given: [journey] peer review budget
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.execute.guard.review.i1.8739656801d5e77f22.r1.md
+      │       └─ review: .reviews/peer/1.execute._.review.i1.8739656801d5e77f22.r1._.given.by_peer.mock-reviewer.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗
@@ -38,7 +38,7 @@ exports[`driver.route.peer-budget.acceptance given: [journey] peer review budget
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.mock-reviewer.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -54,7 +54,7 @@ exports[`driver.route.peer-budget.acceptance given: [journey] peer review budget
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+      │       └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.mock-reviewer.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗
@@ -69,7 +69,7 @@ exports[`driver.route.peer-budget.acceptance given: [journey] peer review budget
    │   ├─ exhausted, cached
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.mock-reviewer.md
    │
    └─ halted: peer reviewer budget exhausted
 
@@ -90,7 +90,7 @@ exports[`driver.route.peer-budget.acceptance given: [journey] peer review budget
               ├─ exhausted, cached
               ├─ 1 blocker 🔴
               ├─ 0 nitpicks ✓
-              └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+              └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.mock-reviewer.md
 "
 `;
 
@@ -115,7 +115,7 @@ exports[`driver.route.peer-budget.acceptance given: [journey] peer review budget
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i3.8f7cfd245244bc91e6.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i3.8f7cfd245244bc91e6.r1._.given.by_peer.mock-reviewer.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -130,7 +130,7 @@ exports[`driver.route.peer-budget.acceptance given: [journey] peer review budget
    │  │       ├─ approved [TIME]
    │  │       ├─ 0 blockers ✓
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .route/1.execute.guard.review.i3.8f7cfd245244bc91e6.r1.md
+   │  │       └─ review: .reviews/peer/1.execute._.review.i3.8f7cfd245244bc91e6.r1._.given.by_peer.mock-reviewer.md
    │  └─ judges
    │      └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
    │          └─ finished [TIME] ✓
@@ -147,8 +147,7 @@ exports[`driver.route.peer-budget.acceptance given: [journey] peer review budget
    │   ├─ approved, cached
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i3.8f7cfd245244bc91e6.r1.md
-   └─ ✓ judge.1 - allowed (cached)
+   │   └─ review: .reviews/peer/1.execute._.review.i3.8f7cfd245244bc91e6.r1._.given.by_peer.mock-reviewer.md
 
 🗿 route.stone.set
    ├─ stone = 1.execute
@@ -161,7 +160,7 @@ exports[`driver.route.peer-budget.acceptance given: [journey] peer review budget
    │  │       ├─ approved, cached
    │  │       ├─ 0 blockers ✓
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .route/1.execute.guard.review.i3.8f7cfd245244bc91e6.r1.md
+   │  │       └─ review: .reviews/peer/1.execute._.review.i3.8f7cfd245244bc91e6.r1._.given.by_peer.mock-reviewer.md
    │  └─ judges
    │      └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
    │          └─ · cached

--- a/blackbox/__snapshots__/driver.route.peer-review-output.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.peer-review-output.acceptance.test.ts.snap
@@ -1,0 +1,52 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`driver.route.peer-review-output.acceptance given: [output-test] guard with --output $output variable when: [t1] driver tries to pass the stone then: stdout has good vibes 1`] = `
+"🦉 the way speaks for itself
+   │
+   ├─ r1: mock-output (l1, 1/3)
+   │   ├─ approved [TIME]
+   │   ├─ 0 blockers ✓
+   │   ├─ 1 nitpick 🟠
+   │   └─ review: .reviews/peer/1.execute._.review.i1.1c1cfc20e88065ecab.r1._.given.by_peer.mock-output.md
+   │
+   └─ ✓ judge.1 - allowed [TIME]
+
+🗿 route.stone.set
+   ├─ stone = 1.execute
+   ├─ passage = allowed
+   ├─ guard
+   │  ├─ artifacts
+   │  │   └─ 1.execute*.md
+   │  ├─ reviews
+   │  │   └─ r1: mock-output (l1, 1/3)
+   │  │       ├─ approved [TIME]
+   │  │       ├─ 0 blockers ✓
+   │  │       ├─ 1 nitpick 🟠
+   │  │       └─ review: .reviews/peer/1.execute._.review.i1.1c1cfc20e88065ecab.r1._.given.by_peer.mock-output.md
+   │  └─ judges
+   │      └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
+   │          └─ finished [TIME] ✓
+   │
+   └─ the way continues, run
+      └─ rhx route.drive
+"
+`;
+
+exports[`driver.route.peer-review-output.acceptance given: [output-test] guard with --output $output variable when: [t2] report file was written then: report content matches snapshot 1`] = `
+"# detailed review report
+
+this is the detailed review report that was written to the $output path.
+
+## summary
+
+the review found no blockers but 1 nitpick.
+
+## nitpicks
+
+1. consider more comments to improve code readability
+
+## notes
+
+this file proves that the --output $output variable substitution works correctly.
+"
+`;

--- a/blackbox/__snapshots__/driver.route.self-review.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.self-review.acceptance.test.ts.snap
@@ -196,7 +196,7 @@ exports[`driver.route.review.self.acceptance given: [case1] stone with reviews.s
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.guard.review.i1.11a1a67a230e75f442.r1.md
+   │   └─ review: .reviews/peer/1._.review.i1.11a1a67a230e75f442.r1._.given.by_peer..test-mock-review.sh.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -211,7 +211,7 @@ exports[`driver.route.review.self.acceptance given: [case1] stone with reviews.s
    │  │       ├─ approved [TIME]
    │  │       ├─ 0 blockers ✓
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .route/1.guard.review.i1.11a1a67a230e75f442.r1.md
+   │  │       └─ review: .reviews/peer/1._.review.i1.11a1a67a230e75f442.r1._.given.by_peer..test-mock-review.sh.md
    │  └─ judges
    │      └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0
    │          └─ finished [TIME] ✓
@@ -318,7 +318,7 @@ exports[`driver.route.review.self.acceptance given: [case4] flat reviews array (
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.guard.review.i1.11a1a67a230e75f442.r1.md
+   │   └─ review: .reviews/peer/1._.review.i1.11a1a67a230e75f442.r1._.given.by_peer..test-mock-review.sh.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -333,7 +333,7 @@ exports[`driver.route.review.self.acceptance given: [case4] flat reviews array (
    │  │       ├─ approved [TIME]
    │  │       ├─ 0 blockers ✓
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .route/1.guard.review.i1.11a1a67a230e75f442.r1.md
+   │  │       └─ review: .reviews/peer/1._.review.i1.11a1a67a230e75f442.r1._.given.by_peer..test-mock-review.sh.md
    │  └─ judges
    │      └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0
    │          └─ finished [TIME] ✓

--- a/blackbox/__snapshots__/driver.route.set.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.set.acceptance.test.ts.snap
@@ -46,7 +46,7 @@ exports[`driver.route.set.acceptance given: [case3] route.stone.set --as passed 
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 1 nitpick 🟠
-   │   └─ review: .route/1.test.guard.review.i1.35e3128f097925a158.r1.md
+   │   └─ review: .reviews/peer/1.test._.review.i1.35e3128f097925a158.r1._.given.by_peer.echo.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -61,7 +61,7 @@ exports[`driver.route.set.acceptance given: [case3] route.stone.set --as passed 
    │  │       ├─ rejected [TIME]
    │  │       ├─ 0 blockers ✓
    │  │       ├─ 1 nitpick 🟠
-   │  │       └─ review: .route/1.test.guard.review.i1.35e3128f097925a158.r1.md
+   │  │       └─ review: .reviews/peer/1.test._.review.i1.35e3128f097925a158.r1._.given.by_peer.echo.md
    │  └─ judges
    │      └─ j1: echo "passed: true\\nreason: all checks passed"
    │          └─ finished [TIME] ✓
@@ -95,7 +95,7 @@ exports[`driver.route.set.acceptance given: [case4] route.stone.set --as passed 
    │   ├─ rejected [TIME]
    │   ├─ 3 blockers 🔴
    │   ├─ 1 nitpick 🟠
-   │   └─ review: .route/2.blocked.guard.review.i1.fb9cffb3eb889d2f8e.r1.md
+   │   └─ review: .reviews/peer/2.blocked._.review.i1.fb9cffb3eb889d2f8e.r1._.given.by_peer.echo.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -111,7 +111,7 @@ exports[`driver.route.set.acceptance given: [case4] route.stone.set --as passed 
       │       ├─ rejected [TIME]
       │       ├─ 3 blockers 🔴
       │       ├─ 1 nitpick 🟠
-      │       └─ review: .route/2.blocked.guard.review.i1.fb9cffb3eb889d2f8e.r1.md
+      │       └─ review: .reviews/peer/2.blocked._.review.i1.fb9cffb3eb889d2f8e.r1._.given.by_peer.echo.md
       └─ judges
           └─ j1: echo "passed: false\\nreason: blockers exceed threshold (3 > 0)"
               ├─ finished [TIME] ✗
@@ -168,8 +168,7 @@ exports[`driver.route.set.acceptance given: [case7] route.stone.set --as passed 
    │   ├─ approved, cached
    │   ├─ 0 blockers ✓
    │   ├─ 1 nitpick 🟠
-   │   └─ review: .route/1.test.guard.review.i1.faa07cdc907435dee8.r1.md
-   └─ ✓ judge.1 - allowed (cached)
+   │   └─ review: .reviews/peer/1.test._.review.i1.faa07cdc907435dee8.r1._.given.by_peer.echo.md
 
 🗿 route.stone.set
    ├─ stone = 1.test
@@ -182,7 +181,7 @@ exports[`driver.route.set.acceptance given: [case7] route.stone.set --as passed 
    │  │       ├─ rejected, cached
    │  │       ├─ 0 blockers ✓
    │  │       ├─ 1 nitpick 🟠
-   │  │       └─ review: .route/1.test.guard.review.i1.faa07cdc907435dee8.r1.md
+   │  │       └─ review: .reviews/peer/1.test._.review.i1.faa07cdc907435dee8.r1._.given.by_peer.echo.md
    │  └─ judges
    │      └─ j1: echo "passed: true\\nreason: all checks passed"
    │          └─ · cached

--- a/blackbox/driver.route.malfunction.acceptance.test.ts
+++ b/blackbox/driver.route.malfunction.acceptance.test.ts
@@ -165,15 +165,15 @@ describe('driver.route.malfunction.acceptance', () => {
       });
 
       then('review artifact was created with malfunction', async () => {
-        const routeDir = path.join(scene.tempDir, '.route');
-        const files = await fs.readdir(routeDir);
+        const reviewsDir = path.join(scene.tempDir, '.reviews', 'peer');
+        const files = await fs.readdir(reviewsDir);
         const reviewFiles = files.filter(
-          (f) => f.includes('.guard.review.') && f.endsWith('.md'),
+          (f) => f.includes('._.review.') && f.endsWith('.md'),
         );
         expect(reviewFiles.length).toBeGreaterThan(0);
 
         // check first review artifact contains malfunction
-        const reviewPath = path.join(routeDir, reviewFiles[0]!);
+        const reviewPath = path.join(reviewsDir, reviewFiles[0]!);
         const content = await fs.readFile(reviewPath, 'utf-8');
         expect(content).toContain('malfunction');
       });
@@ -193,10 +193,10 @@ describe('driver.route.malfunction.acceptance', () => {
         );
 
         // count review artifacts before
-        const routeDir = path.join(scene.tempDir, '.route');
-        const filesBefore = await fs.readdir(routeDir);
+        const reviewsDir = path.join(scene.tempDir, '.reviews', 'peer');
+        const filesBefore = await fs.readdir(reviewsDir);
         const reviewFilesBefore = filesBefore.filter(
-          (f) => f.includes('.guard.review.') && f.endsWith('.md'),
+          (f) => f.includes('._.review.') && f.endsWith('.md'),
         );
         const countBefore = reviewFilesBefore.length;
 
@@ -208,9 +208,9 @@ describe('driver.route.malfunction.acceptance', () => {
         });
 
         // count review artifacts after
-        const filesAfter = await fs.readdir(routeDir);
+        const filesAfter = await fs.readdir(reviewsDir);
         const reviewFilesAfter = filesAfter.filter(
-          (f) => f.includes('.guard.review.') && f.endsWith('.md'),
+          (f) => f.includes('._.review.') && f.endsWith('.md'),
         );
         const countAfter = reviewFilesAfter.length;
 
@@ -235,9 +235,9 @@ describe('driver.route.malfunction.acceptance', () => {
         // sort by name to get latest (includes iteration number)
         const sorted = result.reviewFilesAfter.sort();
         const latestFile = sorted[sorted.length - 1]!;
-        const routeDir = path.join(scene.tempDir, '.route');
+        const reviewsDir = path.join(scene.tempDir, '.reviews', 'peer');
         const content = await fs.readFile(
-          path.join(routeDir, latestFile),
+          path.join(reviewsDir, latestFile),
           'utf-8',
         );
         expect(content).toContain('review passed');
@@ -300,10 +300,10 @@ describe('driver.route.malfunction.acceptance', () => {
       });
 
       then('review artifact was created', async () => {
-        const routeDir = path.join(scene.tempDir, '.route');
-        const files = await fs.readdir(routeDir);
+        const reviewsDir = path.join(scene.tempDir, '.reviews', 'peer');
+        const files = await fs.readdir(reviewsDir);
         const reviewFiles = files.filter(
-          (f) => f.includes('.guard.review.') && f.endsWith('.md'),
+          (f) => f.includes('._.review.') && f.endsWith('.md'),
         );
         expect(reviewFiles.length).toBeGreaterThan(0);
       });
@@ -323,10 +323,10 @@ describe('driver.route.malfunction.acceptance', () => {
         );
 
         // count review artifacts before
-        const routeDir = path.join(scene.tempDir, '.route');
-        const filesBefore = await fs.readdir(routeDir);
+        const reviewsDir = path.join(scene.tempDir, '.reviews', 'peer');
+        const filesBefore = await fs.readdir(reviewsDir);
         const reviewFilesBefore = filesBefore.filter(
-          (f) => f.includes('.guard.review.') && f.endsWith('.md'),
+          (f) => f.includes('._.review.') && f.endsWith('.md'),
         );
         const countBefore = reviewFilesBefore.length;
 
@@ -338,9 +338,9 @@ describe('driver.route.malfunction.acceptance', () => {
         });
 
         // count review artifacts after
-        const filesAfter = await fs.readdir(routeDir);
+        const filesAfter = await fs.readdir(reviewsDir);
         const reviewFilesAfter = filesAfter.filter(
-          (f) => f.includes('.guard.review.') && f.endsWith('.md'),
+          (f) => f.includes('._.review.') && f.endsWith('.md'),
         );
         const countAfter = reviewFilesAfter.length;
 
@@ -365,9 +365,9 @@ describe('driver.route.malfunction.acceptance', () => {
         // sort by name to get latest (includes iteration number)
         const sorted = result.reviewFilesAfter.sort();
         const latestFile = sorted[sorted.length - 1]!;
-        const routeDir = path.join(scene.tempDir, '.route');
+        const reviewsDir = path.join(scene.tempDir, '.reviews', 'peer');
         const content = await fs.readFile(
-          path.join(routeDir, latestFile),
+          path.join(reviewsDir, latestFile),
           'utf-8',
         );
         expect(content).toContain('review passed');

--- a/blackbox/driver.route.peer-review-output.acceptance.test.ts
+++ b/blackbox/driver.route.peer-review-output.acceptance.test.ts
@@ -1,0 +1,172 @@
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { given, then, useBeforeAll, useThen, when } from 'test-fns';
+
+import {
+  execAsync,
+  genTempDirForRhachet,
+  invokeRouteSkill,
+  sanitizeTimeForSnapshot,
+} from './.test/invokeRouteSkill';
+
+const ASSETS_DIR = path.join(__dirname, '.test/assets/route-peer-review-output');
+
+/**
+ * .what = acceptance test that proves --output $output variable substitution works
+ * .why = verifies that guard review commands can write reports to the $output path
+ *
+ * scenario:
+ *   - guard has review.peer with `--output $output` in run command
+ *   - when guard runs, $output is substituted with .reviews/peer/...report.md
+ *   - review command writes to that path
+ *   - driver can read the detailed report
+ */
+describe('driver.route.peer-review-output.acceptance', () => {
+  given('[output-test] guard with --output $output variable', () => {
+    const scene = useBeforeAll(async () => {
+      const tempDir = genTempDirForRhachet({
+        slug: 'peer-review-output',
+        clone: ASSETS_DIR,
+      });
+
+      // link the driver role
+      await execAsync('npx rhachet roles link --role driver', { cwd: tempDir });
+
+      // make mock review executable
+      await execAsync('chmod +x .test/mock-review-with-output.sh', {
+        cwd: tempDir,
+      });
+
+      return { tempDir };
+    });
+
+    when('[t0] artifact created', () => {
+      const result = useThen('artifact is written', async () => {
+        await fs.writeFile(
+          path.join(scene.tempDir, '1.execute.md'),
+          '# execute\n\nthis is the artifact content.',
+        );
+        return { created: true };
+      });
+
+      then('artifact exists', () => {
+        expect(result.created).toBe(true);
+      });
+    });
+
+    when('[t1] driver tries to pass the stone', () => {
+      const result = useThen('guard runs review', async () =>
+        invokeRouteSkill({
+          skill: 'route.stone.set',
+          args: { stone: '1.execute', route: '.', as: 'passed' },
+          cwd: scene.tempDir,
+        }),
+      );
+
+      then('exit code is 0 (review passed)', () => {
+        expect(result.code).toEqual(0);
+      });
+
+      then('stdout confirms passage', () => {
+        expect(result.stdout).toContain('passage = allowed');
+      });
+
+      then('stdout has good vibes', () => {
+        expect(sanitizeTimeForSnapshot(result.stdout)).toMatchSnapshot();
+      });
+    });
+
+    when('[t2] report file was written', () => {
+      const result = useThen('report file exists', async () => {
+        // find the .reviews/peer directory
+        const reviewsDir = path.join(scene.tempDir, '.reviews', 'peer');
+
+        // list files that match the report pattern
+        const files = await fs.readdir(reviewsDir);
+        const reportFiles = files.filter(
+          (f) => f.includes('.report.md') && f.includes('mock-output'),
+        );
+
+        if (reportFiles.length === 0) {
+          return { found: false, content: null, files };
+        }
+
+        // read the report content
+        const reportPath = path.join(reviewsDir, reportFiles[0]!);
+        const content = await fs.readFile(reportPath, 'utf-8');
+
+        return { found: true, content, files: reportFiles };
+      });
+
+      then('report file was found', () => {
+        expect(result.found).toBe(true);
+        expect(result.files.length).toBeGreaterThan(0);
+      });
+
+      then('report contains detailed content', () => {
+        expect(result.content).toContain('detailed review report');
+        expect(result.content).toContain('$output variable substitution works');
+      });
+
+      then('report content matches snapshot', () => {
+        expect(result.content).toMatchSnapshot();
+      });
+    });
+
+    when('[t3] stdout artifact was also written', () => {
+      const result = useThen('stdout artifact exists', async () => {
+        const reviewsDir = path.join(scene.tempDir, '.reviews', 'peer');
+        const files = await fs.readdir(reviewsDir);
+
+        // stdout artifact is the one WITHOUT .report.md suffix
+        const stdoutFiles = files.filter(
+          (f) =>
+            f.includes('mock-output') &&
+            f.endsWith('.md') &&
+            !f.includes('.report.md'),
+        );
+
+        if (stdoutFiles.length === 0) {
+          return { found: false, content: null, files };
+        }
+
+        const stdoutPath = path.join(reviewsDir, stdoutFiles[0]!);
+        const content = await fs.readFile(stdoutPath, 'utf-8');
+
+        return { found: true, content, files: stdoutFiles };
+      });
+
+      then('stdout artifact was found', () => {
+        expect(result.found).toBe(true);
+      });
+
+      then('stdout artifact contains review output', () => {
+        expect(result.content).toContain('blockers: 0');
+        expect(result.content).toContain('nitpicks: 1');
+      });
+    });
+
+    when('[t4] verify review path points to .reviews/peer/', () => {
+      const result = useThen('get file list', async () => {
+        const reviewsDir = path.join(scene.tempDir, '.reviews', 'peer');
+        const files = await fs.readdir(reviewsDir);
+        return { reviewsDir, files };
+      });
+
+      then('review files are in .reviews/peer/', () => {
+        expect(result.reviewsDir).toContain('.reviews/peer');
+        expect(result.files.length).toBeGreaterThan(0);
+      });
+
+      then('files follow expected name pattern', () => {
+        // pattern: $stone._.review.i$iter.$hash.r$idx._.given.by_peer.$slug.md
+        const stdoutFile = result.files.find(
+          (f) => f.includes('mock-output') && !f.includes('.report.md'),
+        );
+        expect(stdoutFile).toMatch(
+          /1\.execute\._\.review\.i\d+\.[a-f0-9]+\.r\d+\._\.given\.by_peer\.mock-output\.md/,
+        );
+      });
+    });
+  });
+});

--- a/blackbox/driver.route.rewind-drive.acceptance.test.ts
+++ b/blackbox/driver.route.rewind-drive.acceptance.test.ts
@@ -175,13 +175,16 @@ describe('driver.route.rewind-drive.acceptance', () => {
 
         await execAsync('npx rhachet roles link --role driver', { cwd: tempDir });
 
-        // create .route with gitignore that ignores all content
+        // create .route and .reviews/peer/ directories
         await fs.mkdir(path.join(tempDir, '.route'), { recursive: true });
-        await fs.writeFile(path.join(tempDir, '.route', '.gitignore'), '*\n');
+        await fs.mkdir(path.join(tempDir, '.reviews', 'peer'), { recursive: true });
+
+        // create gitignore that ignores all content in .reviews/peer/
+        await fs.writeFile(path.join(tempDir, '.reviews', 'peer', '.gitignore'), '*\n');
 
         // create guard artifacts (would be ignored by gitignore)
         await fs.writeFile(
-          path.join(tempDir, '.route', '1.vision.guard.review.i1.abc.r1.md'),
+          path.join(tempDir, '.reviews', 'peer', '1.vision._.review.i1.abc.r1._.given.by_peer.mock.md'),
           '# review',
         );
         await fs.writeFile(
@@ -190,8 +193,10 @@ describe('driver.route.rewind-drive.acceptance', () => {
         );
 
         // count files before
-        const filesBefore = await fs.readdir(path.join(tempDir, '.route'));
-        const guardFilesBefore = filesBefore.filter((f) => f.includes('.guard.'));
+        const reviewFilesBefore = await fs.readdir(path.join(tempDir, '.reviews', 'peer'));
+        const reviewCountBefore = reviewFilesBefore.filter((f) => f.includes('._.review.'));
+        const judgeFilesBefore = await fs.readdir(path.join(tempDir, '.route'));
+        const judgeCountBefore = judgeFilesBefore.filter((f) => f.includes('.guard.judge.'));
 
         // invoke rewind
         const cli = await invokeRouteSkill({
@@ -201,22 +206,26 @@ describe('driver.route.rewind-drive.acceptance', () => {
         });
 
         // count files after
-        const filesAfter = await fs.readdir(path.join(tempDir, '.route'));
-        const guardFilesAfter = filesAfter.filter((f) => f.includes('.guard.'));
+        const reviewFilesAfter = await fs.readdir(path.join(tempDir, '.reviews', 'peer'));
+        const reviewCountAfter = reviewFilesAfter.filter((f) => f.includes('._.review.'));
+        const judgeFilesAfter = await fs.readdir(path.join(tempDir, '.route'));
+        const judgeCountAfter = judgeFilesAfter.filter((f) => f.includes('.guard.judge.'));
 
         console.log('\n--- cli.stdout ---');
         console.log(cli.stdout);
         console.log('--- end ---\n');
 
-        return { cli, guardFilesBefore, guardFilesAfter, tempDir };
+        return { cli, reviewCountBefore, reviewCountAfter, judgeCountBefore, judgeCountAfter, tempDir };
       });
 
       then('guard artifacts existed before rewind', () => {
-        expect(res.guardFilesBefore).toHaveLength(2);
+        expect(res.reviewCountBefore).toHaveLength(1);
+        expect(res.judgeCountBefore).toHaveLength(1);
       });
 
       then('guard artifacts deleted after rewind (even if gitignored)', () => {
-        expect(res.guardFilesAfter).toHaveLength(0);
+        expect(res.reviewCountAfter).toHaveLength(0);
+        expect(res.judgeCountAfter).toHaveLength(0);
       });
 
       then('cli output shows deleted counts', () => {

--- a/blackbox/driver.route.set.acceptance.test.ts
+++ b/blackbox/driver.route.set.acceptance.test.ts
@@ -572,10 +572,16 @@ describe('driver.route.set.acceptance', () => {
 
         await execAsync('npx rhachet roles link --role driver', { cwd: tempDir });
 
-        // create .route directory and guard artifacts
+        // create .reviews/peer/ directory and guard artifacts
+        await fs.mkdir(path.join(tempDir, '.reviews', 'peer'), { recursive: true });
         await fs.mkdir(path.join(tempDir, '.route'), { recursive: true });
         await fs.writeFile(
-          path.join(tempDir, '.route', '1.vision.guard.review.i1.abc.r1.md'),
+          path.join(
+            tempDir,
+            '.reviews',
+            'peer',
+            '1.vision._.review.i1.abc.r1._.given.by_peer.mock.md',
+          ),
           '# review',
         );
         await fs.writeFile(
@@ -607,11 +613,13 @@ describe('driver.route.set.acceptance', () => {
             return entry.stone === '1.vision' && entry.status === 'rewound';
           });
 
-        // check guard artifacts are deleted
+        // check guard artifacts are deleted (reviews in .reviews/peer/, judges in .route/)
+        const reviewsDir = path.join(tempDir, '.reviews', 'peer');
+        const reviewFiles = await fs.readdir(reviewsDir).catch(() => [] as string[]);
         const routeFiles = await fs.readdir(path.join(tempDir, '.route'));
-        const guardFiles = routeFiles.filter((f) => f.includes('.guard.'));
+        const judgeFiles = routeFiles.filter((f) => f.includes('.guard.judge.'));
 
-        return { cli, tempDir, rewoundExists, guardFiles };
+        return { cli, tempDir, rewoundExists, reviewFiles, judgeFiles };
       });
 
       then('cli completes successfully', () => {
@@ -629,7 +637,8 @@ describe('driver.route.set.acceptance', () => {
       });
 
       then('deletes guard artifacts', () => {
-        expect(res.guardFiles).toHaveLength(0);
+        expect(res.reviewFiles).toHaveLength(0);
+        expect(res.judgeFiles).toHaveLength(0);
       });
 
       then('stdout matches snapshot', () => {
@@ -646,18 +655,34 @@ describe('driver.route.set.acceptance', () => {
 
         await execAsync('npx rhachet roles link --role driver', { cwd: tempDir });
 
-        // create .route directory with artifacts for multiple stones
+        // create .reviews/peer/ directory with review artifacts for multiple stones
+        await fs.mkdir(path.join(tempDir, '.reviews', 'peer'), { recursive: true });
         await fs.mkdir(path.join(tempDir, '.route'), { recursive: true });
         await fs.writeFile(
-          path.join(tempDir, '.route', '1.vision.guard.review.i1.abc.r1.md'),
+          path.join(
+            tempDir,
+            '.reviews',
+            'peer',
+            '1.vision._.review.i1.abc.r1._.given.by_peer.mock.md',
+          ),
           '# review',
         );
         await fs.writeFile(
-          path.join(tempDir, '.route', '2.criteria.guard.review.i1.abc.r1.md'),
+          path.join(
+            tempDir,
+            '.reviews',
+            'peer',
+            '2.criteria._.review.i1.abc.r1._.given.by_peer.mock.md',
+          ),
           '# review',
         );
         await fs.writeFile(
-          path.join(tempDir, '.route', '3.plan.guard.review.i1.abc.r1.md'),
+          path.join(
+            tempDir,
+            '.reviews',
+            'peer',
+            '3.plan._.review.i1.abc.r1._.given.by_peer.mock.md',
+          ),
           '# review',
         );
 
@@ -668,9 +693,9 @@ describe('driver.route.set.acceptance', () => {
           cwd: tempDir,
         });
 
-        // check which guard files remain
-        const routeFiles = await fs.readdir(path.join(tempDir, '.route'));
-        const guardFiles = routeFiles.filter((f) => f.includes('.guard.'));
+        // check which review files remain in .reviews/peer/
+        const reviewsDir = path.join(tempDir, '.reviews', 'peer');
+        const reviewFiles = await fs.readdir(reviewsDir).catch(() => [] as string[]);
 
         // check passage.jsonl for rewound entries
         const passagePath = path.join(tempDir, '.route', 'passage.jsonl');
@@ -681,7 +706,7 @@ describe('driver.route.set.acceptance', () => {
           .filter((e: { status: string }) => e.status === 'rewound')
           .map((e: { stone: string }) => e.stone);
 
-        return { cli, tempDir, guardFiles, rewoundStones };
+        return { cli, tempDir, reviewFiles, rewoundStones };
       });
 
       then('cli completes successfully', () => {
@@ -699,9 +724,9 @@ describe('driver.route.set.acceptance', () => {
         expect(res.rewoundStones).not.toContain('1.vision');
       });
 
-      then('only stone 1 guard artifacts remain', () => {
-        expect(res.guardFiles).toHaveLength(1);
-        expect(res.guardFiles[0]).toContain('1.vision');
+      then('only stone 1 review artifacts remain', () => {
+        expect(res.reviewFiles).toHaveLength(1);
+        expect(res.reviewFiles[0]).toContain('1.vision');
       });
 
       then('stdout matches snapshot', () => {

--- a/src/contract/cli/route.ts
+++ b/src/contract/cli/route.ts
@@ -12,6 +12,7 @@ import { getRouteBouncerCache } from '@src/domain.operations/route/bouncer/getRo
 import { computeReviewThresholdVerdict } from '@src/domain.operations/route/guard/computeReviewThresholdVerdict';
 import { computeReviewTotalsFromFiles } from '@src/domain.operations/route/guard/computeReviewTotalsFromFiles';
 import { computeStoneReviewInputHash } from '@src/domain.operations/route/guard/computeStoneReviewInputHash';
+import { enumRouteGuardReviewPeerFiles } from '@src/domain.operations/route/guard/enumRouteGuardReviewPeerFiles';
 import { genContextCliEmit } from '@src/domain.operations/route/guard/genContextCliEmit';
 import { getLatestReviewFilesPerIndex } from '@src/domain.operations/route/guard/getLatestReviewFilesPerIndex';
 import { getAllReviewPeerMeterStatuses } from '@src/domain.operations/route/guard/reviewPeerMeter/getAllReviewPeerMeterStatuses';
@@ -1153,12 +1154,10 @@ const judgeReviewed = async (input: {
   });
 
   // find review files for this stone and hash
-  const routeDir = path.join(input.route, '.route');
-  const reviewGlob = `${input.stone}.guard.review.*.${hash}.*.md`;
-
-  const reviewFiles = await enumFilesFromGlob({
-    glob: reviewGlob,
-    cwd: routeDir,
+  const reviewFiles = await enumRouteGuardReviewPeerFiles({
+    route: input.route,
+    stone: input.stone,
+    hash,
   });
 
   if (reviewFiles.length === 0) {

--- a/src/domain.objects/Driver/GuardProgressEvent.ts
+++ b/src/domain.objects/Driver/GuardProgressEvent.ts
@@ -61,14 +61,14 @@ export interface GuardProgressEvent {
     path: string | null;
     review:
       | { blockers: number; nitpicks: number }
-      | { malfunction: Error }
-      | { constraint: Error }
+      | { malfunction: string }
+      | { constraint: string }
       | { exhausted: true; blockers: number; nitpicks: number }
       | { queued: true }
       | null;
     judge:
       | { decision: 'allowed' | 'blocked'; reason: string | null }
-      | { malfunction: Error }
+      | { malfunction: string }
       | null;
   } | null;
 }

--- a/src/domain.operations/route/gitignore/__snapshots__/findsertSelfReviewGitignore.integration.test.ts.snap
+++ b/src/domain.operations/route/gitignore/__snapshots__/findsertSelfReviewGitignore.integration.test.ts.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`findsertSelfReviewGitignore.integration given: [case1] called multiple times when: [t0] findsert is called multiple times then: only creates once, subsequent calls return unchanged: result-first-call 1`] = `
+{
+  "action": "created",
+  "pathRelative": "$ROUTE/review/self/.gitignore",
+}
+`;
+
+exports[`findsertSelfReviewGitignore.integration given: [case1] called multiple times when: [t0] findsert is called multiple times then: only creates once, subsequent calls return unchanged: result-second-call 1`] = `
+{
+  "action": "unchanged",
+  "pathRelative": "$ROUTE/review/self/.gitignore",
+}
+`;
+
+exports[`findsertSelfReviewGitignore.integration given: [case1] called multiple times when: [t0] findsert is called multiple times then: only creates once, subsequent calls return unchanged: result-third-call 1`] = `
+{
+  "action": "unchanged",
+  "pathRelative": "$ROUTE/review/self/.gitignore",
+}
+`;
+
+exports[`findsertSelfReviewGitignore.integration given: [case2] self-review files in directory when: [t0] findsert is called with self-review files present then: gitignore created alongside self-review files: result-with-files-present 1`] = `
+{
+  "action": "created",
+  "pathRelative": "$ROUTE/review/self/.gitignore",
+}
+`;
+
+exports[`findsertSelfReviewGitignore.integration given: [case3] route is a file instead of directory when: [t0] findsert is called then: throws ENOTDIR error: error-enotdir-route 1`] = `[Error: ENOTDIR: not a directory, mkdir '/tmp/test-selfreview-gitignore-route-file-int-1781865232594/route-as-file/review/self']`;
+
+exports[`findsertSelfReviewGitignore.integration given: [case4] invalid route path when: [t0] findsert is called with non-writable path then: throws permission error: error-eacces 1`] = `[Error: EACCES: permission denied, mkdir '/nonexistent']`;
+
+exports[`findsertSelfReviewGitignore.integration given: [case5] .gitignore present with incorrect content when: [t0] findsert is called then: overwrites with correct content: result-overwrite 1`] = `
+{
+  "action": "created",
+  "pathRelative": "$ROUTE/review/self/.gitignore",
+}
+`;
+
+exports[`findsertSelfReviewGitignore.integration given: [case6] .gitignore is a directory when: [t0] findsert is called then: throws EISDIR error: error-eisdir 1`] = `[Error: EISDIR: illegal operation on a directory, read]`;
+
+exports[`findsertSelfReviewGitignore.integration given: [case7] review path is a file instead of directory when: [t0] findsert is called then: throws ENOTDIR error: error-enotdir-review 1`] = `[Error: ENOTDIR: not a directory, mkdir '/tmp/test-selfreview-gitignore-review-file-int-1781865232595/review/self']`;
+
+exports[`findsertSelfReviewGitignore.integration given: [case8] self path is a file instead of directory when: [t0] findsert is called then: throws ENOTDIR error: error-enotdir-self 1`] = `[Error: EEXIST: file already exists, mkdir '/tmp/test-selfreview-gitignore-self-file-int-1781865232595/review/self']`;

--- a/src/domain.operations/route/gitignore/__snapshots__/findsertSelfReviewGitignore.test.ts.snap
+++ b/src/domain.operations/route/gitignore/__snapshots__/findsertSelfReviewGitignore.test.ts.snap
@@ -39,8 +39,8 @@ exports[`findsertSelfReviewGitignore given: [case4] read error other than ENOENT
 
 exports[`findsertSelfReviewGitignore given: [case5] invalid route path when: [t0] findsert is called with non-writable path then: throws mkdir error: error-eacces 1`] = `[Error: EACCES: permission denied, mkdir '/nonexistent']`;
 
-exports[`findsertSelfReviewGitignore given: [case6] route is a file instead of directory when: [t0] findsert is called then: throws ENOTDIR error: error-enotdir-route 1`] = `[Error: ENOTDIR: not a directory, mkdir '/tmp/test-selfreview-gitignore-route-file-1781865200996/route-as-file/review/self']`;
+exports[`findsertSelfReviewGitignore given: [case6] route is a file instead of directory when: [t0] findsert is called then: throws ENOTDIR error: error-enotdir-route 1`] = `[Error: ENOTDIR: not a directory, mkdir '/tmp/test-selfreview-gitignore-route-file-1781871484082/route-as-file/review/self']`;
 
-exports[`findsertSelfReviewGitignore given: [case7] review path is a file instead of directory when: [t0] findsert is called then: throws ENOTDIR error: error-enotdir-review 1`] = `[Error: ENOTDIR: not a directory, mkdir '/tmp/test-selfreview-gitignore-review-file-1781865200997/review/self']`;
+exports[`findsertSelfReviewGitignore given: [case7] review path is a file instead of directory when: [t0] findsert is called then: throws ENOTDIR error: error-enotdir-review 1`] = `[Error: ENOTDIR: not a directory, mkdir '/tmp/test-selfreview-gitignore-review-file-1781871484083/review/self']`;
 
-exports[`findsertSelfReviewGitignore given: [case8] self path is a file instead of directory when: [t0] findsert is called then: throws ENOTDIR error: error-enotdir-self 1`] = `[Error: EEXIST: file already exists, mkdir '/tmp/test-selfreview-gitignore-self-file-1781865200998/review/self']`;
+exports[`findsertSelfReviewGitignore given: [case8] self path is a file instead of directory when: [t0] findsert is called then: throws ENOTDIR error: error-enotdir-self 1`] = `[Error: EEXIST: file already exists, mkdir '/tmp/test-selfreview-gitignore-self-file-1781871484083/review/self']`;

--- a/src/domain.operations/route/gitignore/__snapshots__/findsertSelfReviewGitignore.test.ts.snap
+++ b/src/domain.operations/route/gitignore/__snapshots__/findsertSelfReviewGitignore.test.ts.snap
@@ -39,8 +39,8 @@ exports[`findsertSelfReviewGitignore given: [case4] read error other than ENOENT
 
 exports[`findsertSelfReviewGitignore given: [case5] invalid route path when: [t0] findsert is called with non-writable path then: throws mkdir error: error-eacces 1`] = `[Error: EACCES: permission denied, mkdir '/nonexistent']`;
 
-exports[`findsertSelfReviewGitignore given: [case6] route is a file instead of directory when: [t0] findsert is called then: throws ENOTDIR error: error-enotdir-route 1`] = `[Error: ENOTDIR: not a directory, mkdir '/tmp/test-selfreview-gitignore-route-file-1781866772039/route-as-file/review/self']`;
+exports[`findsertSelfReviewGitignore given: [case6] route is a file instead of directory when: [t0] findsert is called then: throws ENOTDIR error: error-enotdir-route 1`] = `[Error: ENOTDIR: not a directory, mkdir '/tmp/test-selfreview-gitignore-route-file-1781865200996/route-as-file/review/self']`;
 
-exports[`findsertSelfReviewGitignore given: [case7] review path is a file instead of directory when: [t0] findsert is called then: throws ENOTDIR error: error-enotdir-review 1`] = `[Error: ENOTDIR: not a directory, mkdir '/tmp/test-selfreview-gitignore-review-file-1781866772040/review/self']`;
+exports[`findsertSelfReviewGitignore given: [case7] review path is a file instead of directory when: [t0] findsert is called then: throws ENOTDIR error: error-enotdir-review 1`] = `[Error: ENOTDIR: not a directory, mkdir '/tmp/test-selfreview-gitignore-review-file-1781865200997/review/self']`;
 
-exports[`findsertSelfReviewGitignore given: [case8] self path is a file instead of directory when: [t0] findsert is called then: throws ENOTDIR error: error-enotdir-self 1`] = `[Error: EEXIST: file already exists, mkdir '/tmp/test-selfreview-gitignore-self-file-1781866772040/review/self']`;
+exports[`findsertSelfReviewGitignore given: [case8] self path is a file instead of directory when: [t0] findsert is called then: throws ENOTDIR error: error-enotdir-self 1`] = `[Error: EEXIST: file already exists, mkdir '/tmp/test-selfreview-gitignore-self-file-1781865200998/review/self']`;

--- a/src/domain.operations/route/guard/__snapshots__/runStoneGuardReviews.integration.test.ts.snap
+++ b/src/domain.operations/route/guard/__snapshots__/runStoneGuardReviews.integration.test.ts.snap
@@ -26,14 +26,14 @@ exports[`runStoneGuardReviews given: [case1] guard with echo review command when
     "index": 1,
     "iteration": 1,
     "nitpicks": 1,
-    "path": "<route>/.route/1.test.guard.review.i1.case1ret.r1.md",
+    "path": "<route>/.reviews/peer/1.test._.review.i1.case1ret.r1._.given.by_peer.echo.md",
     "stderr": "",
     "stdout": "blockers: 0
 nitpicks: 1
 review output
 ",
     "stone": {
-      "path": "/tmp/test-reviews-1781866797975/1.test.stone",
+      "path": "/tmp/test-reviews-1781865229158/1.test.stone",
     },
   },
 ]
@@ -78,13 +78,13 @@ exports[`runStoneGuardReviews given: [case2] guard with multiple review commands
     "index": 1,
     "iteration": 1,
     "nitpicks": 0,
-    "path": "<route>/.route/1.test.guard.review.i1.case2ret.r1.md",
+    "path": "<route>/.reviews/peer/1.test._.review.i1.case2ret.r1._.given.by_peer.echo.md",
     "stderr": "",
     "stdout": "blockers: 1
 nitpicks: 0
 ",
     "stone": {
-      "path": "/tmp/test-reviews-multi-1781866797976/1.test.stone",
+      "path": "/tmp/test-reviews-multi-1781865229161/1.test.stone",
     },
   },
   {
@@ -96,13 +96,13 @@ nitpicks: 0
     "index": 2,
     "iteration": 1,
     "nitpicks": 2,
-    "path": "<route>/.route/1.test.guard.review.i1.case2ret.r2.md",
+    "path": "<route>/.reviews/peer/1.test._.review.i1.case2ret.r2._.given.by_peer.echo.md",
     "stderr": "",
     "stdout": "blockers: 0
 nitpicks: 2
 ",
     "stone": {
-      "path": "/tmp/test-reviews-multi-1781866797976/1.test.stone",
+      "path": "/tmp/test-reviews-multi-1781865229161/1.test.stone",
     },
   },
 ]
@@ -133,13 +133,13 @@ exports[`runStoneGuardReviews given: [case3] review exits with code 0 (passed) w
     "index": 1,
     "iteration": 1,
     "nitpicks": 0,
-    "path": "<route>/.route/1.test.guard.review.i1.case3ret.r1.md",
+    "path": "<route>/.reviews/peer/1.test._.review.i1.case3ret.r1._.given.by_peer.echo.md",
     "stderr": "",
     "stdout": "blockers: 0
 review passed
 ",
     "stone": {
-      "path": "/tmp/test-reviews-exit0-1781866797977/1.test.stone",
+      "path": "/tmp/test-reviews-exit0-1781865229162/1.test.stone",
     },
   },
 ]
@@ -173,13 +173,13 @@ exports[`runStoneGuardReviews given: [case4] review exits with code 2 (constrain
     "index": 1,
     "iteration": 1,
     "nitpicks": 0,
-    "path": "<route>/.route/1.test.guard.review.i1.case4ret.r1.md",
+    "path": "<route>/.reviews/peer/1.test._.review.i1.case4ret.r1._.given.by_peer.bash.md",
     "stderr": "",
     "stdout": "blockers: 1
 constraint failure
 ",
     "stone": {
-      "path": "/tmp/test-reviews-exit2-1781866797978/1.test.stone",
+      "path": "/tmp/test-reviews-exit2-1781865229163/1.test.stone",
     },
   },
 ]
@@ -214,13 +214,13 @@ exports[`runStoneGuardReviews given: [case5] review exits with code 1 (malfuncti
     "index": 1,
     "iteration": 1,
     "nitpicks": 0,
-    "path": "<route>/.route/1.test.guard.review.i1.case5ret.r1.md",
+    "path": "<route>/.reviews/peer/1.test._.review.i1.case5ret.r1._.given.by_peer.bash.md",
     "stderr": "stderr error
 ",
     "stdout": "stdout output
 ",
     "stone": {
-      "path": "/tmp/test-reviews-exit1-1781866797979/1.test.stone",
+      "path": "/tmp/test-reviews-exit1-1781865229164/1.test.stone",
     },
   },
 ]
@@ -252,14 +252,14 @@ exports[`runStoneGuardReviews given: [case6] guard with $route variable in revie
     "index": 1,
     "iteration": 1,
     "nitpicks": 0,
-    "path": "<route>/.route/1.test.guard.review.i1.case6ret.r1.md",
+    "path": "<route>/.reviews/peer/1.test._.review.i1.case6ret.r1._.given.by_peer.bash.md",
     "stderr": "",
     "stdout": "blockers: 0
 nitpicks: 0
 marker found at <route-path>
 ",
     "stone": {
-      "path": "/tmp/test-reviews-route-1781866797980/1.test.stone",
+      "path": "/tmp/test-reviews-route-1781865229165/1.test.stone",
     },
   },
 ]
@@ -291,14 +291,14 @@ exports[`runStoneGuardReviews given: [case7] guard with $rhx variable in review 
     "index": 1,
     "iteration": 1,
     "nitpicks": 0,
-    "path": "<route>/.route/1.test.guard.review.i1.case7ret.r1.md",
+    "path": "<route>/.reviews/peer/1.test._.review.i1.case7ret.r1._.given.by_peer.bash.md",
     "stderr": "",
     "stdout": "blockers: 0
 nitpicks: 0
 rhx=<repo-root>/node_modules/.bin/rhx
 ",
     "stone": {
-      "path": "/tmp/test-reviews-rhx-1781866797981/1.test.stone",
+      "path": "/tmp/test-reviews-rhx-1781865229174/1.test.stone",
     },
   },
 ]
@@ -330,14 +330,14 @@ exports[`runStoneGuardReviews given: [case8] guard with $rhachet variable in rev
     "index": 1,
     "iteration": 1,
     "nitpicks": 0,
-    "path": "<route>/.route/1.test.guard.review.i1.case8ret.r1.md",
+    "path": "<route>/.reviews/peer/1.test._.review.i1.case8ret.r1._.given.by_peer.bash.md",
     "stderr": "",
     "stdout": "blockers: 0
 nitpicks: 0
 rhachet=<repo-root>/node_modules/.bin/rhachet
 ",
     "stone": {
-      "path": "/tmp/test-reviews-rhachet-1781866797981/1.test.stone",
+      "path": "/tmp/test-reviews-rhachet-1781865229175/1.test.stone",
     },
   },
 ]

--- a/src/domain.operations/route/guard/enumRouteFiles.ts
+++ b/src/domain.operations/route/guard/enumRouteFiles.ts
@@ -1,0 +1,29 @@
+import * as fs from 'fs/promises';
+
+import { enumFilesFromGlob } from '@src/utils/enumFilesFromGlob';
+
+import { isENOENT } from './isENOENT';
+
+/**
+ * .what = enumerates files within a route that match a glob pattern
+ * .why = centralizes route file enumeration + ENOENT handle
+ *
+ * glob is relative to route root, e.g.:
+ * - '.route/*.md' for route artifacts
+ * - '.reviews/peer/*.md' for peer reviews
+ */
+export const enumRouteFiles = async (input: {
+  route: string;
+  glob: string;
+}): Promise<string[]> => {
+  try {
+    await fs.access(input.route);
+    return await enumFilesFromGlob({
+      glob: input.glob,
+      cwd: input.route,
+    });
+  } catch (error) {
+    if (!isENOENT(error)) throw error;
+    return [];
+  }
+};

--- a/src/domain.operations/route/guard/enumRouteGuardJudgeFiles.test.ts
+++ b/src/domain.operations/route/guard/enumRouteGuardJudgeFiles.test.ts
@@ -1,0 +1,269 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { given, then, useBeforeAll, when } from 'test-fns';
+
+import { enumRouteGuardJudgeFiles } from './enumRouteGuardJudgeFiles';
+
+describe('enumRouteGuardJudgeFiles', () => {
+  given('[case1] route with no .route/ directory', () => {
+    const scene = useBeforeAll(async () => {
+      const route = await fs.mkdtemp(path.join(os.tmpdir(), 'route-test-'));
+      return { route };
+    });
+
+    when('[t0] called with stone filter', () => {
+      then('returns empty array', async () => {
+        const files = await enumRouteGuardJudgeFiles({
+          route: scene.route,
+          stone: '1.vision',
+        });
+        expect(files).toEqual([]);
+      });
+    });
+  });
+
+  given('[case2] route with empty .route/ directory', () => {
+    const scene = useBeforeAll(async () => {
+      const route = await fs.mkdtemp(path.join(os.tmpdir(), 'route-test-'));
+      await fs.mkdir(path.join(route, '.route'), { recursive: true });
+      return { route };
+    });
+
+    when('[t0] called with stone filter', () => {
+      then('returns empty array', async () => {
+        const files = await enumRouteGuardJudgeFiles({
+          route: scene.route,
+          stone: '1.vision',
+        });
+        expect(files).toEqual([]);
+      });
+    });
+  });
+
+  given('[case3] route with judge files for different stones', () => {
+    const scene = useBeforeAll(async () => {
+      const route = await fs.mkdtemp(path.join(os.tmpdir(), 'route-test-'));
+      const routeDir = path.join(route, '.route');
+      await fs.mkdir(routeDir, { recursive: true });
+
+      // create judges for different stones
+      const files = [
+        '1.vision.guard.judge.i1.abc123.j1.md',
+        '1.vision.guard.judge.i2.def456.j1.md',
+        '2.plan.guard.judge.i1.ghi789.j1.md',
+        '3.exec.guard.judge.i1.jkl012.j1.md',
+      ];
+      for (const file of files) {
+        await fs.writeFile(path.join(routeDir, file), '');
+      }
+
+      return { route, routeDir };
+    });
+
+    when('[t0] called with stone=1.vision', () => {
+      then('returns only 1.vision files', async () => {
+        const files = await enumRouteGuardJudgeFiles({
+          route: scene.route,
+          stone: '1.vision',
+        });
+        expect(files).toHaveLength(2);
+        expect(files.every((f) => f.includes('1.vision'))).toBe(true);
+      });
+    });
+
+    when('[t1] called with stone=2.plan', () => {
+      then('returns only 2.plan files', async () => {
+        const files = await enumRouteGuardJudgeFiles({
+          route: scene.route,
+          stone: '2.plan',
+        });
+        expect(files).toHaveLength(1);
+        expect(files[0]).toContain('2.plan');
+      });
+    });
+
+    when('[t2] called with stone=nonexistent', () => {
+      then('returns empty array', async () => {
+        const files = await enumRouteGuardJudgeFiles({
+          route: scene.route,
+          stone: 'nonexistent',
+        });
+        expect(files).toEqual([]);
+      });
+    });
+  });
+
+  given('[case4] route with multiple iterations, hashes, and indices', () => {
+    const scene = useBeforeAll(async () => {
+      const route = await fs.mkdtemp(path.join(os.tmpdir(), 'route-test-'));
+      const routeDir = path.join(route, '.route');
+      await fs.mkdir(routeDir, { recursive: true });
+
+      // create varied judge files
+      const files = [
+        // iteration 1, hash abc, judges 1 and 2
+        '1.vision.guard.judge.i1.abc123.j1.md',
+        '1.vision.guard.judge.i1.abc123.j2.md',
+        // iteration 2, hash abc, judge 1
+        '1.vision.guard.judge.i2.abc123.j1.md',
+        // iteration 2, hash def, judge 1
+        '1.vision.guard.judge.i2.def456.j1.md',
+        // iteration 3, hash ghi, judges 1 and 2
+        '1.vision.guard.judge.i3.ghi789.j1.md',
+        '1.vision.guard.judge.i3.ghi789.j2.md',
+      ];
+      for (const file of files) {
+        await fs.writeFile(path.join(routeDir, file), '');
+      }
+
+      return { route, routeDir };
+    });
+
+    when('[t0] called with only stone', () => {
+      then('returns all files for that stone', async () => {
+        const files = await enumRouteGuardJudgeFiles({
+          route: scene.route,
+          stone: '1.vision',
+        });
+        expect(files).toHaveLength(6);
+      });
+    });
+
+    when('[t1] called with stone and iteration=1', () => {
+      then('returns only iteration 1 files', async () => {
+        const files = await enumRouteGuardJudgeFiles({
+          route: scene.route,
+          stone: '1.vision',
+          iteration: 1,
+        });
+        expect(files).toHaveLength(2);
+        expect(files.every((f) => f.includes('.i1.'))).toBe(true);
+      });
+    });
+
+    when('[t2] called with stone and hash=abc123', () => {
+      then('returns only files with that hash', async () => {
+        const files = await enumRouteGuardJudgeFiles({
+          route: scene.route,
+          stone: '1.vision',
+          hash: 'abc123',
+        });
+        expect(files).toHaveLength(3);
+        expect(files.every((f) => f.includes('.abc123.'))).toBe(true);
+      });
+    });
+
+    when('[t3] called with stone and index=2', () => {
+      then('returns only judge 2 files', async () => {
+        const files = await enumRouteGuardJudgeFiles({
+          route: scene.route,
+          stone: '1.vision',
+          index: 2,
+        });
+        expect(files).toHaveLength(2);
+        expect(files.every((f) => f.includes('.j2.'))).toBe(true);
+      });
+    });
+
+    when('[t4] called with stone, iteration, and hash', () => {
+      then('returns files that satisfy both criteria', async () => {
+        const files = await enumRouteGuardJudgeFiles({
+          route: scene.route,
+          stone: '1.vision',
+          iteration: 2,
+          hash: 'abc123',
+        });
+        expect(files).toHaveLength(1);
+        expect(files[0]).toContain('.i2.');
+        expect(files[0]).toContain('.abc123.');
+      });
+    });
+
+    when('[t5] called with stone, hash, and index', () => {
+      then('returns files that satisfy all criteria', async () => {
+        const files = await enumRouteGuardJudgeFiles({
+          route: scene.route,
+          stone: '1.vision',
+          hash: 'ghi789',
+          index: 2,
+        });
+        expect(files).toHaveLength(1);
+        expect(files[0]).toContain('.ghi789.');
+        expect(files[0]).toContain('.j2.');
+      });
+    });
+
+    when('[t6] called with all filters', () => {
+      then('returns files that satisfy all criteria', async () => {
+        const files = await enumRouteGuardJudgeFiles({
+          route: scene.route,
+          stone: '1.vision',
+          iteration: 1,
+          hash: 'abc123',
+          index: 1,
+        });
+        expect(files).toHaveLength(1);
+        expect(files[0]).toContain('.i1.');
+        expect(files[0]).toContain('.abc123.');
+        expect(files[0]).toContain('.j1.');
+      });
+    });
+
+    when('[t7] called with filters that have no results', () => {
+      then('returns empty array', async () => {
+        const files = await enumRouteGuardJudgeFiles({
+          route: scene.route,
+          stone: '1.vision',
+          iteration: 99,
+        });
+        expect(files).toEqual([]);
+      });
+    });
+  });
+
+  given('[case5] route path does not exist', () => {
+    when('[t0] called with nonexistent route', () => {
+      then('returns empty array', async () => {
+        const files = await enumRouteGuardJudgeFiles({
+          route: '/nonexistent/path/to/route',
+          stone: '1.vision',
+        });
+        expect(files).toEqual([]);
+      });
+    });
+  });
+
+  given('[case6] .route/ directory has non-judge files', () => {
+    const scene = useBeforeAll(async () => {
+      const route = await fs.mkdtemp(path.join(os.tmpdir(), 'route-test-'));
+      const routeDir = path.join(route, '.route');
+      await fs.mkdir(routeDir, { recursive: true });
+
+      // create mixed files - judges and non-judges
+      const files = [
+        '1.vision.guard.judge.i1.abc123.j1.md', // judge
+        '1.vision.stone', // stone file
+        '1.vision.guard', // guard file
+        '1.vision.guard.promise.abc123.md', // promise file
+        '1.vision.guard.selfreview.xyz.triggered.abc.md', // trigger file
+      ];
+      for (const file of files) {
+        await fs.writeFile(path.join(routeDir, file), '');
+      }
+
+      return { route, routeDir };
+    });
+
+    when('[t0] called with stone filter', () => {
+      then('returns only judge files', async () => {
+        const files = await enumRouteGuardJudgeFiles({
+          route: scene.route,
+          stone: '1.vision',
+        });
+        expect(files).toHaveLength(1);
+        expect(files[0]).toContain('.guard.judge.');
+      });
+    });
+  });
+});

--- a/src/domain.operations/route/guard/enumRouteGuardJudgeFiles.ts
+++ b/src/domain.operations/route/guard/enumRouteGuardJudgeFiles.ts
@@ -1,0 +1,25 @@
+import { enumRouteFiles } from './enumRouteFiles';
+
+/**
+ * .what = enumerates judge guard files by semantic criteria
+ * .why = centralizes glob pattern construction for judges
+ *
+ * filename pattern: .route/$stone.guard.judge.i$iter.$hash.j$idx.md
+ */
+export const enumRouteGuardJudgeFiles = async (input: {
+  route: string;
+  stone: string;
+  iteration?: number;
+  hash?: string;
+  index?: number;
+}): Promise<string[]> => {
+  // construct glob from semantic inputs
+  // pattern: .route/$stone.guard.judge.i$iter.$hash.j$idx.md
+  let glob = `.route/${input.stone}.guard.judge.`;
+  glob += input.iteration !== undefined ? `i${input.iteration}.` : 'i*.';
+  glob += input.hash ? `${input.hash}.` : '*.';
+  glob += input.index !== undefined ? `j${input.index}.` : 'j*.';
+  glob += 'md';
+
+  return enumRouteFiles({ route: input.route, glob });
+};

--- a/src/domain.operations/route/guard/enumRouteGuardReviewPeerFiles.test.ts
+++ b/src/domain.operations/route/guard/enumRouteGuardReviewPeerFiles.test.ts
@@ -1,0 +1,236 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { given, then, useBeforeAll, when } from 'test-fns';
+
+import { enumRouteGuardReviewPeerFiles } from './enumRouteGuardReviewPeerFiles';
+
+describe('enumRouteGuardReviewPeerFiles', () => {
+  given('[case1] route with no .reviews/peer/ directory', () => {
+    const scene = useBeforeAll(async () => {
+      const route = await fs.mkdtemp(path.join(os.tmpdir(), 'route-test-'));
+      return { route };
+    });
+
+    when('[t0] called with stone filter', () => {
+      then('returns empty array', async () => {
+        const files = await enumRouteGuardReviewPeerFiles({
+          route: scene.route,
+          stone: '1.vision',
+        });
+        expect(files).toEqual([]);
+      });
+    });
+  });
+
+  given('[case2] route with empty .reviews/peer/ directory', () => {
+    const scene = useBeforeAll(async () => {
+      const route = await fs.mkdtemp(path.join(os.tmpdir(), 'route-test-'));
+      await fs.mkdir(path.join(route, '.reviews', 'peer'), { recursive: true });
+      return { route };
+    });
+
+    when('[t0] called with stone filter', () => {
+      then('returns empty array', async () => {
+        const files = await enumRouteGuardReviewPeerFiles({
+          route: scene.route,
+          stone: '1.vision',
+        });
+        expect(files).toEqual([]);
+      });
+    });
+  });
+
+  given('[case3] route with review files for different stones', () => {
+    const scene = useBeforeAll(async () => {
+      const route = await fs.mkdtemp(path.join(os.tmpdir(), 'route-test-'));
+      const reviewsDir = path.join(route, '.reviews', 'peer');
+      await fs.mkdir(reviewsDir, { recursive: true });
+
+      // create reviews for different stones
+      const files = [
+        '1.vision._.review.i1.abc123.r1._.given.by_peer.arch.md',
+        '1.vision._.review.i2.def456.r1._.given.by_peer.arch.md',
+        '2.plan._.review.i1.ghi789.r1._.given.by_peer.mech.md',
+        '3.exec._.review.i1.jkl012.r1._.given.by_peer.ergo.md',
+      ];
+      for (const file of files) {
+        await fs.writeFile(path.join(reviewsDir, file), '');
+      }
+
+      return { route, reviewsDir };
+    });
+
+    when('[t0] called with stone=1.vision', () => {
+      then('returns only 1.vision files', async () => {
+        const files = await enumRouteGuardReviewPeerFiles({
+          route: scene.route,
+          stone: '1.vision',
+        });
+        expect(files).toHaveLength(2);
+        expect(files.every((f) => f.includes('1.vision'))).toBe(true);
+      });
+    });
+
+    when('[t1] called with stone=2.plan', () => {
+      then('returns only 2.plan files', async () => {
+        const files = await enumRouteGuardReviewPeerFiles({
+          route: scene.route,
+          stone: '2.plan',
+        });
+        expect(files).toHaveLength(1);
+        expect(files[0]).toContain('2.plan');
+      });
+    });
+
+    when('[t2] called with stone=nonexistent', () => {
+      then('returns empty array', async () => {
+        const files = await enumRouteGuardReviewPeerFiles({
+          route: scene.route,
+          stone: 'nonexistent',
+        });
+        expect(files).toEqual([]);
+      });
+    });
+  });
+
+  given('[case4] route with multiple iterations, hashes, and indices', () => {
+    const scene = useBeforeAll(async () => {
+      const route = await fs.mkdtemp(path.join(os.tmpdir(), 'route-test-'));
+      const reviewsDir = path.join(route, '.reviews', 'peer');
+      await fs.mkdir(reviewsDir, { recursive: true });
+
+      // create varied review files
+      const files = [
+        // iteration 1, hash abc, reviewers 1 and 2
+        '1.vision._.review.i1.abc123.r1._.given.by_peer.arch.md',
+        '1.vision._.review.i1.abc123.r2._.given.by_peer.mech.md',
+        // iteration 2, hash abc, reviewer 1
+        '1.vision._.review.i2.abc123.r1._.given.by_peer.arch.md',
+        // iteration 2, hash def, reviewer 1
+        '1.vision._.review.i2.def456.r1._.given.by_peer.arch.md',
+        // iteration 3, hash ghi, reviewers 1 and 2
+        '1.vision._.review.i3.ghi789.r1._.given.by_peer.arch.md',
+        '1.vision._.review.i3.ghi789.r2._.given.by_peer.mech.md',
+      ];
+      for (const file of files) {
+        await fs.writeFile(path.join(reviewsDir, file), '');
+      }
+
+      return { route, reviewsDir };
+    });
+
+    when('[t0] called with only stone', () => {
+      then('returns all files for that stone', async () => {
+        const files = await enumRouteGuardReviewPeerFiles({
+          route: scene.route,
+          stone: '1.vision',
+        });
+        expect(files).toHaveLength(6);
+      });
+    });
+
+    when('[t1] called with stone and iteration=1', () => {
+      then('returns only iteration 1 files', async () => {
+        const files = await enumRouteGuardReviewPeerFiles({
+          route: scene.route,
+          stone: '1.vision',
+          iteration: 1,
+        });
+        expect(files).toHaveLength(2);
+        expect(files.every((f) => f.includes('.i1.'))).toBe(true);
+      });
+    });
+
+    when('[t2] called with stone and hash=abc123', () => {
+      then('returns only files with that hash', async () => {
+        const files = await enumRouteGuardReviewPeerFiles({
+          route: scene.route,
+          stone: '1.vision',
+          hash: 'abc123',
+        });
+        expect(files).toHaveLength(3);
+        expect(files.every((f) => f.includes('.abc123.'))).toBe(true);
+      });
+    });
+
+    when('[t3] called with stone and index=2', () => {
+      then('returns only reviewer 2 files', async () => {
+        const files = await enumRouteGuardReviewPeerFiles({
+          route: scene.route,
+          stone: '1.vision',
+          index: 2,
+        });
+        expect(files).toHaveLength(2);
+        expect(files.every((f) => f.includes('.r2.'))).toBe(true);
+      });
+    });
+
+    when('[t4] called with stone, iteration, and hash', () => {
+      then('returns files that satisfy both criteria', async () => {
+        const files = await enumRouteGuardReviewPeerFiles({
+          route: scene.route,
+          stone: '1.vision',
+          iteration: 2,
+          hash: 'abc123',
+        });
+        expect(files).toHaveLength(1);
+        expect(files[0]).toContain('.i2.');
+        expect(files[0]).toContain('.abc123.');
+      });
+    });
+
+    when('[t5] called with stone, hash, and index', () => {
+      then('returns files that satisfy all criteria', async () => {
+        const files = await enumRouteGuardReviewPeerFiles({
+          route: scene.route,
+          stone: '1.vision',
+          hash: 'ghi789',
+          index: 2,
+        });
+        expect(files).toHaveLength(1);
+        expect(files[0]).toContain('.ghi789.');
+        expect(files[0]).toContain('.r2.');
+      });
+    });
+
+    when('[t6] called with all filters', () => {
+      then('returns files that satisfy all criteria', async () => {
+        const files = await enumRouteGuardReviewPeerFiles({
+          route: scene.route,
+          stone: '1.vision',
+          iteration: 1,
+          hash: 'abc123',
+          index: 1,
+        });
+        expect(files).toHaveLength(1);
+        expect(files[0]).toContain('.i1.');
+        expect(files[0]).toContain('.abc123.');
+        expect(files[0]).toContain('.r1.');
+      });
+    });
+
+    when('[t7] called with filters that have no results', () => {
+      then('returns empty array', async () => {
+        const files = await enumRouteGuardReviewPeerFiles({
+          route: scene.route,
+          stone: '1.vision',
+          iteration: 99,
+        });
+        expect(files).toEqual([]);
+      });
+    });
+  });
+
+  given('[case5] route path does not exist', () => {
+    when('[t0] called with nonexistent route', () => {
+      then('returns empty array', async () => {
+        const files = await enumRouteGuardReviewPeerFiles({
+          route: '/nonexistent/path/to/route',
+          stone: '1.vision',
+        });
+        expect(files).toEqual([]);
+      });
+    });
+  });
+});

--- a/src/domain.operations/route/guard/enumRouteGuardReviewPeerFiles.ts
+++ b/src/domain.operations/route/guard/enumRouteGuardReviewPeerFiles.ts
@@ -1,0 +1,25 @@
+import { enumRouteFiles } from './enumRouteFiles';
+
+/**
+ * .what = enumerates peer review guard files by semantic criteria
+ * .why = centralizes glob pattern construction for peer reviews
+ *
+ * filename pattern: .reviews/peer/$stone._.review.i$iter.$hash.r$idx._.given.by_peer.$slug.md
+ */
+export const enumRouteGuardReviewPeerFiles = async (input: {
+  route: string;
+  stone: string;
+  iteration?: number;
+  hash?: string;
+  index?: number;
+}): Promise<string[]> => {
+  // construct glob from semantic inputs
+  // pattern: .reviews/peer/$stone._.review.i$iter.$hash.r$idx._.given.by_peer.$slug.md
+  let glob = `.reviews/peer/${input.stone}._.review.`;
+  glob += input.iteration !== undefined ? `i${input.iteration}.` : 'i*.';
+  glob += input.hash ? `${input.hash}.` : '*.';
+  glob += input.index !== undefined ? `r${input.index}.` : 'r*.';
+  glob += '_.given.by_peer.*.md';
+
+  return enumRouteFiles({ route: input.route, glob });
+};

--- a/src/domain.operations/route/guard/getAllStoneGuardArtifactsByHash.test.ts
+++ b/src/domain.operations/route/guard/getAllStoneGuardArtifactsByHash.test.ts
@@ -8,7 +8,7 @@ import { RouteStone } from '@src/domain.objects/Driver/RouteStone';
 import { getAllStoneGuardArtifactsByHash } from './getAllStoneGuardArtifactsByHash';
 
 describe('getAllStoneGuardArtifactsByHash', () => {
-  given('[case1] route with no .route directory', () => {
+  given('[case1] route with no .reviews/peer or .route directory', () => {
     const routePath = path.join(os.tmpdir(), `test-no-route-${Date.now()}`);
     const stone = new RouteStone({
       name: '1.vision',
@@ -34,6 +34,7 @@ describe('getAllStoneGuardArtifactsByHash', () => {
       os.tmpdir(),
       `test-guard-artifacts-${Date.now()}`,
     );
+    const reviewsDir = path.join(tempDir, '.reviews', 'peer');
     const routeDir = path.join(tempDir, '.route');
     const testHash = 'abc123def456';
     const stone = new RouteStone({
@@ -43,11 +44,15 @@ describe('getAllStoneGuardArtifactsByHash', () => {
     });
 
     beforeEach(async () => {
+      await fs.mkdir(reviewsDir, { recursive: true });
       await fs.mkdir(routeDir, { recursive: true });
 
-      // create review file with treestruct format (matches actual output)
+      // create review file in .reviews/peer/ with new filename pattern
       await fs.writeFile(
-        path.join(routeDir, `1.vision.guard.review.i1.${testHash}.r1.md`),
+        path.join(
+          reviewsDir,
+          `1.vision._.review.i1.${testHash}.r1._.given.by_peer.test-reviewer.md`,
+        ),
         `├─ stdout
 │  ├─
 │  │  🦉 needs your talons
@@ -59,7 +64,7 @@ describe('getAllStoneGuardArtifactsByHash', () => {
 │  └─`,
       );
 
-      // create judge file with treestruct format
+      // create judge file in .route/ (judges still live there)
       await fs.writeFile(
         path.join(routeDir, `1.vision.guard.judge.i1.${testHash}.j1.md`),
         `passed: false
@@ -113,7 +118,7 @@ reason: blockers found`,
       os.tmpdir(),
       `test-guard-zero-blockers-${Date.now()}`,
     );
-    const routeDir = path.join(tempDir, '.route');
+    const reviewsDir = path.join(tempDir, '.reviews', 'peer');
     const testHash = 'zeroblockershash';
     const stone = new RouteStone({
       name: '1.vision',
@@ -122,11 +127,14 @@ reason: blockers found`,
     });
 
     beforeEach(async () => {
-      await fs.mkdir(routeDir, { recursive: true });
+      await fs.mkdir(reviewsDir, { recursive: true });
 
       // create review file with zero blockers (approved format)
       await fs.writeFile(
-        path.join(routeDir, `1.vision.guard.review.i1.${testHash}.r1.md`),
+        path.join(
+          reviewsDir,
+          `1.vision._.review.i1.${testHash}.r1._.given.by_peer.test-reviewer.md`,
+        ),
         `├─ stdout
 │  ├─
 │  │  🦉 the way speaks for itself
@@ -159,7 +167,7 @@ reason: blockers found`,
 
   given('[case4] review with singular blocker/nitpick', () => {
     const tempDir = path.join(os.tmpdir(), `test-guard-singular-${Date.now()}`);
-    const routeDir = path.join(tempDir, '.route');
+    const reviewsDir = path.join(tempDir, '.reviews', 'peer');
     const testHash = 'singularhash';
     const stone = new RouteStone({
       name: '1.vision',
@@ -168,11 +176,14 @@ reason: blockers found`,
     });
 
     beforeEach(async () => {
-      await fs.mkdir(routeDir, { recursive: true });
+      await fs.mkdir(reviewsDir, { recursive: true });
 
       // create review file with singular forms
       await fs.writeFile(
-        path.join(routeDir, `1.vision.guard.review.i1.${testHash}.r1.md`),
+        path.join(
+          reviewsDir,
+          `1.vision._.review.i1.${testHash}.r1._.given.by_peer.test-reviewer.md`,
+        ),
         `├─ stdout
 │  ├─
 │  │  🦉 needs your talons
@@ -205,7 +216,7 @@ reason: blockers found`,
 
   given('[case5] review with duration in stdout', () => {
     const tempDir = path.join(os.tmpdir(), `test-guard-duration-${Date.now()}`);
-    const routeDir = path.join(tempDir, '.route');
+    const reviewsDir = path.join(tempDir, '.reviews', 'peer');
     const testHash = 'durationhash';
     const stone = new RouteStone({
       name: '1.vision',
@@ -214,11 +225,14 @@ reason: blockers found`,
     });
 
     beforeEach(async () => {
-      await fs.mkdir(routeDir, { recursive: true });
+      await fs.mkdir(reviewsDir, { recursive: true });
 
       // create review file with duration in metrics.realized
       await fs.writeFile(
-        path.join(routeDir, `1.vision.guard.review.i1.${testHash}.r1.md`),
+        path.join(
+          reviewsDir,
+          `1.vision._.review.i1.${testHash}.r1._.given.by_peer.test-reviewer.md`,
+        ),
         `├─ stdout
 │  ├─
 │  │  🦉 the way speaks for itself
@@ -256,7 +270,7 @@ reason: blockers found`,
       os.tmpdir(),
       `test-guard-no-duration-${Date.now()}`,
     );
-    const routeDir = path.join(tempDir, '.route');
+    const reviewsDir = path.join(tempDir, '.reviews', 'peer');
     const testHash = 'nodurationhash';
     const stone = new RouteStone({
       name: '1.vision',
@@ -265,11 +279,14 @@ reason: blockers found`,
     });
 
     beforeEach(async () => {
-      await fs.mkdir(routeDir, { recursive: true });
+      await fs.mkdir(reviewsDir, { recursive: true });
 
       // create review file without duration
       await fs.writeFile(
-        path.join(routeDir, `1.vision.guard.review.i1.${testHash}.r1.md`),
+        path.join(
+          reviewsDir,
+          `1.vision._.review.i1.${testHash}.r1._.given.by_peer.test-reviewer.md`,
+        ),
         `├─ stdout
 │  ├─
 │  │  🦉 the way speaks for itself

--- a/src/domain.operations/route/guard/getAllStoneGuardArtifactsByHash.ts
+++ b/src/domain.operations/route/guard/getAllStoneGuardArtifactsByHash.ts
@@ -1,11 +1,13 @@
 import * as fs from 'fs/promises';
+import { UnexpectedCodePathError } from 'helpful-errors';
 import * as path from 'path';
 
 import type { RouteStone } from '@src/domain.objects/Driver/RouteStone';
 import { RouteStoneGuardJudgeArtifact } from '@src/domain.objects/Driver/RouteStoneGuardJudgeArtifact';
 import { RouteStoneGuardReviewArtifact } from '@src/domain.objects/Driver/RouteStoneGuardReviewArtifact';
-import { enumFilesFromGlob } from '@src/utils/enumFilesFromGlob';
 
+import { enumRouteGuardJudgeFiles } from './enumRouteGuardJudgeFiles';
+import { enumRouteGuardReviewPeerFiles } from './enumRouteGuardReviewPeerFiles';
 import { getExitCodeClass } from './getExitCodeClass';
 import { getReviewCountsFromContent } from './getReviewCountsFromContent';
 
@@ -21,28 +23,24 @@ export const getAllStoneGuardArtifactsByHash = async (input: {
   reviews: RouteStoneGuardReviewArtifact[];
   judges: RouteStoneGuardJudgeArtifact[];
 }> => {
-  const routeDir = path.join(input.route, '.route');
+  // enumerate review files from .reviews/peer/
+  const reviewFiles = await enumRouteGuardReviewPeerFiles({
+    route: input.route,
+    stone: input.stone.name,
+    hash: input.hash,
+  });
 
-  // check if .route dir found
-  try {
-    await fs.access(routeDir);
-  } catch {
+  // enumerate judge files from .route/
+  const judgeFiles = await enumRouteGuardJudgeFiles({
+    route: input.route,
+    stone: input.stone.name,
+    hash: input.hash,
+  });
+
+  // return early if no files found
+  if (reviewFiles.length === 0 && judgeFiles.length === 0) {
     return { reviews: [], judges: [] };
   }
-
-  // glob for review files: $stone.guard.review.i$iter.$hash.r$n.md
-  const reviewGlob = `${input.stone.name}.guard.review.*.${input.hash}.*.md`;
-  const reviewFiles = await enumFilesFromGlob({
-    glob: reviewGlob,
-    cwd: routeDir,
-  });
-
-  // glob for judge files: $stone.guard.judge.i$iter.$hash.j$n.md
-  const judgeGlob = `${input.stone.name}.guard.judge.*.${input.hash}.*.md`;
-  const judgeFiles = await enumFilesFromGlob({
-    glob: judgeGlob,
-    cwd: routeDir,
-  });
 
   // parse review files into artifacts
   const reviews: RouteStoneGuardReviewArtifact[] = [];
@@ -110,13 +108,33 @@ const parseReviewMetadata = (
   stderr: string;
   durationMs: number | null;
 } => {
-  // filename pattern: $stone.guard.review.i$iter.$hash.r$n.md
+  // filename format: $stone._.review.i$iter.$hash.r$n._.given.by_peer.$slug.md
   const filename = path.basename(filePath);
   const iterMatch = filename.match(/\.i(\d+)\./);
-  const indexMatch = filename.match(/\.r(\d+)\.md$/);
+  const indexMatch = filename.match(/\.r(\d+)\./);
 
-  const iteration = iterMatch?.[1] ? parseInt(iterMatch[1], 10) : 0;
-  const index = indexMatch?.[1] ? parseInt(indexMatch[1], 10) : 0;
+  // iteration is required - file matched our glob, must have iteration marker
+  if (!iterMatch?.[1])
+    UnexpectedCodePathError.throw(
+      'review file lacks iteration marker in filename. ' +
+        'expected format: $stone._.review.i$iter.$hash.r$n._.given.by_peer.$slug.md. ' +
+        'fix: delete the malformed file and re-run the guard',
+      { filename, filePath },
+    );
+  const iteration = parseInt(iterMatch[1], 10);
+
+  // index is required - file matched our glob, must have reviewer index
+  if (!indexMatch?.[1])
+    UnexpectedCodePathError.throw(
+      'review file lacks reviewer index in filename. ' +
+        'expected format: $stone._.review.i$iter.$hash.r$n._.given.by_peer.$slug.md. ' +
+        'fix: delete the malformed file and re-run the guard',
+      {
+        filename,
+        filePath,
+      },
+    );
+  const index = parseInt(indexMatch[1], 10);
 
   // parse blockers and nitpicks from content
   const counts = getReviewCountsFromContent({ content });
@@ -166,13 +184,36 @@ const parseJudgeMetadata = (
   stdout: string;
   stderr: string;
 } => {
-  // filename pattern: $stone.guard.judge.i$iter.$hash.j$n.md
+  // filename format: $stone.guard.judge.i$rp$j.$reviewHash.$judgeHash.j$index.md
   const filename = path.basename(filePath);
-  const iterMatch = filename.match(/\.i(\d+)\./);
+  const iterMatch = filename.match(/\.i(\d+)[p.]/);
   const indexMatch = filename.match(/\.j(\d+)\.md$/);
 
-  const iteration = iterMatch?.[1] ? parseInt(iterMatch[1], 10) : 0;
-  const index = indexMatch?.[1] ? parseInt(indexMatch[1], 10) : 0;
+  // iteration is required - file matched our glob, must have iteration marker
+  if (!iterMatch?.[1])
+    UnexpectedCodePathError.throw(
+      'judge file lacks iteration marker in filename. ' +
+        'expected format: $stone.guard.judge.i$rp$j.$hash.j$index.md. ' +
+        'fix: delete the malformed file and re-run the guard',
+      {
+        filename,
+        filePath,
+      },
+    );
+  const iteration = parseInt(iterMatch[1], 10);
+
+  // index is required - file matched our glob, must have judge index
+  if (!indexMatch?.[1])
+    UnexpectedCodePathError.throw(
+      'judge file lacks judge index in filename. ' +
+        'expected format: $stone.guard.judge.i$rp$j.$hash.j$index.md. ' +
+        'fix: delete the malformed file and re-run the guard',
+      {
+        filename,
+        filePath,
+      },
+    );
+  const index = parseInt(indexMatch[1], 10);
 
   // parse passed and reason from content
   const passedMatch = content.match(/passed:\s*(true|false)/i);

--- a/src/domain.operations/route/guard/getLatestReviewArtifactForIndex.test.ts
+++ b/src/domain.operations/route/guard/getLatestReviewArtifactForIndex.test.ts
@@ -10,10 +10,10 @@ import { getLatestReviewArtifactForIndex } from './getLatestReviewArtifactForInd
 describe('getLatestReviewArtifactForIndex', () => {
   given('[case1] route with review files for different iterations', () => {
     const scene = useBeforeAll(async () => {
-      // create temp route dir
+      // create temp route with .reviews/peer/ dir
       const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'test-route-'));
-      const routeDir = path.join(tempDir, '.route');
-      await fs.mkdir(routeDir, { recursive: true });
+      const reviewsDir = path.join(tempDir, '.reviews', 'peer');
+      await fs.mkdir(reviewsDir, { recursive: true });
 
       // create review files for different iterations
       const reviewContentI1 = `├─ stdout
@@ -58,23 +58,35 @@ describe('getLatestReviewArtifactForIndex', () => {
 │  │
 │  └─`;
 
-      // write files with different iterations and hashes
+      // write files with new filename pattern: $stone._.review.i$iter.$hash.r$idx._.given.by_peer.$slug.md
       await fs.writeFile(
-        path.join(routeDir, 'test.stone.guard.review.i1.hash1.r1.md'),
+        path.join(
+          reviewsDir,
+          'test.stone._.review.i1.a1b2c3d4.r1._.given.by_peer.test-reviewer.md',
+        ),
         reviewContentI1,
       );
       await fs.writeFile(
-        path.join(routeDir, 'test.stone.guard.review.i2.hash2.r1.md'),
+        path.join(
+          reviewsDir,
+          'test.stone._.review.i2.e5f6a7b8.r1._.given.by_peer.test-reviewer.md',
+        ),
         reviewContentI2,
       );
       await fs.writeFile(
-        path.join(routeDir, 'test.stone.guard.review.i3.hash3.r1.md'),
+        path.join(
+          reviewsDir,
+          'test.stone._.review.i3.c9d0e1f2.r1._.given.by_peer.test-reviewer.md',
+        ),
         reviewContentI3,
       );
 
       // also create file for r2
       await fs.writeFile(
-        path.join(routeDir, 'test.stone.guard.review.i3.hash3.r2.md'),
+        path.join(
+          reviewsDir,
+          'test.stone._.review.i3.c9d0e1f2.r2._.given.by_peer.test-reviewer.md',
+        ),
         `├─ stdout
 │  ├─
 │  │
@@ -138,10 +150,10 @@ describe('getLatestReviewArtifactForIndex', () => {
     });
   });
 
-  given('[case2] no .route directory', () => {
+  given('[case2] no .reviews/peer directory', () => {
     const scene = useBeforeAll(async () => {
       const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'test-route-'));
-      // no .route dir
+      // no .reviews/peer dir
       const stone = {
         name: 'test.stone',
         path: path.join(tempDir, 'test.stone.stone'),

--- a/src/domain.operations/route/guard/getLatestReviewArtifactForIndex.ts
+++ b/src/domain.operations/route/guard/getLatestReviewArtifactForIndex.ts
@@ -1,10 +1,11 @@
 import * as fs from 'fs/promises';
+import { UnexpectedCodePathError } from 'helpful-errors';
 import * as path from 'path';
 
 import type { RouteStone } from '@src/domain.objects/Driver/RouteStone';
 import { RouteStoneGuardReviewArtifact } from '@src/domain.objects/Driver/RouteStoneGuardReviewArtifact';
-import { enumFilesFromGlob } from '@src/utils/enumFilesFromGlob';
 
+import { enumRouteGuardReviewPeerFiles } from './enumRouteGuardReviewPeerFiles';
 import { getExitCodeClass } from './getExitCodeClass';
 import { getReviewCountsFromContent } from './getReviewCountsFromContent';
 
@@ -12,7 +13,7 @@ import { getReviewCountsFromContent } from './getReviewCountsFromContent';
  * .what = finds the latest review artifact for a specific reviewer index, regardless of hash
  * .why = when a reviewer is exhausted, we need their latest review even if hash changed
  *
- * .note = filename format: $stone.guard.review.i$iteration.$hash.r$index.md
+ * .note = filename format: $stone._.review.i$iteration.$hash.r$index._.given.by_peer.$slug.md
  *         finds all reviews for this index, returns highest iteration
  */
 export const getLatestReviewArtifactForIndex = async (input: {
@@ -20,21 +21,11 @@ export const getLatestReviewArtifactForIndex = async (input: {
   index: number;
   route: string;
 }): Promise<RouteStoneGuardReviewArtifact | null> => {
-  const routeDir = path.join(input.route, '.route');
-
-  // check if .route dir found
-  try {
-    await fs.access(routeDir);
-  } catch {
-    return null;
-  }
-
-  // glob for all review files that match this index (any hash, any iteration)
-  // pattern: $stone.guard.review.i*.*.r$index.md
-  const reviewGlob = `${input.stone.name}.guard.review.*.r${input.index}.md`;
-  const reviewFiles = await enumFilesFromGlob({
-    glob: reviewGlob,
-    cwd: routeDir,
+  // find all reviews for this reviewer index
+  const reviewFiles = await enumRouteGuardReviewPeerFiles({
+    route: input.route,
+    stone: input.stone.name,
+    index: input.index,
   });
 
   if (reviewFiles.length === 0) return null;
@@ -45,9 +36,18 @@ export const getLatestReviewArtifactForIndex = async (input: {
 
   for (const filePath of reviewFiles) {
     const filename = path.basename(filePath);
-    // parse iteration from filename: $stone.guard.review.i$iter.$hash.r$index.md
+    // parse iteration from filename
     const iterMatch = filename.match(/\.i(\d+)\./);
-    const iteration = iterMatch?.[1] ? parseInt(iterMatch[1], 10) : 0;
+
+    // iteration is required - file matched our glob, must have iteration marker
+    if (!iterMatch?.[1])
+      UnexpectedCodePathError.throw(
+        'review file lacks iteration marker in filename. ' +
+          'expected format: $stone._.review.i$iter.$hash.r$n._.given.by_peer.$slug.md. ' +
+          'fix: delete the malformed file and re-run the guard',
+        { filename, filePath },
+      );
+    const iteration = parseInt(iterMatch[1], 10);
 
     if (iteration > latestIteration) {
       latestIteration = iteration;
@@ -61,10 +61,22 @@ export const getLatestReviewArtifactForIndex = async (input: {
   const content = await fs.readFile(latestFile, 'utf-8');
   const filename = path.basename(latestFile);
 
-  // extract hash from filename: $stone.guard.review.i$iter.$hash.r$index.md
-  // the hash is between the iteration and the index
-  const hashMatch = filename.match(/\.i\d+\.([a-f0-9]+)\.r\d+\.md$/);
-  const hash = hashMatch?.[1] ?? '';
+  // extract hash from filename
+  // format: .i$iter.$hash.r$n._.given...
+  const hashMatch = filename.match(/\.i\d+\.([a-f0-9]+)\.r\d+\./);
+
+  // hash is required - file matched our glob, must have hash
+  if (!hashMatch?.[1])
+    UnexpectedCodePathError.throw(
+      'review file lacks hash in filename. ' +
+        'expected format: $stone._.review.i$iter.$hash.r$n._.given.by_peer.$slug.md. ' +
+        'fix: delete the malformed file and re-run the guard',
+      {
+        filename,
+        filePath: latestFile,
+      },
+    );
+  const hash = hashMatch[1];
 
   // parse blockers and nitpicks from stdout
   const counts = getReviewCountsFromContent({ content });

--- a/src/domain.operations/route/guard/getLatestReviewFilesPerIndex.ts
+++ b/src/domain.operations/route/guard/getLatestReviewFilesPerIndex.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
  * .what = groups review files by index, keeps only latest iteration per index
  * .why = review artifacts are versioned via iteration (i$N); latest supersedes earlier
  *
- * .note = filename format: $stone.guard.review.i$iteration.$hash.r$index.md
+ * .note = filename format: $stone._.review.i$iteration.$hash.r$index._.given.by_peer.$slug.md
  *         later iterations represent re-runs after fix
  */
 export const getLatestReviewFilesPerIndex = (input: {

--- a/src/domain.operations/route/guard/getLatestReviewFilesPerIndex.ts
+++ b/src/domain.operations/route/guard/getLatestReviewFilesPerIndex.ts
@@ -15,8 +15,9 @@ export const getLatestReviewFilesPerIndex = (input: {
 
   for (const filePath of input.reviewFiles) {
     // parse iteration and index from filename
+    // .note = format: $stone._.review.i$iteration.$hash.r$index._.given.by_peer.$slug.md
     const iterMatch = path.basename(filePath).match(/\.i(\d+)\./);
-    const indexMatch = path.basename(filePath).match(/\.r(\d+)\.md$/);
+    const indexMatch = path.basename(filePath).match(/\.r(\d+)\./);
     const iteration = iterMatch?.[1] ? parseInt(iterMatch[1], 10) : 0;
     const index = indexMatch?.[1] ? parseInt(indexMatch[1], 10) : 0;
 

--- a/src/domain.operations/route/guard/getMaxStoneGuardIteration.test.ts
+++ b/src/domain.operations/route/guard/getMaxStoneGuardIteration.test.ts
@@ -38,32 +38,34 @@ describe('getMaxStoneGuardIteration', () => {
 
     beforeAll(async () => {
       const routeDir = path.join(tempDir, '.route');
+      const reviewsDir = path.join(tempDir, '.reviews', 'peer');
       await fs.mkdir(routeDir, { recursive: true });
+      await fs.mkdir(reviewsDir, { recursive: true });
 
-      // create review artifacts with different iterations and hashes
+      // create review artifacts in .reviews/peer/ with new filename pattern
       // simulates: i1 with hash1, i2 with hash2, i5 with hash3
       await fs.writeFile(
         path.join(
-          routeDir,
-          '1.vision.guard.review.i1.abc123def456789012.r1.md',
+          reviewsDir,
+          '1.vision._.review.i1.abc123def456789012.r1._.given.by_peer.test-reviewer.md',
         ),
         'review 1',
       );
       await fs.writeFile(
         path.join(
-          routeDir,
-          '1.vision.guard.review.i2.def456abc123789012.r1.md',
+          reviewsDir,
+          '1.vision._.review.i2.def456abc123789012.r1._.given.by_peer.test-reviewer.md',
         ),
         'review 2',
       );
       await fs.writeFile(
         path.join(
-          routeDir,
-          '1.vision.guard.review.i5.789012abc123def456.r1.md',
+          reviewsDir,
+          '1.vision._.review.i5.789012abc123def456.r1._.given.by_peer.test-reviewer.md',
         ),
         'review 5',
       );
-      // create judge artifact at i3
+      // create judge artifact at i3 in .route/
       await fs.writeFile(
         path.join(routeDir, '1.vision.guard.judge.i3.abc123def456789012.j1.md'),
         'judge 3',
@@ -93,21 +95,21 @@ describe('getMaxStoneGuardIteration', () => {
     const tempDir = path.join(__dirname, '../.test/temp-iteration-multi-stone');
 
     beforeAll(async () => {
-      const routeDir = path.join(tempDir, '.route');
-      await fs.mkdir(routeDir, { recursive: true });
+      const reviewsDir = path.join(tempDir, '.reviews', 'peer');
+      await fs.mkdir(reviewsDir, { recursive: true });
 
-      // create artifacts for different stones
+      // create review artifacts for different stones in .reviews/peer/
       await fs.writeFile(
         path.join(
-          routeDir,
-          '1.vision.guard.review.i3.abc123def456789012.r1.md',
+          reviewsDir,
+          '1.vision._.review.i3.abc123def456789012.r1._.given.by_peer.test-reviewer.md',
         ),
         'vision review',
       );
       await fs.writeFile(
         path.join(
-          routeDir,
-          '2.execution.guard.review.i10.abc123def456789012.r1.md',
+          reviewsDir,
+          '2.execution._.review.i10.abc123def456789012.r1._.given.by_peer.test-reviewer.md',
         ),
         'execution review',
       );

--- a/src/domain.operations/route/guard/getMaxStoneGuardIteration.ts
+++ b/src/domain.operations/route/guard/getMaxStoneGuardIteration.ts
@@ -1,7 +1,9 @@
 import * as path from 'path';
 
 import type { RouteStone } from '@src/domain.objects/Driver/RouteStone';
-import { enumFilesFromGlob } from '@src/utils/enumFilesFromGlob';
+
+import { enumRouteGuardJudgeFiles } from './enumRouteGuardJudgeFiles';
+import { enumRouteGuardReviewPeerFiles } from './enumRouteGuardReviewPeerFiles';
 
 /**
  * .what = gets the max iteration number across all guard artifacts for a stone
@@ -14,21 +16,18 @@ export const getMaxStoneGuardIteration = async (input: {
   stone: RouteStone;
   route: string;
 }): Promise<number> => {
-  const routeDir = path.join(input.route, '.route');
-
-  // glob for all review and judge files for this stone
-  // pattern: $stone.guard.{review,judge}.i$iter.$hash.*
-  const reviewGlob = `${input.stone.name}.guard.review.*.md`;
-  const judgeGlob = `${input.stone.name}.guard.judge.*.md`;
-
+  // reviews live in .reviews/peer/, judges live in .route/
   const [reviewFiles, judgeFiles] = await Promise.all([
-    enumFilesFromGlob({ glob: reviewGlob, cwd: routeDir }).catch(() => []),
-    enumFilesFromGlob({ glob: judgeGlob, cwd: routeDir }).catch(() => []),
+    enumRouteGuardReviewPeerFiles({
+      route: input.route,
+      stone: input.stone.name,
+    }),
+    enumRouteGuardJudgeFiles({ route: input.route, stone: input.stone.name }),
   ]);
 
   const allFiles = [...reviewFiles, ...judgeFiles];
 
-  // parse iteration from filenames: $stone.guard.{review,judge}.i$iter.$hash.*
+  // parse iteration from filenames: .i$iter.
   let maxIteration = 0;
   for (const filePath of allFiles) {
     const filename = path.basename(filePath);

--- a/src/domain.operations/route/guard/isENOENT.ts
+++ b/src/domain.operations/route/guard/isENOENT.ts
@@ -1,0 +1,10 @@
+/**
+ * .what = checks if an error is ENOENT (file/directory not found)
+ * .why = enables failfast pattern: catch only expected errors, rethrow others
+ */
+export const isENOENT = (error: unknown): boolean => {
+  if (error && typeof error === 'object' && 'code' in error) {
+    return (error as { code: string }).code === 'ENOENT';
+  }
+  return false;
+};

--- a/src/domain.operations/route/guard/runStoneGuardReviews.integration.test.ts
+++ b/src/domain.operations/route/guard/runStoneGuardReviews.integration.test.ts
@@ -68,7 +68,7 @@ describe('runStoneGuardReviews', () => {
         );
         expect(result.artifacts).toHaveLength(1);
         expect(result.artifacts[0]?.path).toContain(
-          '.guard.review.i1.testhash.r1.md',
+          '.reviews/peer/1.test._.review.i1.testhash.r1._.given.by_peer.echo.md',
         );
         const stat = await fs.stat(result.artifacts[0]?.path ?? '');
         expect(stat.isFile()).toBe(true);
@@ -107,10 +107,13 @@ describe('runStoneGuardReviews', () => {
           { stone, guard, hash: 'case1snap', iteration: 1, route: tempDir },
           noopContext,
         );
+        expect(result.artifacts).toHaveLength(1);
+        expect(result.artifacts[0]?.path).toBeDefined();
         const content = await fs.readFile(
           result.artifacts[0]?.path ?? '',
           'utf-8',
         );
+        expect(content).toContain('stdout');
         expect(content).toMatchSnapshot();
       });
 
@@ -119,6 +122,9 @@ describe('runStoneGuardReviews', () => {
           { stone, guard, hash: 'case1ret', iteration: 1, route: tempDir },
           noopContext,
         );
+        expect(result.artifacts).toHaveLength(1);
+        expect(result.artifacts[0]?.exitCode).toBe(0);
+        expect(result.artifacts[0]?.exitClass).toBe('passed');
         // sanitize dynamic paths for portable snapshots
         const sanitized = result.artifacts.map((r) => ({
           ...r,
@@ -180,6 +186,9 @@ describe('runStoneGuardReviews', () => {
           { stone, guard, hash: 'case2snap', iteration: 1, route: tempDir },
           noopContext,
         );
+        expect(result.artifacts).toHaveLength(2);
+        expect(result.artifacts[0]?.path).toBeDefined();
+        expect(result.artifacts[1]?.path).toBeDefined();
         const content1 = await fs.readFile(
           result.artifacts[0]?.path ?? '',
           'utf-8',
@@ -188,6 +197,8 @@ describe('runStoneGuardReviews', () => {
           result.artifacts[1]?.path ?? '',
           'utf-8',
         );
+        expect(content1).toContain('stdout');
+        expect(content2).toContain('stdout');
         expect(content1).toMatchSnapshot();
         expect(content2).toMatchSnapshot();
       });
@@ -197,6 +208,9 @@ describe('runStoneGuardReviews', () => {
           { stone, guard, hash: 'case2ret', iteration: 1, route: tempDir },
           noopContext,
         );
+        expect(result.artifacts).toHaveLength(2);
+        expect(result.artifacts[0]?.exitCode).toBe(0);
+        expect(result.artifacts[1]?.exitCode).toBe(0);
         const sanitized = result.artifacts.map((r) => ({
           ...r,
           path: r.path?.replace(tempDir, '<route>'),
@@ -260,10 +274,13 @@ describe('runStoneGuardReviews', () => {
           { stone, guard, hash: 'exit0snap', iteration: 1, route: tempDir },
           noopContext,
         );
+        expect(result.artifacts).toHaveLength(1);
+        expect(result.artifacts[0]?.path).toBeDefined();
         const content = await fs.readFile(
           result.artifacts[0]?.path ?? '',
           'utf-8',
         );
+        expect(content).toContain('stdout');
         expect(content).toMatchSnapshot();
       });
 
@@ -272,6 +289,9 @@ describe('runStoneGuardReviews', () => {
           { stone, guard, hash: 'case3ret', iteration: 1, route: tempDir },
           noopContext,
         );
+        expect(result.artifacts).toHaveLength(1);
+        expect(result.artifacts[0]?.exitCode).toBe(0);
+        expect(result.artifacts[0]?.exitClass).toBe('passed');
         const sanitized = result.artifacts.map((r) => ({
           ...r,
           path: r.path?.replace(tempDir, '<route>'),
@@ -340,10 +360,13 @@ describe('runStoneGuardReviews', () => {
           { stone, guard, hash: 'exit2snap', iteration: 1, route: tempDir },
           noopContext,
         );
+        expect(result.artifacts).toHaveLength(1);
+        expect(result.artifacts[0]?.path).toBeDefined();
         const content = await fs.readFile(
           result.artifacts[0]?.path ?? '',
           'utf-8',
         );
+        expect(content).toContain('blocked by constraints');
         expect(content).toMatchSnapshot();
       });
 
@@ -352,6 +375,9 @@ describe('runStoneGuardReviews', () => {
           { stone, guard, hash: 'case4ret', iteration: 1, route: tempDir },
           noopContext,
         );
+        expect(result.artifacts).toHaveLength(1);
+        expect(result.artifacts[0]?.exitCode).toBe(2);
+        expect(result.artifacts[0]?.exitClass).toBe('constraint');
         const sanitized = result.artifacts.map((r) => ({
           ...r,
           path: r.path?.replace(tempDir, '<route>'),
@@ -429,10 +455,13 @@ describe('runStoneGuardReviews', () => {
           { stone, guard, hash: 'exit1snap', iteration: 1, route: tempDir },
           noopContext,
         );
+        expect(result.artifacts).toHaveLength(1);
+        expect(result.artifacts[0]?.path).toBeDefined();
         const content = await fs.readFile(
           result.artifacts[0]?.path ?? '',
           'utf-8',
         );
+        expect(content).toContain('blocked by malfunction');
         expect(content).toMatchSnapshot();
       });
 
@@ -441,6 +470,9 @@ describe('runStoneGuardReviews', () => {
           { stone, guard, hash: 'case5ret', iteration: 1, route: tempDir },
           noopContext,
         );
+        expect(result.artifacts).toHaveLength(1);
+        expect(result.artifacts[0]?.exitCode).toBe(1);
+        expect(result.artifacts[0]?.exitClass).toBe('malfunction');
         const sanitized = result.artifacts.map((r) => ({
           ...r,
           path: r.path?.replace(tempDir, '<route>'),
@@ -531,10 +563,13 @@ describe('runStoneGuardReviews', () => {
           { stone, guard, hash: 'case6snap', iteration: 1, route: tempDir },
           noopContext,
         );
+        expect(result.artifacts).toHaveLength(1);
+        expect(result.artifacts[0]?.path).toBeDefined();
         const content = await fs.readFile(
           result.artifacts[0]?.path ?? '',
           'utf-8',
         );
+        expect(content).toContain('marker found');
         // sanitize dynamic temp path for portable snapshots
         const sanitized = content.replace(
           new RegExp(tempDir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'),
@@ -548,6 +583,9 @@ describe('runStoneGuardReviews', () => {
           { stone, guard, hash: 'case6ret', iteration: 1, route: tempDir },
           noopContext,
         );
+        expect(result.artifacts).toHaveLength(1);
+        expect(result.artifacts[0]?.exitCode).toBe(0);
+        expect(result.artifacts[0]?.blockers).toBe(0);
         const sanitized = result.artifacts.map((r) => ({
           ...r,
           path: r.path?.replace(tempDir, '<route>'),
@@ -619,10 +657,13 @@ describe('runStoneGuardReviews', () => {
           { stone, guard, hash: 'rhxsnap', iteration: 1, route: tempDir },
           noopContext,
         );
+        expect(result.artifacts).toHaveLength(1);
+        expect(result.artifacts[0]?.path).toBeDefined();
         const content = await fs.readFile(
           result.artifacts[0]?.path ?? '',
           'utf-8',
         );
+        expect(content).toContain('node_modules/.bin/rhx');
         // sanitize absolute path for portable snapshots
         const sanitized = content.replace(
           /rhx=.*\/node_modules/g,
@@ -636,6 +677,9 @@ describe('runStoneGuardReviews', () => {
           { stone, guard, hash: 'case7ret', iteration: 1, route: tempDir },
           noopContext,
         );
+        expect(result.artifacts).toHaveLength(1);
+        expect(result.artifacts[0]?.exitCode).toBe(0);
+        expect(result.artifacts[0]?.blockers).toBe(0);
         const sanitized = result.artifacts.map((r) => ({
           ...r,
           path: r.path?.replace(tempDir, '<route>'),
@@ -713,10 +757,13 @@ describe('runStoneGuardReviews', () => {
           { stone, guard, hash: 'rhachetsnap', iteration: 1, route: tempDir },
           noopContext,
         );
+        expect(result.artifacts).toHaveLength(1);
+        expect(result.artifacts[0]?.path).toBeDefined();
         const content = await fs.readFile(
           result.artifacts[0]?.path ?? '',
           'utf-8',
         );
+        expect(content).toContain('node_modules/.bin/rhachet');
         // sanitize absolute path for portable snapshots
         const sanitized = content.replace(
           /rhachet=.*\/node_modules/g,
@@ -730,6 +777,9 @@ describe('runStoneGuardReviews', () => {
           { stone, guard, hash: 'case8ret', iteration: 1, route: tempDir },
           noopContext,
         );
+        expect(result.artifacts).toHaveLength(1);
+        expect(result.artifacts[0]?.exitCode).toBe(0);
+        expect(result.artifacts[0]?.blockers).toBe(0);
         const sanitized = result.artifacts.map((r) => ({
           ...r,
           path: r.path?.replace(tempDir, '<route>'),

--- a/src/domain.operations/route/guard/runStoneGuardReviews.ts
+++ b/src/domain.operations/route/guard/runStoneGuardReviews.ts
@@ -101,15 +101,20 @@ export const runOneStoneGuardReview = async (input: {
   // validate no npx patterns before variable substitution
   validateNoNpx(input.reviewCmd);
 
+  // sanitize slug for filename
+  // .why = legacy peer reviews use command as slug (e.g., ".test/mock-review.sh")
+  //        path separators would create nested directories
+  const sanitizedSlug = input.slug.replace(/[/\\]/g, '-');
+
   // generate stdout path (what guard writes) and report path (what review skill writes)
   // .note = symmetric names: stdout is .md, report is .report.md
   const stdoutPath = path.join(
     reviewsDir,
-    `${input.stone.name}._.review.i${input.iteration}.${input.hash}.r${input.index}._.given.by_peer.${input.slug}.md`,
+    `${input.stone.name}._.review.i${input.iteration}.${input.hash}.r${input.index}._.given.by_peer.${sanitizedSlug}.md`,
   );
   const reportPath = path.join(
     reviewsDir,
-    `${input.stone.name}._.review.i${input.iteration}.${input.hash}.r${input.index}._.given.by_peer.${input.slug}.report.md`,
+    `${input.stone.name}._.review.i${input.iteration}.${input.hash}.r${input.index}._.given.by_peer.${sanitizedSlug}.report.md`,
   );
 
   // substitute variables in command
@@ -138,6 +143,7 @@ export const runOneStoneGuardReview = async (input: {
   let exitCode = 0;
   try {
     const result = await execAsync(cmd, {
+      cwd: input.route,
       env: execEnv,
       timeout: REVIEW_TIMEOUT_MS,
     });

--- a/src/domain.operations/route/guard/runStoneGuardReviews.ts
+++ b/src/domain.operations/route/guard/runStoneGuardReviews.ts
@@ -1,5 +1,6 @@
 import { exec } from 'child_process';
 import * as fs from 'fs/promises';
+import { BadRequestError } from 'helpful-errors';
 import * as path from 'path';
 import { getGitRepoRoot } from 'rhachet-artifact-git';
 import { promisify } from 'util';
@@ -20,6 +21,7 @@ import { getAllStoneGuardArtifactsByHash } from './getAllStoneGuardArtifactsByHa
 import { getExitCodeClass } from './getExitCodeClass';
 import { getLatestReviewArtifactForIndex } from './getLatestReviewArtifactForIndex';
 import { getReviewCountsFromContent } from './getReviewCountsFromContent';
+import { isENOENT } from './isENOENT';
 import { computeReviewPeerVerdict } from './reviewPeerMeter/computeReviewPeerVerdict';
 import { getAllRouteStoneGuardReviewPeerMeters } from './reviewPeerMeter/getAllRouteStoneGuardReviewPeerMeters';
 import { getReviewedJudgeThresholds } from './reviewPeerMeter/getReviewedJudgeThresholds';
@@ -73,33 +75,50 @@ export const runOneStoneGuardReview = async (input: {
   hash: string;
   iteration: number;
   route: string;
+  slug: string;
 }): Promise<RouteStoneGuardReviewArtifact> => {
-  // ensure .route directory found or created
-  const routeDir = path.join(input.route, '.route');
-  await fs.mkdir(routeDir, { recursive: true });
+  // ensure .reviews/peer directory found or created
+  // .why = peer reviews go to .reviews/peer/ so drivers can read them
+  //        (.route/ is sealed by route.mutate.guard)
+  const reviewsDir = path.join(input.route, '.reviews', 'peer');
+  await fs.mkdir(reviewsDir, { recursive: true });
 
   // lookup repo root for $rhx/$rhachet paths
   // .note = falls back to cwd when not in a git repo (e.g., integration tests)
   let repoRoot: string;
   try {
     repoRoot = await getGitRepoRoot({ from: input.route });
-  } catch {
+  } catch (error) {
+    // only catch "not in git repo" error; rethrow any other errors
+    // .note = check error message instead of instanceof due to cross-module class instances
+    const isNotInGitRepoError =
+      error instanceof Error && error.message.includes('Not inside a Git');
+    if (!isNotInGitRepoError) throw error;
+
     repoRoot = process.cwd();
   }
 
   // validate no npx patterns before variable substitution
   validateNoNpx(input.reviewCmd);
 
-  // substitute variables in command
-  const outputPath = path.join(
-    routeDir,
-    `${input.stone.name}.guard.review.i${input.iteration}.${input.hash}.r${input.index}.md`,
+  // generate stdout path (what guard writes) and report path (what review skill writes)
+  // .note = symmetric names: stdout is .md, report is .report.md
+  const stdoutPath = path.join(
+    reviewsDir,
+    `${input.stone.name}._.review.i${input.iteration}.${input.hash}.r${input.index}._.given.by_peer.${input.slug}.md`,
   );
+  const reportPath = path.join(
+    reviewsDir,
+    `${input.stone.name}._.review.i${input.iteration}.${input.hash}.r${input.index}._.given.by_peer.${input.slug}.report.md`,
+  );
+
+  // substitute variables in command
+  // .note = $output points to report path (for review skill to write)
   const cmd = substituteVars(input.reviewCmd, {
     stone: input.stone.name,
     route: input.route,
     hash: input.hash,
-    output: outputPath,
+    output: reportPath,
     repoRoot,
   });
 
@@ -126,19 +145,30 @@ export const runOneStoneGuardReview = async (input: {
     stderr = result.stderr;
     exitCode = 0;
   } catch (error: unknown) {
-    // capture output and exit code even on failure
-    if (error && typeof error === 'object') {
-      const errObj = error as Record<string, unknown>;
-      stdout = typeof errObj.stdout === 'string' ? errObj.stdout : '';
-      stderr = typeof errObj.stderr === 'string' ? errObj.stderr : '';
+    // capture output and exit code from command failure
+    // exec errors have specific shape: { stdout, stderr, code, killed }
+    // rethrow if error doesn't match this shape (unexpected error)
+    if (
+      !error ||
+      typeof error !== 'object' ||
+      !('code' in error || 'killed' in error)
+    ) {
+      throw error;
+    }
 
-      // detect timeout (process killed by signal)
-      if (errObj.killed === true) {
-        stderr = `💥 malfunction: review timed out after ${Math.floor(REVIEW_TIMEOUT_MS / 60000)} minutes`;
-        exitCode = 1;
-      } else {
-        exitCode = typeof errObj.code === 'number' ? errObj.code : 1;
-      }
+    const errObj = error as Record<string, unknown>;
+    stdout = typeof errObj.stdout === 'string' ? errObj.stdout : '';
+    stderr = typeof errObj.stderr === 'string' ? errObj.stderr : '';
+
+    // detect timeout (process killed by signal)
+    if (errObj.killed === true) {
+      stderr = `💥 malfunction: review timed out after ${Math.floor(REVIEW_TIMEOUT_MS / 60000)} minutes`;
+      exitCode = 1;
+    }
+
+    // extract exit code from error
+    if (errObj.killed !== true) {
+      exitCode = typeof errObj.code === 'number' ? errObj.code : 1;
     }
   }
 
@@ -164,8 +194,8 @@ export const runOneStoneGuardReview = async (input: {
 
   const artifactContent = artifactLines.join('\n');
 
-  // write artifact file
-  await fs.writeFile(outputPath, artifactContent);
+  // write stdout artifact file
+  await fs.writeFile(stdoutPath, artifactContent);
 
   // parse blockers and nitpicks from stdout via shared operation
   const counts = getReviewCountsFromContent({ content: stdout });
@@ -181,7 +211,7 @@ export const runOneStoneGuardReview = async (input: {
     hash: input.hash,
     iteration: input.iteration,
     index: input.index,
-    path: outputPath,
+    path: stdoutPath,
     blockers,
     nitpicks,
     exitCode,
@@ -214,7 +244,13 @@ export const runStoneGuardReviews = async (
   let gitRoot: string;
   try {
     gitRoot = await getGitRepoRoot({ from: input.route });
-  } catch {
+  } catch (error) {
+    // only catch "not in git repo" error; rethrow any other errors
+    // .note = check error name instead of instanceof due to cross-module class instances
+    const isNotInGitRepoError =
+      error instanceof Error && error.message.includes('Not inside a Git');
+    if (!isNotInGitRepoError) throw error;
+
     gitRoot = process.cwd();
   }
 
@@ -487,6 +523,7 @@ export const runStoneGuardReviews = async (
       hash: input.hash,
       iteration: input.iteration,
       route: input.route,
+      slug: pr.slug,
     });
 
     // determine if review actually completed (vs constraint/malfunction)
@@ -518,12 +555,24 @@ export const runStoneGuardReviews = async (
 
     // determine review outcome based on exit class and blockers
     // .note = constraint (exit 2) with blockers = review worked, show blockers
-    // .note = constraint (exit 2) without blockers = genuine constraint, show constraint error
+    // .note = constraint (exit 2) without blockers = genuine constraint, show constraint message
+    // .note = malfunction/constraint outcomes are messages, not Error objects
+    //         (Error objects should only be constructed when thrown)
     const reviewOutcome = (() => {
-      if (review.exitClass === 'malfunction')
-        return { malfunction: new Error(`exit code ${review.exitCode}`) };
+      if (review.exitClass === 'malfunction') {
+        // include first line of stderr if available for actionable context
+        const stderrFirstLine = review.stderr.split('\n')[0]?.trim();
+        const detail = stderrFirstLine
+          ? `. ${stderrFirstLine}`
+          : `. see review artifact for details`;
+        return {
+          malfunction: `review command failed with exit code ${review.exitCode}${detail}`,
+        };
+      }
       if (isGenuineConstraint)
-        return { constraint: new Error(`exit code ${review.exitCode}`) };
+        return {
+          constraint: `review returned constraint (exit code ${review.exitCode}) without blockers`,
+        };
       return { blockers: review.blockers, nitpicks: review.nitpicks };
     })();
 
@@ -556,13 +605,17 @@ export const runStoneGuardReviews = async (
  * .why = npx adds 500-2000ms latency and has cross-platform issues
  */
 const validateNoNpx = (cmd: string): void => {
+  // reject guards that use npx patterns
   if (cmd.includes('npx rhachet') || cmd.includes('npx rhx')) {
     const pattern = cmd.includes('npx rhachet') ? 'npx rhachet' : 'npx rhx';
     const alias = cmd.includes('npx rhachet') ? '$rhachet' : '$rhx';
-    throw new Error(
-      `guard uses ${pattern} which causes latency and cross-platform issues\n\n` +
-        `fix: use ${alias} alias instead\n` +
-        `  - ${alias} expands to ./node_modules/.bin/${alias.slice(1)}\n`,
+    BadRequestError.throw(
+      `guard uses ${pattern} which causes latency and cross-platform issues. ` +
+        `fix: use ${alias} alias instead (${alias} expands to ./node_modules/.bin/${alias.slice(1)})`,
+      {
+        pattern,
+        alias,
+      },
     );
   }
 };
@@ -606,7 +659,9 @@ const isFilePresent = async (filePath: string): Promise<boolean> => {
   try {
     await fs.access(filePath);
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    // only catch ENOENT (file not found); rethrow other errors
+    if (isENOENT(error)) return false;
+    throw error;
   }
 };

--- a/src/domain.operations/route/judges/__snapshots__/runStoneGuardJudges.integration.test.ts.snap
+++ b/src/domain.operations/route/judges/__snapshots__/runStoneGuardJudges.integration.test.ts.snap
@@ -30,7 +30,7 @@ exports[`runStoneGuardJudges given: [case1] guard with echo judge command that p
 reason: all checks passed
 ",
     "stone": {
-      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-symlinks/.temp/genTempDir.symlink/2026-06-19T10-59-57.412Z.judges-pass.0c8b7565/1.test.stone",
+      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/genTempDir.symlink/2026-06-19T10-33-49.609Z.judges-pass.bc9e733d/1.test.stone",
     },
   },
 ]
@@ -66,7 +66,7 @@ exports[`runStoneGuardJudges given: [case2] guard with judge command that fails 
 reason: blockers found
 ",
     "stone": {
-      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-symlinks/.temp/genTempDir.symlink/2026-06-19T10-59-57.434Z.judges-fail.334b10bf/1.test.stone",
+      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/genTempDir.symlink/2026-06-19T10-33-49.657Z.judges-fail.f6d6f45c/1.test.stone",
     },
   },
 ]
@@ -116,7 +116,7 @@ exports[`runStoneGuardJudges given: [case3] guard with multiple judge commands w
 reason: review passed
 ",
     "stone": {
-      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-symlinks/.temp/genTempDir.symlink/2026-06-19T10-59-57.449Z.judges-multi.13d16485/1.test.stone",
+      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/genTempDir.symlink/2026-06-19T10-33-49.708Z.judges-multi.d6ffe568/1.test.stone",
     },
   },
   {
@@ -133,7 +133,7 @@ reason: review passed
 reason: approval required
 ",
     "stone": {
-      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-symlinks/.temp/genTempDir.symlink/2026-06-19T10-59-57.449Z.judges-multi.13d16485/1.test.stone",
+      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/genTempDir.symlink/2026-06-19T10-33-49.708Z.judges-multi.d6ffe568/1.test.stone",
     },
   },
 ]
@@ -166,10 +166,10 @@ exports[`runStoneGuardJudges given: [case4] guard with $route variable in judge 
     "reason": "marker found at <route-path>",
     "stderr": "",
     "stdout": "passed: true
-reason: marker found at /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-symlinks/.temp/genTempDir.symlink/2026-06-19T10-59-57.472Z.judges-route-var.4e684cc1
+reason: marker found at /home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/genTempDir.symlink/2026-06-19T10-33-49.750Z.judges-route-var.add3cbeb
 ",
     "stone": {
-      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-symlinks/.temp/genTempDir.symlink/2026-06-19T10-59-57.472Z.judges-route-var.4e684cc1/1.test.stone",
+      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/genTempDir.symlink/2026-06-19T10-33-49.750Z.judges-route-var.add3cbeb/1.test.stone",
     },
   },
 ]
@@ -205,7 +205,7 @@ exports[`runStoneGuardJudges given: [case5] passed judge is cached on retry when
 reason: all checks passed
 ",
     "stone": {
-      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-symlinks/.temp/genTempDir.symlink/2026-06-19T10-59-57.492Z.judges-cache-pass.099dd5d1/1.test.stone",
+      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/genTempDir.symlink/2026-06-19T10-33-49.799Z.judges-cache-pass.4639bc5c/1.test.stone",
     },
   },
 ]
@@ -241,7 +241,7 @@ exports[`runStoneGuardJudges given: [case6] failed judge is NOT cached (retries 
 reason: blockers found
 ",
     "stone": {
-      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-symlinks/.temp/genTempDir.symlink/2026-06-19T10-59-57.535Z.judges-nocache-fail.cf1822cf/1.test.stone",
+      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/genTempDir.symlink/2026-06-19T10-33-49.847Z.judges-nocache-fail.3fe0a5d2/1.test.stone",
     },
   },
 ]
@@ -277,7 +277,7 @@ exports[`runStoneGuardJudges given: [case7] judge exits with code 0 (passed) whe
 reason: judge passed
 ",
     "stone": {
-      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-symlinks/.temp/genTempDir.symlink/2026-06-19T10-59-57.612Z.judges-exit0.c23ed647/1.test.stone",
+      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/genTempDir.symlink/2026-06-19T10-33-49.894Z.judges-exit0.02f102a6/1.test.stone",
     },
   },
 ]
@@ -316,7 +316,7 @@ exports[`runStoneGuardJudges given: [case8] judge exits with code 2 (constraint)
 reason: approval required
 ",
     "stone": {
-      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-symlinks/.temp/genTempDir.symlink/2026-06-19T10-59-57.667Z.judges-exit2.f52a1f15/1.test.stone",
+      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/genTempDir.symlink/2026-06-19T10-33-49.940Z.judges-exit2.16ca11de/1.test.stone",
     },
   },
 ]
@@ -356,7 +356,7 @@ exports[`runStoneGuardJudges given: [case9] judge exits with code 1 (malfunction
     "stdout": "stdout output
 ",
     "stone": {
-      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-symlinks/.temp/genTempDir.symlink/2026-06-19T10-59-57.728Z.judges-exit1.23d892e3/1.test.stone",
+      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/genTempDir.symlink/2026-06-19T10-33-49.986Z.judges-exit1.49f9c374/1.test.stone",
     },
   },
 ]
@@ -395,7 +395,7 @@ exports[`runStoneGuardJudges given: [case10] blocked judge (exit 2) is NOT cache
 reason: approval required
 ",
     "stone": {
-      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-symlinks/.temp/genTempDir.symlink/2026-06-19T10-59-57.775Z.judges-nocache-block.3bcce248/1.test.stone",
+      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/genTempDir.symlink/2026-06-19T10-33-50.031Z.judges-nocache-block.735e6406/1.test.stone",
     },
   },
 ]
@@ -428,10 +428,10 @@ exports[`runStoneGuardJudges given: [case11] guard with $rhx variable in judge c
     "reason": "rhx=<repo-root>/node_modules/.bin/rhx",
     "stderr": "",
     "stdout": "passed: true
-reason: rhx=/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-symlinks/node_modules/.bin/rhx
+reason: rhx=/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-review-blocker-access/node_modules/.bin/rhx
 ",
     "stone": {
-      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-symlinks/.temp/genTempDir.symlink/2026-06-19T10-59-57.817Z.judges-rhx-var.fb669779/1.test.stone",
+      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/genTempDir.symlink/2026-06-19T10-33-50.078Z.judges-rhx-var.a8d2ab34/1.test.stone",
     },
   },
 ]
@@ -464,10 +464,10 @@ exports[`runStoneGuardJudges given: [case12] guard with $rhachet variable in jud
     "reason": "rhachet=<repo-root>/node_modules/.bin/rhachet",
     "stderr": "",
     "stdout": "passed: true
-reason: rhachet=/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-symlinks/node_modules/.bin/rhachet
+reason: rhachet=/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-review-blocker-access/node_modules/.bin/rhachet
 ",
     "stone": {
-      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-symlinks/.temp/genTempDir.symlink/2026-06-19T10-59-57.869Z.judges-rhachet-var.d7a2e2b4/1.test.stone",
+      "path": "/home/vlad/git/ehmpathy/_worktrees/rhachet-roles-bhrain.vlad.fix-review-blocker-access/.temp/genTempDir.symlink/2026-06-19T10-33-50.124Z.judges-rhachet-var.4949d4fb/1.test.stone",
     },
   },
 ]

--- a/src/domain.operations/route/judges/computeStoneJudgeInputHash.ts
+++ b/src/domain.operations/route/judges/computeStoneJudgeInputHash.ts
@@ -3,8 +3,8 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 
 import type { RouteStone } from '@src/domain.objects/Driver/RouteStone';
-import { enumFilesFromGlob } from '@src/utils/enumFilesFromGlob';
 
+import { enumRouteGuardReviewPeerFiles } from '../guard/enumRouteGuardReviewPeerFiles';
 import { getLatestReviewFilesPerIndex } from '../guard/getLatestReviewFilesPerIndex';
 import { getOnePassageReport } from '../passage/getOnePassageReport';
 
@@ -23,22 +23,19 @@ export const computeStoneJudgeInputHash = async (input: {
   reviewInputHash: string;
   route: string;
 }): Promise<string> => {
-  const routeDir = path.join(input.route, '.route');
-
   // find all review files for this review input hash
-  const reviewGlob = `${input.stone.name}.guard.review.*.${input.reviewInputHash}.*.md`;
-  let reviewFiles: string[] = [];
-  try {
-    reviewFiles = await enumFilesFromGlob({ glob: reviewGlob, cwd: routeDir });
-  } catch {
-    // .route/ may not exist yet
-  }
+  // review pattern: $stone._.review.i$iter.$hash.r$idx._.given.by_peer.$slug.md
+  const reviewFiles = await enumRouteGuardReviewPeerFiles({
+    route: input.route,
+    stone: input.stone.name,
+    hash: input.reviewInputHash,
+  });
 
   // get latest review per index (later iterations supersede earlier)
   const latestReviewFiles = getLatestReviewFilesPerIndex({ reviewFiles });
 
   // read review contents from latest reviews only
-  // note: enumFilesFromGlob returns absolute paths, so use directly
+  // note: enumRouteGuardReviewPeerFiles returns absolute paths, so use directly
   const reviewContents: string[] = [];
   for (const filePath of latestReviewFiles) {
     const content = await fs.readFile(filePath, 'utf-8');

--- a/src/domain.operations/route/judges/runStoneGuardJudges.ts
+++ b/src/domain.operations/route/judges/runStoneGuardJudges.ts
@@ -1,5 +1,6 @@
 import { exec } from 'child_process';
 import * as fs from 'fs/promises';
+import { BadRequestError } from 'helpful-errors';
 import * as path from 'path';
 import { getGitRepoRoot } from 'rhachet-artifact-git';
 import { promisify } from 'util';
@@ -10,6 +11,7 @@ import type { RouteStoneGuard } from '@src/domain.objects/Driver/RouteStoneGuard
 import { RouteStoneGuardJudgeArtifact } from '@src/domain.objects/Driver/RouteStoneGuardJudgeArtifact';
 import { formatTreeBucket } from '@src/domain.operations/route/guard/formatTreeBucket';
 import { getExitCodeClass } from '@src/domain.operations/route/guard/getExitCodeClass';
+import { isENOENT } from '@src/domain.operations/route/guard/isENOENT';
 import { enumFilesFromGlob } from '@src/utils/enumFilesFromGlob';
 
 import { computeStoneJudgeInputHash } from './computeStoneJudgeInputHash';
@@ -39,7 +41,13 @@ export const runOneStoneGuardJudge = async (input: {
   let repoRoot: string;
   try {
     repoRoot = await getGitRepoRoot({ from: input.route });
-  } catch {
+  } catch (error) {
+    // only catch "not in git repo" error; rethrow any other errors
+    // .note = check error message instead of instanceof due to cross-module class instances
+    const isNotInGitRepoError =
+      error instanceof Error && error.message.includes('Not inside a Git');
+    if (!isNotInGitRepoError) throw error;
+
     repoRoot = process.cwd();
   }
 
@@ -82,13 +90,21 @@ export const runOneStoneGuardJudge = async (input: {
     stderr = result.stderr;
     exitCode = 0;
   } catch (error: unknown) {
-    // capture output and exit code even on failure
-    if (error && typeof error === 'object') {
-      const errObj = error as Record<string, unknown>;
-      stdout = typeof errObj.stdout === 'string' ? errObj.stdout : '';
-      stderr = typeof errObj.stderr === 'string' ? errObj.stderr : '';
-      exitCode = typeof errObj.code === 'number' ? errObj.code : 1;
+    // capture output and exit code from command failure
+    // exec errors have specific shape: { stdout, stderr, code, killed }
+    // rethrow if error doesn't match this shape (unexpected error)
+    if (
+      !error ||
+      typeof error !== 'object' ||
+      !('code' in error || 'killed' in error)
+    ) {
+      throw error;
     }
+
+    const errObj = error as Record<string, unknown>;
+    stdout = typeof errObj.stdout === 'string' ? errObj.stdout : '';
+    stderr = typeof errObj.stderr === 'string' ? errObj.stderr : '';
+    exitCode = typeof errObj.code === 'number' ? errObj.code : 1;
   }
 
   // classify exit code
@@ -174,8 +190,9 @@ export const runStoneGuardJudges = async (
       glob: judgeGlob,
       cwd: routeDir,
     });
-  } catch {
-    // .route/ may not exist yet
+  } catch (error) {
+    // .route/ may not exist yet; rethrow any other errors
+    if (!isENOENT(error)) throw error;
   }
 
   // parse prior judges to build cache
@@ -238,11 +255,19 @@ export const runStoneGuardJudges = async (
     const prior = priorByIndex.get(index);
     if (prior) {
       // emit cached event for progress output
+      // .note = include outcome data for consistency with reviews cached events
       context.cliEmit.onGuardProgress({
         stone: input.stone,
         step: { phase: 'judge', index: i },
         inflight: null,
-        outcome: null,
+        outcome: {
+          path: prior.path,
+          review: null,
+          judge: {
+            decision: prior.passed ? 'allowed' : 'blocked',
+            reason: prior.reason,
+          },
+        },
       });
       judges.push(prior);
       continue;
@@ -279,7 +304,9 @@ export const runStoneGuardJudges = async (
         review: null,
         judge:
           judge.exitClass === 'malfunction'
-            ? { malfunction: new Error(`exit code ${judge.exitCode}`) }
+            ? {
+                malfunction: `judge command failed with exit code ${judge.exitCode}`,
+              }
             : {
                 decision: judge.passed ? 'allowed' : 'blocked',
                 reason: judge.reason,
@@ -298,13 +325,17 @@ export const runStoneGuardJudges = async (
  * .why = npx adds 500-2000ms latency and has cross-platform issues
  */
 const validateNoNpx = (cmd: string): void => {
+  // reject guards that use npx patterns
   if (cmd.includes('npx rhachet') || cmd.includes('npx rhx')) {
     const pattern = cmd.includes('npx rhachet') ? 'npx rhachet' : 'npx rhx';
     const alias = cmd.includes('npx rhachet') ? '$rhachet' : '$rhx';
-    throw new Error(
-      `guard uses ${pattern} which causes latency and cross-platform issues\n\n` +
-        `fix: use ${alias} alias instead\n` +
-        `  - ${alias} expands to ./node_modules/.bin/${alias.slice(1)}\n`,
+    BadRequestError.throw(
+      `guard uses ${pattern} which causes latency and cross-platform issues. ` +
+        `fix: use ${alias} alias instead (${alias} expands to ./node_modules/.bin/${alias.slice(1)})`,
+      {
+        pattern,
+        alias,
+      },
     );
   }
 };
@@ -459,7 +490,9 @@ const isFilePresent = async (filePath: string): Promise<boolean> => {
   try {
     await fs.access(filePath);
     return true;
-  } catch {
-    return false;
+  } catch (error) {
+    // only catch ENOENT (file not found); rethrow other errors
+    if (isENOENT(error)) return false;
+    throw error;
   }
 };

--- a/src/domain.operations/route/stones/delStoneGuardArtifacts.test.ts
+++ b/src/domain.operations/route/stones/delStoneGuardArtifacts.test.ts
@@ -41,16 +41,22 @@ describe('delStoneGuardArtifacts', () => {
       os.tmpdir(),
       `test-del-guard-artifacts-reviews-${Date.now()}`,
     );
-    const routeDir = path.join(tempDir, '.route');
+    const reviewsDir = path.join(tempDir, '.reviews', 'peer');
 
     beforeEach(async () => {
-      await fs.mkdir(routeDir, { recursive: true });
+      await fs.mkdir(reviewsDir, { recursive: true });
       await fs.writeFile(
-        path.join(routeDir, '1.vision.guard.review.i1.abc123.r1.md'),
+        path.join(
+          reviewsDir,
+          '1.vision._.review.i1.abc123.r1._.given.by_peer.test-reviewer.md',
+        ),
         'review 1',
       );
       await fs.writeFile(
-        path.join(routeDir, '1.vision.guard.review.i1.abc123.r2.md'),
+        path.join(
+          reviewsDir,
+          '1.vision._.review.i1.abc123.r2._.given.by_peer.test-reviewer.md',
+        ),
         'review 2',
       );
     });
@@ -63,7 +69,7 @@ describe('delStoneGuardArtifacts', () => {
       then('deletes review files', async () => {
         await delStoneGuardArtifacts({ stone: '1.vision', route: tempDir });
 
-        const files = await fs.readdir(routeDir);
+        const files = await fs.readdir(reviewsDir);
         expect(files.filter((f) => f.includes('.review.'))).toHaveLength(0);
       });
 
@@ -197,13 +203,20 @@ describe('delStoneGuardArtifacts', () => {
       `test-del-guard-artifacts-mixed-${Date.now()}`,
     );
     const routeDir = path.join(tempDir, '.route');
+    const reviewsDir = path.join(tempDir, '.reviews', 'peer');
 
     beforeEach(async () => {
       await fs.mkdir(routeDir, { recursive: true });
+      await fs.mkdir(reviewsDir, { recursive: true });
+      // reviews go to .reviews/peer/
       await fs.writeFile(
-        path.join(routeDir, '1.vision.guard.review.i1.abc123.r1.md'),
+        path.join(
+          reviewsDir,
+          '1.vision._.review.i1.abc123.r1._.given.by_peer.test-reviewer.md',
+        ),
         'review',
       );
+      // judges, promises, triggers stay in .route/
       await fs.writeFile(
         path.join(routeDir, '1.vision.guard.judge.i1.abc123.j1.md'),
         'judge',
@@ -229,8 +242,10 @@ describe('delStoneGuardArtifacts', () => {
       then('deletes all guard artifact types', async () => {
         await delStoneGuardArtifacts({ stone: '1.vision', route: tempDir });
 
-        const files = await fs.readdir(routeDir);
-        expect(files).toHaveLength(0);
+        const routeFiles = await fs.readdir(routeDir);
+        expect(routeFiles).toHaveLength(0);
+        const reviewFiles = await fs.readdir(reviewsDir);
+        expect(reviewFiles).toHaveLength(0);
       });
 
       then('returns correct counts for all types', async () => {
@@ -283,16 +298,22 @@ describe('delStoneGuardArtifacts', () => {
       os.tmpdir(),
       `test-del-guard-artifacts-preserve-${Date.now()}`,
     );
-    const routeDir = path.join(tempDir, '.route');
+    const reviewsDir = path.join(tempDir, '.reviews', 'peer');
 
     beforeEach(async () => {
-      await fs.mkdir(routeDir, { recursive: true });
+      await fs.mkdir(reviewsDir, { recursive: true });
       await fs.writeFile(
-        path.join(routeDir, '1.vision.guard.review.i1.abc123.r1.md'),
+        path.join(
+          reviewsDir,
+          '1.vision._.review.i1.abc123.r1._.given.by_peer.test-reviewer.md',
+        ),
         'review for 1.vision',
       );
       await fs.writeFile(
-        path.join(routeDir, '2.criteria.guard.review.i1.def456.r1.md'),
+        path.join(
+          reviewsDir,
+          '2.criteria._.review.i1.def456.r1._.given.by_peer.test-reviewer.md',
+        ),
         'review for 2.criteria',
       );
     });
@@ -305,7 +326,7 @@ describe('delStoneGuardArtifacts', () => {
       then('only deletes 1.vision artifacts', async () => {
         await delStoneGuardArtifacts({ stone: '1.vision', route: tempDir });
 
-        const files = await fs.readdir(routeDir);
+        const files = await fs.readdir(reviewsDir);
         expect(files).toHaveLength(1);
         expect(files[0]).toContain('2.criteria');
       });
@@ -318,14 +339,20 @@ describe('delStoneGuardArtifacts', () => {
       `test-del-guard-artifacts-gitignore-${Date.now()}`,
     );
     const routeDir = path.join(tempDir, '.route');
+    const reviewsDir = path.join(tempDir, '.reviews', 'peer');
 
     beforeEach(async () => {
       await fs.mkdir(routeDir, { recursive: true });
+      await fs.mkdir(reviewsDir, { recursive: true });
       // create .gitignore that ignores all files
       await fs.writeFile(path.join(routeDir, '.gitignore'), '*\n');
+      await fs.writeFile(path.join(reviewsDir, '.gitignore'), '*\n');
       // create guard artifacts (would be gitignored in production)
       await fs.writeFile(
-        path.join(routeDir, '1.vision.guard.review.i1.abc123.r1.md'),
+        path.join(
+          reviewsDir,
+          '1.vision._.review.i1.abc123.r1._.given.by_peer.test-reviewer.md',
+        ),
         'review',
       );
       await fs.writeFile(
@@ -352,9 +379,15 @@ describe('delStoneGuardArtifacts', () => {
       then('files are actually deleted', async () => {
         await delStoneGuardArtifacts({ stone: '1.vision', route: tempDir });
 
-        const files = await fs.readdir(routeDir);
-        const guardFiles = files.filter((f) => f.includes('.guard.'));
+        const routeFiles = await fs.readdir(routeDir);
+        const guardFiles = routeFiles.filter((f) => f.includes('.guard.'));
         expect(guardFiles).toHaveLength(0);
+
+        const reviewFiles = await fs.readdir(reviewsDir);
+        const reviewArtifacts = reviewFiles.filter((f) =>
+          f.includes('.review.'),
+        );
+        expect(reviewArtifacts).toHaveLength(0);
       });
     });
   });

--- a/src/domain.operations/route/stones/delStoneGuardArtifacts.ts
+++ b/src/domain.operations/route/stones/delStoneGuardArtifacts.ts
@@ -1,7 +1,8 @@
 import * as fs from 'fs/promises';
-import * as path from 'path';
 
-import { enumFilesFromGlob } from '@src/utils/enumFilesFromGlob';
+import { enumRouteFiles } from '@src/domain.operations/route/guard/enumRouteFiles';
+import { enumRouteGuardJudgeFiles } from '@src/domain.operations/route/guard/enumRouteGuardJudgeFiles';
+import { enumRouteGuardReviewPeerFiles } from '@src/domain.operations/route/guard/enumRouteGuardReviewPeerFiles';
 
 /**
  * .what = deletes all guard artifacts for a stone
@@ -19,54 +20,34 @@ export const delStoneGuardArtifacts = async (input: {
     promises: number;
   };
 }> => {
-  const routeDir = path.join(input.route, '.route');
-
-  // check if .route dir found
-  try {
-    await fs.access(routeDir);
-  } catch {
-    return {
-      reviews: 0,
-      judges: 0,
-      promises: 0,
-      triggers: { blockers: 0, promises: 0 },
-    };
-  }
-
-  // glob for review files: $stone.guard.review.*.md
-  // note: dot=true to find files even if directory has gitignore
-  const reviewFiles = await enumFilesFromGlob({
-    glob: `${input.stone}.guard.review.*.md`,
-    cwd: routeDir,
-    dot: true,
+  // collect review files from .reviews/peer/
+  const reviewFiles = await enumRouteGuardReviewPeerFiles({
+    route: input.route,
+    stone: input.stone,
   });
 
-  // glob for judge files: $stone.guard.judge.*.md
-  const judgeFiles = await enumFilesFromGlob({
-    glob: `${input.stone}.guard.judge.*.md`,
-    cwd: routeDir,
-    dot: true,
+  // collect judge files from .route/
+  const judgeFiles = await enumRouteGuardJudgeFiles({
+    route: input.route,
+    stone: input.stone,
   });
 
-  // glob for promise files: $stone.guard.promise.*.md
-  const promiseFiles = await enumFilesFromGlob({
-    glob: `${input.stone}.guard.promise.*.md`,
-    cwd: routeDir,
-    dot: true,
+  // collect promise files from .route/
+  const promiseFiles = await enumRouteFiles({
+    route: input.route,
+    glob: `.route/${input.stone}.guard.promise.*.md`,
   });
 
-  // glob for triggered files: $stone.guard.selfreview.*.triggered.*.md
-  const triggerFiles = await enumFilesFromGlob({
-    glob: `${input.stone}.guard.selfreview.*.triggered.*.md`,
-    cwd: routeDir,
-    dot: true,
+  // collect triggered files from .route/
+  const triggerFiles = await enumRouteFiles({
+    route: input.route,
+    glob: `.route/${input.stone}.guard.selfreview.*.triggered.*.md`,
   });
 
-  // glob for blocked trigger files: $stone.blocked.triggered
-  const blockedTriggerFiles = await enumFilesFromGlob({
-    glob: `${input.stone}.blocked.triggered`,
-    cwd: routeDir,
-    dot: true,
+  // collect blocked trigger files from .route/
+  const blockedTriggerFiles = await enumRouteFiles({
+    route: input.route,
+    glob: `.route/${input.stone}.blocked.triggered`,
   });
 
   // delete all found files

--- a/src/domain.operations/route/stones/setStoneAsRewound.test.ts
+++ b/src/domain.operations/route/stones/setStoneAsRewound.test.ts
@@ -124,14 +124,21 @@ describe('setStoneAsRewound', () => {
       `test-set-rewound-artifacts-${Date.now()}`,
     );
     const routeDir = path.join(tempDir, '.route');
+    const reviewsDir = path.join(tempDir, '.reviews', 'peer');
 
     beforeEach(async () => {
       await fs.mkdir(routeDir, { recursive: true });
+      await fs.mkdir(reviewsDir, { recursive: true });
       await fs.writeFile(path.join(tempDir, '1.vision.stone'), 'stone content');
+      // reviews go to .reviews/peer/
       await fs.writeFile(
-        path.join(routeDir, '1.vision.guard.review.i1.abc123.r1.md'),
+        path.join(
+          reviewsDir,
+          '1.vision._.review.i1.abc123.r1._.given.by_peer.test-reviewer.md',
+        ),
         'review',
       );
+      // judges stay in .route/
       await fs.writeFile(
         path.join(routeDir, '1.vision.guard.judge.i1.abc123.j1.md'),
         'judge',
@@ -148,8 +155,12 @@ describe('setStoneAsRewound', () => {
           { stone: '1.vision', route: tempDir },
           mockContext,
         );
-        const files = await fs.readdir(routeDir);
-        expect(files.filter((f) => f.includes('.guard.'))).toHaveLength(0);
+        const routeFiles = await fs.readdir(routeDir);
+        expect(routeFiles.filter((f) => f.includes('.guard.'))).toHaveLength(0);
+        const reviewFiles = await fs.readdir(reviewsDir);
+        expect(reviewFiles.filter((f) => f.includes('.review.'))).toHaveLength(
+          0,
+        );
       });
 
       then('stdout matches snapshot', async () => {
@@ -279,17 +290,23 @@ describe('setStoneAsRewound', () => {
       `test-set-rewound-snapshot-${Date.now()}`,
     );
     const routeDir = path.join(tempDir, '.route');
+    const reviewsDir = path.join(tempDir, '.reviews', 'peer');
 
     beforeEach(async () => {
       await fs.mkdir(routeDir, { recursive: true });
+      await fs.mkdir(reviewsDir, { recursive: true });
       await fs.writeFile(path.join(tempDir, '1.vision.stone'), 'stone 1');
       await fs.writeFile(path.join(tempDir, '2.criteria.stone'), 'stone 2');
       await fs.writeFile(path.join(tempDir, '3.blueprint.stone'), 'stone 3');
-      // add guard artifacts
+      // reviews go to .reviews/peer/
       await fs.writeFile(
-        path.join(routeDir, '2.criteria.guard.review.i1.abc123.r1.md'),
+        path.join(
+          reviewsDir,
+          '2.criteria._.review.i1.abc123.r1._.given.by_peer.test-reviewer.md',
+        ),
         'review',
       );
+      // judges and promises stay in .route/
       await fs.writeFile(
         path.join(routeDir, '2.criteria.guard.judge.i1.abc123.j1.md'),
         'judge',


### PR DESCRIPTION
fix(route): persist peer reviews to .reviews/peer/ for driver access

- add enumRouteGuardReviewPeerFiles to find review files in .reviews/peer/
- add enumRouteGuardJudgeFiles to find judge output files
- refactor guard artifact discovery to use new enum operations
- add acceptance tests proving $output variable substitution works
- reviews now accessible at paths shown in stdout

---
🐢🌊 surfed in by seaturtle[bot]