### PR TITLE
fix(reviewer): remove FIREWORKS_API_KEY from env.test

### DIFF
--- a/src/domain.roles/reviewer/keyrack.yml
+++ b/src/domain.roles/reviewer/keyrack.yml
@@ -1,7 +1,4 @@
 org: ehmpathy
 
-env.test:
-  - FIREWORKS_API_KEY
-
 env.prep:
   - FIREWORKS_API_KEY


### PR DESCRIPTION
fix(reviewer): remove FIREWORKS_API_KEY from env.test

- keyrack now declares FIREWORKS_API_KEY for env.prep only
- env.test does not require this credential

---
🐢🌊 surfed in by seaturtle[bot]