### PR TITLE
fix(guard): use repoRoot as cwd for peer review subprocess execution

### DIFF
--- a/.agent/repo=.this/role=any/briefs/rule.forbid.cwd-outside-gitroot.md
+++ b/.agent/repo=.this/role=any/briefs/rule.forbid.cwd-outside-gitroot.md
@@ -2,7 +2,7 @@
 
 ## .what
 
-never change cwd outside the git repository root. all file operations must use paths relative to gitroot.
+never change cwd outside the git repository root. all subprocess and file operations must use repoRoot as cwd.
 
 ## .why
 
@@ -10,8 +10,37 @@ never change cwd outside the git repository root. all file operations must use p
 - avoids path confusion when functions compose
 - prevents accidental file access outside repo boundaries
 - glob patterns work consistently across all call sites
+- **skill resolution depends on cwd** — rhachet looks for `.agent/` relative to cwd, so skills fail if cwd is not gitroot
+
+## .incident: v0.29.6 regression
+
+in v0.29.6, `runStoneGuardReviews` added `cwd: input.route` to execute peer reviews from the route directory. this broke skill resolution:
+
+```
+BadRequestError: no skill "review" found with --repo bhrain
+```
+
+because `rhx` looked for `.agent/repo=bhrain/` relative to `.behavior/v2026.../` instead of the repo root.
 
 ## .pattern
+
+### subprocess execution
+
+```ts
+// 👎 bad — changes cwd to subdirectory
+const result = await execAsync(cmd, {
+  cwd: input.route,  // route dir like .behavior/v2026.../
+  env: execEnv,
+});
+
+// 👍 good — keep cwd at gitroot
+const result = await execAsync(cmd, {
+  cwd: repoRoot,  // always git root
+  env: execEnv,
+});
+```
+
+### glob enumeration
 
 ```ts
 // 👎 bad — changes cwd to subdirectory
@@ -25,6 +54,7 @@ const matches = await enumFilesFromGlob({ glob: expandedGlob });
 ## .scope
 
 applies to:
+- `execAsync` / `execSync` calls
 - `enumFilesFromGlob` calls
 - `fs` operations
 - any function that accepts a `cwd` parameter

--- a/blackbox/__snapshots__/driver.route.peer-review-exit-codes.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.peer-review-exit-codes.acceptance.test.ts.snap
@@ -7,7 +7,7 @@ exports[`driver.route.peer-review-exit-codes.acceptance given: [journey] exit co
    │   ├─ rejected [TIME]
    │   ├─ 1 blocker 🔴
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i1.8739656801d5e77f22.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i1.8739656801d5e77f22.r1._.given.by_peer.exit-code-reviewer.md
    │
    └─ ✗ judge.1 - blocked [TIME]
 
@@ -23,7 +23,7 @@ exports[`driver.route.peer-review-exit-codes.acceptance given: [journey] exit co
       │       ├─ rejected [TIME]
       │       ├─ 1 blocker 🔴
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.execute.guard.review.i1.8739656801d5e77f22.r1.md
+      │       └─ review: .reviews/peer/1.execute._.review.i1.8739656801d5e77f22.r1._.given.by_peer.exit-code-reviewer.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               ├─ finished [TIME] ✗
@@ -36,7 +36,7 @@ exports[`driver.route.peer-review-exit-codes.acceptance given: [journey] exit co
    │
    ├─ r1: exit-code-reviewer (l1, 2/2)
    │   ├─ ✋ constraint
-   │   └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.exit-code-reviewer.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -52,7 +52,7 @@ exports[`driver.route.peer-review-exit-codes.acceptance given: [journey] exit co
       │       ├─ approved [TIME]
       │       ├─ 0 blockers ✓
       │       ├─ 0 nitpicks ✓
-      │       └─ review: .route/1.execute.guard.review.i2.dfc5faff83ea2fcb55.r1.md
+      │       └─ review: .reviews/peer/1.execute._.review.i2.dfc5faff83ea2fcb55.r1._.given.by_peer.exit-code-reviewer.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               └─ finished [TIME] ✓
@@ -64,7 +64,7 @@ exports[`driver.route.peer-review-exit-codes.acceptance given: [journey] exit co
    │
    ├─ r1: exit-code-reviewer (l1, 2/2)
    │   ├─ 💥 malfunction
-   │   └─ review: .route/1.execute.guard.review.i3.457fd5ef46e053a35e.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i3.457fd5ef46e053a35e.r1._.given.by_peer.exit-code-reviewer.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -78,7 +78,7 @@ exports[`driver.route.peer-review-exit-codes.acceptance given: [journey] exit co
       ├─ reviews
       │   └─ r1: exit-code-reviewer (l1, 1/2)
       │       ├─ 💥 malfunction
-      │       └─ review: .route/1.execute.guard.review.i3.457fd5ef46e053a35e.r1.md
+      │       └─ review: .reviews/peer/1.execute._.review.i3.457fd5ef46e053a35e.r1._.given.by_peer.exit-code-reviewer.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               └─ finished [TIME] ✓
@@ -92,7 +92,7 @@ exports[`driver.route.peer-review-exit-codes.acceptance given: [journey] exit co
    │   ├─ approved [TIME]
    │   ├─ 0 blockers ✓
    │   ├─ 0 nitpicks ✓
-   │   └─ review: .route/1.execute.guard.review.i4.d1bd0b8547352e6396.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i4.d1bd0b8547352e6396.r1._.given.by_peer.exit-code-reviewer.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -107,7 +107,7 @@ exports[`driver.route.peer-review-exit-codes.acceptance given: [journey] exit co
    │  │       ├─ approved [TIME]
    │  │       ├─ 0 blockers ✓
    │  │       ├─ 0 nitpicks ✓
-   │  │       └─ review: .route/1.execute.guard.review.i4.d1bd0b8547352e6396.r1.md
+   │  │       └─ review: .reviews/peer/1.execute._.review.i4.d1bd0b8547352e6396.r1._.given.by_peer.exit-code-reviewer.md
    │  └─ judges
    │      └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
    │          └─ finished [TIME] ✓

--- a/blackbox/__snapshots__/driver.route.peer-review-timeout.acceptance.test.ts.snap
+++ b/blackbox/__snapshots__/driver.route.peer-review-timeout.acceptance.test.ts.snap
@@ -5,7 +5,7 @@ exports[`driver.route.peer-review-timeout.acceptance given: [journey] review tim
    │
    ├─ r1: slow-reviewer (l1, 1/2)
    │   ├─ 💥 malfunction
-   │   └─ review: .route/1.execute.guard.review.i1.8739656801d5e77f22.r1.md
+   │   └─ review: .reviews/peer/1.execute._.review.i1.8739656801d5e77f22.r1._.given.by_peer.slow-reviewer.md
    │
    └─ ✓ judge.1 - allowed [TIME]
 
@@ -19,7 +19,7 @@ exports[`driver.route.peer-review-timeout.acceptance given: [journey] review tim
       ├─ reviews
       │   └─ r1: slow-reviewer (l1, 0/2)
       │       ├─ 💥 malfunction
-      │       └─ review: .route/1.execute.guard.review.i1.8739656801d5e77f22.r1.md
+      │       └─ review: .reviews/peer/1.execute._.review.i1.8739656801d5e77f22.r1._.given.by_peer.slow-reviewer.md
       └─ judges
           └─ j1: rhx route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 1
               └─ finished [TIME] ✓

--- a/src/domain.operations/route/guard/__snapshots__/runStoneGuardReviews.integration.test.ts.snap
+++ b/src/domain.operations/route/guard/__snapshots__/runStoneGuardReviews.integration.test.ts.snap
@@ -26,14 +26,14 @@ exports[`runStoneGuardReviews given: [case1] guard with echo review command when
     "index": 1,
     "iteration": 1,
     "nitpicks": 1,
-    "path": "<route>/.route/1.test.guard.review.i1.case1ret.r1.md",
+    "path": "<route>/.reviews/peer/1.test._.review.i1.case1ret.r1._.given.by_peer.echo.md",
     "stderr": "",
     "stdout": "blockers: 0
 nitpicks: 1
 review output
 ",
     "stone": {
-      "path": "/tmp/test-reviews-1781868187222/1.test.stone",
+      "path": "/tmp/test-reviews-1781903845831/1.test.stone",
     },
   },
 ]
@@ -78,13 +78,13 @@ exports[`runStoneGuardReviews given: [case2] guard with multiple review commands
     "index": 1,
     "iteration": 1,
     "nitpicks": 0,
-    "path": "<route>/.route/1.test.guard.review.i1.case2ret.r1.md",
+    "path": "<route>/.reviews/peer/1.test._.review.i1.case2ret.r1._.given.by_peer.echo.md",
     "stderr": "",
     "stdout": "blockers: 1
 nitpicks: 0
 ",
     "stone": {
-      "path": "/tmp/test-reviews-multi-1781868187223/1.test.stone",
+      "path": "/tmp/test-reviews-multi-1781903845832/1.test.stone",
     },
   },
   {
@@ -96,13 +96,13 @@ nitpicks: 0
     "index": 2,
     "iteration": 1,
     "nitpicks": 2,
-    "path": "<route>/.route/1.test.guard.review.i1.case2ret.r2.md",
+    "path": "<route>/.reviews/peer/1.test._.review.i1.case2ret.r2._.given.by_peer.echo.md",
     "stderr": "",
     "stdout": "blockers: 0
 nitpicks: 2
 ",
     "stone": {
-      "path": "/tmp/test-reviews-multi-1781868187223/1.test.stone",
+      "path": "/tmp/test-reviews-multi-1781903845832/1.test.stone",
     },
   },
 ]
@@ -133,13 +133,13 @@ exports[`runStoneGuardReviews given: [case3] review exits with code 0 (passed) w
     "index": 1,
     "iteration": 1,
     "nitpicks": 0,
-    "path": "<route>/.route/1.test.guard.review.i1.case3ret.r1.md",
+    "path": "<route>/.reviews/peer/1.test._.review.i1.case3ret.r1._.given.by_peer.echo.md",
     "stderr": "",
     "stdout": "blockers: 0
 review passed
 ",
     "stone": {
-      "path": "/tmp/test-reviews-exit0-1781868187224/1.test.stone",
+      "path": "/tmp/test-reviews-exit0-1781903845832/1.test.stone",
     },
   },
 ]
@@ -173,13 +173,13 @@ exports[`runStoneGuardReviews given: [case4] review exits with code 2 (constrain
     "index": 1,
     "iteration": 1,
     "nitpicks": 0,
-    "path": "<route>/.route/1.test.guard.review.i1.case4ret.r1.md",
+    "path": "<route>/.reviews/peer/1.test._.review.i1.case4ret.r1._.given.by_peer.bash.md",
     "stderr": "",
     "stdout": "blockers: 1
 constraint failure
 ",
     "stone": {
-      "path": "/tmp/test-reviews-exit2-1781868187224/1.test.stone",
+      "path": "/tmp/test-reviews-exit2-1781903845833/1.test.stone",
     },
   },
 ]
@@ -214,13 +214,13 @@ exports[`runStoneGuardReviews given: [case5] review exits with code 1 (malfuncti
     "index": 1,
     "iteration": 1,
     "nitpicks": 0,
-    "path": "<route>/.route/1.test.guard.review.i1.case5ret.r1.md",
+    "path": "<route>/.reviews/peer/1.test._.review.i1.case5ret.r1._.given.by_peer.bash.md",
     "stderr": "stderr error
 ",
     "stdout": "stdout output
 ",
     "stone": {
-      "path": "/tmp/test-reviews-exit1-1781868187225/1.test.stone",
+      "path": "/tmp/test-reviews-exit1-1781903845833/1.test.stone",
     },
   },
 ]
@@ -252,14 +252,14 @@ exports[`runStoneGuardReviews given: [case6] guard with $route variable in revie
     "index": 1,
     "iteration": 1,
     "nitpicks": 0,
-    "path": "<route>/.route/1.test.guard.review.i1.case6ret.r1.md",
+    "path": "<route>/.reviews/peer/1.test._.review.i1.case6ret.r1._.given.by_peer.bash.md",
     "stderr": "",
     "stdout": "blockers: 0
 nitpicks: 0
 marker found at <route-path>
 ",
     "stone": {
-      "path": "/tmp/test-reviews-route-1781868187225/1.test.stone",
+      "path": "/tmp/test-reviews-route-1781903845833/1.test.stone",
     },
   },
 ]
@@ -291,14 +291,14 @@ exports[`runStoneGuardReviews given: [case7] guard with $rhx variable in review 
     "index": 1,
     "iteration": 1,
     "nitpicks": 0,
-    "path": "<route>/.route/1.test.guard.review.i1.case7ret.r1.md",
+    "path": "<route>/.reviews/peer/1.test._.review.i1.case7ret.r1._.given.by_peer.bash.md",
     "stderr": "",
     "stdout": "blockers: 0
 nitpicks: 0
 rhx=<repo-root>/node_modules/.bin/rhx
 ",
     "stone": {
-      "path": "/tmp/test-reviews-rhx-1781868187226/1.test.stone",
+      "path": "/tmp/test-reviews-rhx-1781903845833/1.test.stone",
     },
   },
 ]
@@ -330,14 +330,14 @@ exports[`runStoneGuardReviews given: [case8] guard with $rhachet variable in rev
     "index": 1,
     "iteration": 1,
     "nitpicks": 0,
-    "path": "<route>/.route/1.test.guard.review.i1.case8ret.r1.md",
+    "path": "<route>/.reviews/peer/1.test._.review.i1.case8ret.r1._.given.by_peer.bash.md",
     "stderr": "",
     "stdout": "blockers: 0
 nitpicks: 0
 rhachet=<repo-root>/node_modules/.bin/rhachet
 ",
     "stone": {
-      "path": "/tmp/test-reviews-rhachet-1781868187226/1.test.stone",
+      "path": "/tmp/test-reviews-rhachet-1781903845834/1.test.stone",
     },
   },
 ]

--- a/src/domain.operations/route/guard/runStoneGuardReviews.ts
+++ b/src/domain.operations/route/guard/runStoneGuardReviews.ts
@@ -172,7 +172,7 @@ export const runOneStoneGuardReview = async (input: {
   let exitCode = 0;
   try {
     const result = await execAsync(cmd, {
-      cwd: input.route,
+      cwd: repoRoot,
       env: execEnv,
       timeout: timeoutMs,
     });


### PR DESCRIPTION
fix(guard): use repoRoot as cwd for peer review subprocess execution

- v0.29.6 regression: cwd: input.route broke skill resolution
- rhx looks for .agent/ relative to cwd, failed when cwd was route dir
- updated rule.forbid.cwd-outside-gitroot with incident details

---
🐢🌊 surfed in by seaturtle[bot]