### PR TITLE
fix(driver): block route.stone.set in background via foreground guard hook

### DIFF
--- a/.behavior/v2026_07_05.fix-stone-set-foreground/.bind/vlad.fix-stone-set-foreground.flag
+++ b/.behavior/v2026_07_05.fix-stone-set-foreground/.bind/vlad.fix-stone-set-foreground.flag
@@ -1,0 +1,2 @@
+branch: vlad/fix-stone-set-foreground
+bound_by: init.behavior skill

--- a/.behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/.gitignore
+++ b/.behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/.gitignore
@@ -1,0 +1,3 @@
+# ignore all peer-review files
+*
+!.gitignore

--- a/.behavior/v2026_07_05.fix-stone-set-foreground/.route/.bind.vlad.fix-stone-set-foreground.flag
+++ b/.behavior/v2026_07_05.fix-stone-set-foreground/.route/.bind.vlad.fix-stone-set-foreground.flag
@@ -1,0 +1,2 @@
+branch: vlad/fix-stone-set-foreground
+bound_by: route.bind skill

--- a/.behavior/v2026_07_05.fix-stone-set-foreground/.route/.bouncer.cache.json
+++ b/.behavior/v2026_07_05.fix-stone-set-foreground/.route/.bouncer.cache.json
@@ -1,0 +1,3 @@
+{
+  "protections": []
+}

--- a/.behavior/v2026_07_05.fix-stone-set-foreground/.route/.drive.blockers.latest.json
+++ b/.behavior/v2026_07_05.fix-stone-set-foreground/.route/.drive.blockers.latest.json
@@ -1,0 +1,4 @@
+{
+  "count": 1,
+  "stone": "5.3.verification"
+}

--- a/.behavior/v2026_07_05.fix-stone-set-foreground/.route/.gitignore
+++ b/.behavior/v2026_07_05.fix-stone-set-foreground/.route/.gitignore
@@ -1,0 +1,5 @@
+# ignore all except passage.jsonl and .bind flags
+*
+!.gitignore
+!passage.jsonl
+!.bind.*

--- a/.behavior/v2026_07_05.fix-stone-set-foreground/.route/passage.jsonl
+++ b/.behavior/v2026_07_05.fix-stone-set-foreground/.route/passage.jsonl
@@ -1,0 +1,18 @@
+{"stone":"1.vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-grounded-in-reality"}
+{"stone":"1.vision","status":"blocked","blocker":"approval","reason":"wait for human approval"}
+{"stone":"1.vision","status":"blocked","blocker":"approval","reason":"wait for human approval"}
+{"stone":"1.vision","status":"approved"}
+{"stone":"1.vision","status":"passed"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-pruned-yagni"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer","reason":"blockers exceed threshold (3 > 0)"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer","reason":"blockers exceed threshold (1 > 0)"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer","reason":"blockers exceed threshold (3 > 0)"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer.exhausted","reason":"peer reviewer budget exhausted: arch-hazards-maintenance, behavior-intent-coverage, ergo-friction-hazards"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer.exhausted","reason":"peer reviewer budget exhausted: arch-hazards-maintenance, behavior-intent-coverage, ergo-friction-hazards"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer","reason":"blockers exceed threshold (2 > 0)"}
+{"stone":"5.1.execution.from_vision","status":"passed"}
+{"stone":"5.1.execution.from_vision","status":"passed"}
+{"stone":"5.1.execution.from_vision","status":"passed"}
+{"stone":"5.3.verification","status":"blocked","blocker":"review.self","reason":"review.self required: has-behavior-coverage"}
+{"stone":"5.3.verification","status":"blocked"}
+{"stone":"5.3.verification","status":"blocked"}

--- a/.behavior/v2026_07_05.fix-stone-set-foreground/0.wish.md
+++ b/.behavior/v2026_07_05.fix-stone-set-foreground/0.wish.md
@@ -1,0 +1,8 @@
+wish =
+
+yo. we gotta make it so that route.stone.set is only ever called in foreground
+
+reject any attempts to run it in background just like rhachet-roles-ehmpathy did with i think git.repo.test (you can git.repo.get that) . maybe it was rhx git.release that had that stop hook. or both. either way, track it down to use as a reference
+
+we can use a stop hook to detect and block em
+

--- a/.behavior/v2026_07_05.fix-stone-set-foreground/1.vision.guard
+++ b/.behavior/v2026_07_05.fix-stone-set-foreground/1.vision.guard
@@ -1,0 +1,89 @@
+# guard for vision stone
+#
+# requires human approval before stone can be marked as passed
+# because the self-review prompts require human feedback,
+# the process needs to halt here for human review
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism approved? --stone $stone --route $route
+
+reviews:
+  self:
+    - slug: has-grounded-in-reality
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        did the junior ground the vision in reality, or make things up?
+
+        check the groundwork section:
+
+        for external references (APIs, services, docs):
+        - did they actually verify these exist?
+        - did they cite what they checked?
+        - or did they assume without sanity check?
+
+        for internal references (extant behavior, patterns, code):
+        - did they actually verify what that behavior is?
+        - did they verify extant contracts to conform to? (interfaces, types, signatures)
+        - did they verify extant vocab to reuse? (domain terms, name patterns)
+        - did they verify extant stdouts to match? (CLI output patterns, error formats)
+        - did they cite specific files/lines?
+        - or did they assume the code works a certain way without verification?
+
+        this is NOT about exhaustive research — just sanity checks.
+        the question is: is this vision coherent with reality, or built on assumptions?
+
+    - slug: has-questioned-requirements
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any requirements that should be questioned?
+
+        for each requirement, ask:
+        - who said this was needed? when? why?
+        - what evidence supports this requirement?
+        - what if we didn't do this — what would happen?
+        - is the scope too large, too small, or misdirected?
+        - could we achieve the goal in a simpler way?
+
+        challenge each requirement and justify why it belongs.
+
+    - slug: has-questioned-assumptions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any hidden assumptions the junior took as requirements?
+
+        for each assumption, ask:
+        - what do we assume here without evidence?
+        - what evidence supports this assumption?
+        - what if the opposite were true?
+        - did the wisher actually say this, or did we infer it?
+        - what exceptions or counterexamples exist?
+
+        surface all hidden assumptions and question each one.
+
+    - slug: has-questioned-questions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any open questions? triage them:
+
+        for each question, ask:
+        - can this be answered via logic now? if so, answer it now.
+        - can this be answered via extant docs or code now? if so, answer it now.
+        - should this be answered via external research later? if so, mark it for research.
+        - does only the wisher know the answer? if so, ask the wisher.
+
+        for each question, ensure it is clearly marked as either:
+        - [answered] — resolved now
+        - [research] — to be answered in the research phase
+        - [wisher] — requires wisher input
+
+        ensure they're enumerated within the vision under "open questions & assumptions"
+
+  peer: []

--- a/.behavior/v2026_07_05.fix-stone-set-foreground/1.vision.stone
+++ b/.behavior/v2026_07_05.fix-stone-set-foreground/1.vision.stone
@@ -1,0 +1,70 @@
+illustrate the vision implied in the wish .behavior/v2026_07_05.fix-stone-set-foreground/0.wish.md
+
+emit into .behavior/v2026_07_05.fix-stone-set-foreground/1.vision.yield.md
+
+---
+
+paint a picture of what the world looks like when this wish is fulfilled
+
+testdrive the contract we propose via realworld examples
+
+specifically,
+
+## the outcome world
+
+- what does a day-in-the-life look like with this in place?
+- what's the before/after contrast?
+- what's the "aha" moment where the value clicks?
+
+## user experience
+
+- what usecases do folks fulfill? what goals?
+- what contract inputs & outputs do they leverage?
+- what would it look like to leverage them?
+- what timelines do they go through?
+
+## mental model
+
+- how would users describe this to a friend?
+- what analogies or metaphors fit?
+- what terms would they use vs what terms would we use?
+
+## evaluation
+
+- how well does it solve the goals?
+- what are the pros? the cons?
+- what edgecases exist and how do our contracts keep users in a pit of success?
+
+## open questions & assumptions
+
+- what assumptions have we made?
+- what questions remain unanswered?
+- what must we validate with the wisher before we proceed?
+- what must we research externally?
+
+## groundwork
+
+sanity check the vision against reality. NOT exhaustive research — just enough to know the vision isn't built on false assumptions.
+
+### external research
+
+if the wish references external APIs, services, or docs:
+- did you verify they exist and work the way you assume?
+- cite what you checked (links, key constraints noted)
+- if none referenced, say "none — no external dependencies"
+
+### internal research
+
+if the wish references extant behavior, patterns, or code:
+- did you verify what that behavior actually is?
+- contracts: interfaces, types, signatures to conform to
+- vocab: domain terms, name patterns to reuse
+- stdouts: CLI output patterns, error formats to match
+- cite what you checked (file paths, line numbers)
+- if none referenced, say "none — no extant behavior extended"
+
+## what is awkward?
+
+- what feels off or forced?
+- where does the design fight the user's mental model?
+- what tradeoffs feel uncomfortable?

--- a/.behavior/v2026_07_05.fix-stone-set-foreground/1.vision.yield.md
+++ b/.behavior/v2026_07_05.fix-stone-set-foreground/1.vision.yield.md
@@ -1,0 +1,153 @@
+# 1.vision — route.stone.set is foreground-only
+
+## the wish, restated
+
+route.stone.set must only ever run in the foreground. any attempt to run it in the background is rejected, with clear guidance to re-run in foreground. this mirrors what rhachet-roles-ehmpathy does for git.repo.test.
+
+---
+
+## the outcome world
+
+### day-in-the-life
+
+a driver walks a route. they reach a stone, do the work, and mark passage:
+
+```
+rhx route.stone.set --stone 1.vision --route .behavior/... --as arrived
+```
+
+the guard fires. curated stdout streams back: self-review prompts, blockers, next steps. the driver reads it and responds — the live loop the route depends on.
+
+with the fix in place, if the driver (or a clone) ever reaches for a background call — `Bash(command: 'rhx route.stone.set ...', run_in_background: true)` — a pretooluse hook halts it before it runs, prints a short reason, and points to the foreground form. the driver corrects course and never loses the guard's voice.
+
+### before / after
+
+|                  | before                                                     | after                              |
+| ---------------- | ---------------------------------------------------------- | ---------------------------------- |
+| background call  | allowed; guard output lands in a file the driver must poll | rejected before it runs            |
+| guard loop       | broken — driver polls a file, misses the live prompts      | intact — driver reads stdout live  |
+| token cost       | high — poll loops re-read large output                     | low — one curated stream           |
+| failure mode     | silent drift; driver acts on stale or partial output       | loud, immediate, self-corrective   |
+
+### the aha moment
+
+the value clicks the first time a clone tries to background a `--as arrived` and gets an instant, friendly block instead of a half-broken review loop. "oh — this tool talks back, and i must be here to listen."
+
+---
+
+## user experience
+
+- **usecase**: a driver marks stone passage (`--as passed`) or requests review (`--as arrived`) and must consume the guard's response.
+- **goal**: keep the driver in the live guard loop; never let output escape into a poll-a-file pattern.
+- **contract inputs**: unchanged — `--stone`, `--route`, `--as`. the new behavior is a guardrail on *how* the call is invoked (foreground vs background), not on the skill's own args.
+- **leverage**: the driver keeps the same route.stone.set calls as before. the only change is that a background attempt is refused.
+- **timeline**: attempt background → hook reads `tool_input.run_in_background` + `command` → match on route.stone.set → exit 2 with guidance → driver re-runs foreground → guard flows normally.
+
+---
+
+## mental model
+
+- **to a friend**: "the tool won't let you fire-and-forget it. it needs you in the room, because it answers you."
+- **analogy**: a phone call, not a voicemail. you can't leave route.stone.set a message and walk away; you stay on the line for its reply.
+- **their terms vs ours**: users say "run it in the background"; we say `run_in_background: true` on the Bash tool. users say "it blocked me"; we say "pretooluse hook, exit 2".
+
+---
+
+## evaluation
+
+### how well it solves the goal
+
+directly. the guard's stdout is the product; foreground is the only mode where the driver consumes it live. block background → the loop stays intact by construction.
+
+### pros
+
+- proven pattern (ehmpathy git.repo.test) — low risk, known shape
+- one small hook plus one settings wire; no change to route.stone.set itself
+- fast: a simple json check, ~5s timeout
+- friendly failure with copy-paste correction
+
+### cons
+
+- one more pretooluse hook in the chain (marginal latency)
+- guards only the Bash-tool background flag; a truly detached shell (`&`, nohup) would slip past — but that is not how clones background their work
+- couples to Claude Code's `run_in_background` json shape
+
+### why a hook is necessary — not just chosen
+
+the two simpler alternatives cannot even express the condition:
+
+- **in-process refusal** (route.stone.set detects it is backgrounded) — impossible; the node child process cannot see the harness's `run_in_background` flag. the skill is a thin wrapper to `cli/route`, so there is no vantage point for it.
+- **a permission deny rule** in `.claude/settings.json` — impossible; permission rules match on the command *string*, not on `tool_input.run_in_background`. they cannot say "deny only when backgrounded".
+
+a PreToolUse hook is the one layer that sees both the command and the background flag before the call runs. so the hook is not merely the proven choice — it is the minimal mechanism that can do the job at all.
+
+### edgecases & pit of success
+
+- three invocation forms must all match: `rhx route.stone.set`, `npx rhachet run --skill route.stone.set`, `./node_modules/.bin/rhx route.stone.set` (ehmpathy handles the parallel set for git.repo.test)
+- foreground calls: untouched
+- other skills in background: untouched (the match must target route.stone.set specifically)
+- a background call that also pipes or chains: still caught by the command regex
+- **key acceptance check (two layers)**: the foundational assumption is that a background route.stone.set call is blocked. prove it at two layers, because one alone lies:
+  - **(a) isolated unit test** — feed the hook a synthetic stdin payload `{"tool_name":"Bash","tool_input":{"run_in_background":true,"command":"rhx route.stone.set ..."}}` and assert exit 2 + stderr guidance. mirror ehmpathy's `pretooluse.forbid-test-background.integration.test.ts`. deterministic, fast. **but** it only tests the hook's own logic — it does NOT prove the harness fires the hook for background calls.
+  - **(b) live smoke check** — in a real session, genuinely attempt a background route.stone.set and confirm the harness invokes the hook and the call is blocked. this closes the gap the unit test cannot: that PreToolUse actually fires for `run_in_background: true`.
+
+---
+
+## open questions & assumptions
+
+each item is tagged: **[wisher]** = only the wisher can decide (blocks execution); **[answered]** = settled now by logic, docs, or code; **[research]** = deferred to the research phase.
+
+### the one blocker
+
+**[wisher] — pretooluse vs stop hook.** the wish proposes a **stop hook**; i recommend a **pretooluse hook**. verified: a stop hook fires *after* the turn and cannot veto a single tool call, so the literal interpretation is technically unworkable for a pre-block. i assume the wisher wants the *effect* (foreground-only) and that "stop hook" was a first guess at mechanism. **this must be confirmed before execution** — it is the sole open decision.
+
+### settled — no action beyond execution
+
+- **[answered] PreToolUse fires for background calls** — docs + ehmpathy's live hook confirm it; a live smoke check in verification closes the last gap.
+- **[answered] hook home — follow bhrain's extant pattern, NOT ehmpathy's.** bhrain implements PreToolUse hooks as *driver skills* invoked with `--mode hook`, housed in `src/domain.roles/driver/skills/` — see the extant `route.mutate.guard.sh` (a bash hook that reads stdin json and already inspects Bash `tool_input.command`, exit 2) and `route.bounce.sh` (thin bash → `RHACHET_STDIN` → `cli/route`). the new foreground guard mirrors `route.mutate.guard`: a driver skill in `src/domain.roles/driver/skills/`, name TBD at execution (e.g. a `route.stone.set` foreground guard). it is *not* an ehmpathy-style `inits/claude.hooks/*.sh` invoked via `rhachet run --init`.
+- **[answered] where it plugs in** — the current `PreToolUse / matcher: "Bash"` block in `.claude/settings.json`, wired as `rhx <skill> --mode hook` (exactly how `route.mutate.guard --mode hook` and `route.bounce --mode hook` are already wired), author `repo=bhrain/role=driver`.
+- **[answered] block signal** — exit 2 with stderr guidance and owl 🦉 vibes; reuse bhrain's block-output convention (a companion `.output.sh` like `route.mutate.guard.output.sh`), not ehmpathy's inline 🛑 block.
+- **[answered] could it fold into route.mutate.guard?** — that hook already parses Bash `tool_input` on the bound route. a separate small guard is cleaner (single responsibility: invocation-mode vs path-protection), but it reuses the same stdin-parse + block-output infra. decide at execution.
+- **[answered] scope** — block all `--as` forms, only route.stone.set. no `--as` variant has a legitimate background use (proven per-variant); do not generalize to other driver skills (wet-over-dry).
+
+### [research]
+
+none. the only external contract (Claude Code hooks) is already verified against the official docs. no external unknown remains.
+
+### standing assumptions
+
+- route.stone.set's contract stays unchanged; we add an invocation guardrail only
+- "foreground-only" is a proxy for the true goal — the driver consumes guard output live. it holds because Claude Code background output is poll-only (not streamed) today; if that ever changed, the justification would need a fresh look
+- the reason for foreground: token cost (shared with git.repo.test's stated rationale) plus guard interaction (specific to route.stone.set — its `--as` calls drive an interactive self-review loop the driver must consume live, as observed directly in this very stone)
+
+---
+
+## groundwork
+
+### external research
+
+one external contract: Claude Code's hook system. i verified its semantics against the official docs (https://code.claude.com/docs/en/hooks.md):
+
+- a **PreToolUse** hook receives `tool_input` (incl. `run_in_background`) on stdin *before* the tool runs; exit code 2 blocks the tool call. this is exactly the mechanism we need.
+- a **Stop** hook fires *after* the turn completes; its exit 2 forces the agent to continue and cannot veto an individual tool call. a background call made during the turn is already launched by the time Stop fires.
+
+this confirms PreToolUse — not Stop — is the correct mechanism (see open questions). no other external service dependencies. the `run_in_background` json shape is also cross-checked against ehmpathy's live hook (below).
+
+### internal research
+
+- **bhrain precedent (the primary template)** — bhrain already ships PreToolUse hooks as *driver skills* run with `--mode hook`:
+  - `src/domain.roles/driver/skills/route.mutate.guard.sh` — a bash hook: reads stdin json, checks `tool_name` (Read/Write/Edit/Bash), inspects `tool_input.file_path` and `tool_input.command`, finds the bound route, exits 2 with a block message via the companion `route.mutate.guard.output.sh`. covered by `route.mutate.guard.integration.test.ts`. **this is the shape to mirror.**
+  - `src/domain.roles/driver/skills/route.bounce.sh` — thin bash captures stdin into `RHACHET_STDIN` then execs `node cli/route → routeBounce()`; hook logic in TypeScript. an alternate shape if we want the logic in TS.
+- **ehmpathy cross-reference (for the check logic only)** — `rhachet-roles-ehmpathy/.../pretooluse.forbid-test-background.sh` (lines 41–104) solves the identical background-block for git.repo.test: `tool_name == "Bash"` + `run_in_background == true` + command match → exit 2. borrow its `run_in_background` check; do NOT borrow its `inits/claude.hooks/` layout.
+- **route.stone.set contract** — `src/domain.roles/driver/skills/route.stone.set.sh`: `--stone`, `--route`, `--as arrived|passed|approved|blocked`. this is the driver skill we guard.
+- **current settings** — `.claude/settings.json`: the `PreToolUse / matcher: "Bash"` block (lines 93–128) already wires bhrain driver hooks — `route.mutate.guard --mode hook` (Read|Write|Edit|Bash matcher, lines 186–194) and `route.bounce --mode hook` (Write|Edit). the new guard wires here as `rhx <skill> --mode hook`, author `repo=bhrain/role=driver`.
+- **hook invocation form** — bhrain uses `./node_modules/.bin/rhx <skill> --mode hook`, NOT ehmpathy's `rhachet run --init claude.hooks/<name>`.
+- **stdout convention** — reuse bhrain's companion `.output.sh` block-message pattern (see `route.mutate.guard.output.sh`) with owl 🦉 vibes; the exact copy is an execution-phase detail.
+
+---
+
+## what is awkward?
+
+- the wish names a **stop hook**; the right tool is a **pretooluse hook**. to follow the letter of the wish would build a weaker guard. i lean to the proven mechanism and flag the divergence — this is the one spot where the design fights the wish's words.
+- ehmpathy's hook sits under the **mechanic** role as an `inits/claude.hooks/*.sh`; bhrain instead ships PreToolUse hooks as **driver skills** run with `--mode hook` (route.mutate.guard, route.bounce). ours follows bhrain's pattern — a driver skill, not an ehmpathy-style init. i initially anchored on ehmpathy's layout and had to correct course once the wisher pointed to bhrain's own precedent.
+- the hook only sees the Bash tool's background flag. a truly detached invocation via raw shell `&` is beyond its reach. acceptable, since that is not how clones background their work, but worth to name plainly.

--- a/.behavior/v2026_07_05.fix-stone-set-foreground/5.1.execution.from_vision.guard
+++ b/.behavior/v2026_07_05.fix-stone-set-foreground/5.1.execution.from_vision.guard
@@ -1,0 +1,218 @@
+# guard for execution stone (from vision - nano size)
+# includes standardized self-review frame
+
+artifacts:
+  # track execution progress
+  - "$route/5.1.execution.from_vision.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    # 1. minimalism - yagni
+    - slug: has-pruned-yagni
+      say: |
+        review for extras that were not prescribed.
+
+        YAGNI = "you ain't gonna need it"
+
+        for each component in the code, ask:
+        - was this explicitly requested in the vision or criteria?
+        - is this the minimum viable way to satisfy the requirement?
+        - did we add abstraction "for future flexibility"?
+        - did we add features "while we're here"?
+        - did we optimize before we knew it was needed?
+
+        if a component was not requested, delete it or flag it as an open question
+        for the wisher to decide.
+
+    # 2. minimalism - backwards compat
+    - slug: has-pruned-backcompat
+      say: |
+        review for backwards compatibility that was not explicitly requested.
+
+        for each backwards-compat concern in the code, ask:
+        - did the wisher explicitly say to maintain this compatibility?
+        - is there evidence this backwards compat is needed?
+        - or did we assume it "to be safe"?
+
+        if backwards compat was not explicitly requested:
+        1. flag it as an open question for the wisher
+        2. eliminate it if not confirmed as required
+        3. make the open question very clearly reported
+
+    # 3. consistency - mechanisms
+    - slug: has-consistent-mechanisms
+      say: |
+        review for new mechanisms that duplicate extant functionality.
+
+        unless the ask was to refactor, be consistent with extant mechanisms.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). look for extant utilities and patterns.
+
+        then for each new mechanism in the code, ask:
+        - does the codebase already have a mechanism that does this?
+        - do we duplicate extant utilities or patterns?
+        - could we reuse an extant component instead of a new one?
+
+        if a new mechanism duplicates extant functionality:
+        1. replace with the extant mechanism
+        2. or flag as an open question if unsure
+
+    # 4. consistency - conventions
+    - slug: has-consistent-conventions
+      say: |
+        review for divergence from extant names and patterns.
+
+        unless the ask was to refactor, be consistent with extant conventions.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). identify extant name conventions and patterns.
+
+        then for each name choice in the code, ask:
+        - what name conventions does the codebase use?
+        - do we use a different namespace, prefix, or suffix pattern?
+        - do we introduce new terms when extant terms exist?
+        - does our structure match extant patterns?
+
+        if we diverge from extant conventions:
+        1. align with the extant convention
+        2. or flag as an open question if the extant convention seems wrong
+
+    # 5. review against behavior declaration - coverage
+    - slug: behavior-declaration-coverage
+      say: |
+        review for coverage of the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have omitted
+        requirements or left features unimplemented.
+
+        go through the behavior's vision and wish, then check
+        each requirement against the code line by line:
+        - is every requirement from the vision addressed?
+        - did the junior skip or forget any part of the spec?
+
+        fix all gaps before you continue.
+
+    # 6. review against behavior declaration - adherance
+    - slug: behavior-declaration-adherance
+      say: |
+        review for adherance to the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have drifted
+        from the spec or implemented items incorrectly.
+
+        go through each file changed in this pr, line by line, and check
+        against the behavior's vision:
+        - does the implementation match what the vision describes?
+        - did the junior misinterpret or deviate from the spec?
+
+        fix all gaps before you continue.
+
+    # 7. review against role standards - adherance
+    - slug: role-standards-adherance
+      say: |
+        review for adherance to mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have introduced
+        bad practices or violated patterns that we require.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - does the code follow mechanic standards correctly?
+        - are there violations of required patterns?
+        - did the junior introduce anti-patterns, bad practices, or deviations from our conventions?
+
+        fix all gaps before you continue.
+
+    # 8. review against role standards - coverage
+    - slug: role-standards-coverage
+      say: |
+        review for coverage of mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have forgotten
+        best practices or omitted patterns that should be present.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - are all relevant mechanic standards applied?
+        - are there patterns that should be present but are absent?
+        - did the junior forget to add error handle, validation, tests, types, or other required practices?
+
+        fix all gaps before you continue.
+
+  peer:
+    # --- level 1: cheap reviewers (run first, in parallel) ---
+
+    - slug: repo-rules
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-failhides
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-decode-friction
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.{forbid.decode-friction-in-orchestrators,require.orchestrators-as-narrative}.md' --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transforms}.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/{define.domain-operation-grains,philosophy.transform-orchestrator-separation.[philosophy]}.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-without '**/*.test.ts' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    # --- architect reviews (level 1) ---
+
+    - slug: arch-opport-decomposition
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: arch-smell-scopeleaks
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: arch-hazards-maintenance
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.require.solve-at-cause.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.typedefs/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.comments/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: arch-hazards-behavior
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: behavior-intent-coverage
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md' --refs '$route/0.wish.md' --refs '$route/1.vision.yield.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.criteria/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    - slug: ergo-friction-hazards
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 5
+      level: 1
+
+    # --- level 3: expensive reviewers (run after level 1 is terminal) ---
+
+    - slug: enroll-impl-behavior-intent
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current implementation for omissions or divergences from the wished and envisioned behavioral intent. in particular flag any ergonomic friction that is unaddressed or friction hazards that are not clearly covered with acceptance tests and snaps'
+      budget: 3
+      level: 3
+
+    - slug: enroll-impl-arch-defects
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current implementation for architectural defects and omissions; opports to decompose for recompose, prevent scope leaks, and eliminate maintenance and behavior hazards structurally'
+      budget: 3
+      level: 3
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3

--- a/.behavior/v2026_07_05.fix-stone-set-foreground/5.1.execution.from_vision.stamp
+++ b/.behavior/v2026_07_05.fix-stone-set-foreground/5.1.execution.from_vision.stamp
@@ -1,0 +1,73 @@
+🦉 the way speaks for itself
+
+🗿 route.stone.set
+   ├─ stone = 5.1.execution.from_vision
+   ├─ passage = allowed
+   ├─ guard
+   │  ├─ artifacts
+   │  │   ├─ $route/5.1.execution.from_vision.yield.md
+   │  │   └─ src/**/*
+   │  ├─ reviews
+   │  │   ├─ r1: repo-rules (l1, 3/3)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   └─ review: .behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/5.1.execution.from_vision._.review.i3.9f87d4fe39d37853b8.r1._.given.by_peer.repo-rules.md
+   │  │   ├─ r2: mech-failhides (l1, 3/3)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   └─ review: .behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/5.1.execution.from_vision._.review.i3.9f87d4fe39d37853b8.r2._.given.by_peer.mech-failhides.md
+   │  │   ├─ r3: mech-decode-friction (l1, 3/3)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   └─ review: .behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/5.1.execution.from_vision._.review.i3.9f87d4fe39d37853b8.r3._.given.by_peer.mech-decode-friction.md
+   │  │   ├─ r4: arch-opport-decomposition (l1, 3/3)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   └─ review: .behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/5.1.execution.from_vision._.review.i3.9f87d4fe39d37853b8.r4._.given.by_peer.arch-opport-decomposition.md
+   │  │   ├─ r5: arch-smell-scopeleaks (l1, 3/3)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   └─ review: .behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/5.1.execution.from_vision._.review.i3.9f87d4fe39d37853b8.r5._.given.by_peer.arch-smell-scopeleaks.md
+   │  │   ├─ r6: arch-hazards-maintenance (l1, 5/5)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   └─ review: .behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/5.1.execution.from_vision._.review.i6.54ffda7a47093c114e.r6._.given.by_peer.arch-hazards-maintenance.md
+   │  │   ├─ r7: arch-hazards-behavior (l1, 3/3)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   └─ review: .behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/5.1.execution.from_vision._.review.i3.9f87d4fe39d37853b8.r7._.given.by_peer.arch-hazards-behavior.md
+   │  │   ├─ r8: behavior-intent-coverage (l1, 5/5)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   └─ review: .behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/5.1.execution.from_vision._.review.i6.54ffda7a47093c114e.r8._.given.by_peer.behavior-intent-coverage.md
+   │  │   ├─ r9: ergo-friction-hazards (l1, 5/5)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   └─ review: .behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/5.1.execution.from_vision._.review.i6.54ffda7a47093c114e.r9._.given.by_peer.ergo-friction-hazards.md
+   │  │   ├─ r10: enroll-impl-behavior-intent (l3, 2/3)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   └─ review: .behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/5.1.execution.from_vision._.review.i6.54ffda7a47093c114e.r10._.given.by_peer.enroll-impl-behavior-intent.md
+   │  │   └─ r11: enroll-impl-arch-defects (l3, 2/3)
+   │  │       ├─ approved, cached
+   │  │       ├─ 0 blockers ✓
+   │  │       ├─ 0 nitpicks ✓
+   │  │       └─ review: .behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/5.1.execution.from_vision._.review.i6.54ffda7a47093c114e.r11._.given.by_peer.enroll-impl-arch-defects.md
+   │  └─ judges
+   │      └─ j1: $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3
+   │          └─ · cached
+   │             ├─ on $route/5.1.execution.from_vision.yield.md
+   │             └─ on src/**/*
+   │
+   └─ the way continues, run
+      └─ rhx route.drive

--- a/.behavior/v2026_07_05.fix-stone-set-foreground/5.1.execution.from_vision.stone
+++ b/.behavior/v2026_07_05.fix-stone-set-foreground/5.1.execution.from_vision.stone
@@ -1,0 +1,15 @@
+bootup your mechanic's role via `./node_modules/.bin/rhachet roles boot --repo ehmpathy --role mechanic`
+
+then, execute the vision directly
+- .behavior/v2026_07_05.fix-stone-set-foreground/1.vision.md
+
+ref:
+- .behavior/v2026_07_05.fix-stone-set-foreground/0.wish.md
+
+
+---
+
+track your progress
+
+emit todos and check them off into
+- .behavior/v2026_07_05.fix-stone-set-foreground/5.1.execution.from_vision.yield.md

--- a/.behavior/v2026_07_05.fix-stone-set-foreground/5.1.execution.from_vision.yield.md
+++ b/.behavior/v2026_07_05.fix-stone-set-foreground/5.1.execution.from_vision.yield.md
@@ -1,0 +1,57 @@
+# 5.1 execution — from vision
+
+## what we build
+
+a bhrain driver PreToolUse hook that blocks `route.stone.set` when invoked in background (`run_in_background: true`). it mirrors `route.mutate.guard`'s shape. name: `route.foreground.guard` (concern-based, like `route.mutate.guard`).
+
+## todos
+
+- [x] study bhrain precedent (route.mutate.guard.sh, route.bounce.sh, getDriverRole.ts, integration test)
+- [x] create `src/domain.roles/driver/skills/route.foreground.guard.sh` — the hook (stdin json → Bash + run_in_background + route.stone.set match → exit 2)
+- [x] create `src/domain.roles/driver/skills/route.foreground.guard.output.sh` — owl block message
+- [x] create `src/domain.roles/driver/skills/route.foreground.guard.integration.test.ts` — 37 tests, block + allow + edge paths, snapshot every step
+- [x] wire the hook into `src/domain.roles/driver/getDriverRole.ts` (onTool, what=Bash, when=before)
+- [x] set execute bits on the two `.sh` files (skill files must be executable)
+- [x] build + `rhachet init --hooks` — synced into `.agent/` and `.claude/settings.json` (line 129)
+- [x] verify unit: integration test — 37/37 pass; snapshots spotchecked
+- [x] verify quality: types ✓, lint ✓, format ✓
+- [x] verify LIVE: attempted a real backgrounded `route.stone.set` in this session — the harness fired the hook and blocked it (exit 2, owl guidance). the foundational assumption is proven end-to-end, not just in isolation.
+
+## acceptance — layer (b) live smoke check (evidence)
+
+the vision requires a two-layer acceptance check. layer (a) is the 37-case integration test (`route.foreground.guard.integration.test.ts`). layer (b) is a live smoke check that cannot run in jest (no Claude Code harness there) — it is recorded here as durable evidence.
+
+**procedure**: in a real Claude Code session with the hook active, a `route.stone.set` was genuinely invoked with `run_in_background: true` (the actual Bash tool, not a synthetic payload).
+
+**result**: the harness fired the PreToolUse hook and blocked the call before it ran. captured stderr:
+
+```
+PreToolUse:Bash hook error: [./node_modules/.bin/rhx route.foreground.guard --mode hook]:
+🪨 run solid skill repo=bhrain/role=driver/skill=route.foreground.guard
+   └─ ✋ blocked by constraints
+
+🦉 some paths are walked in the open, not in shadow. be present.
+
+🗿 route.foreground guard
+   ├─ skill = route.stone.set
+   ├─ mode = background
+   ├─ access = blocked
+   │
+   ├─ route.stone.set speaks back — self-reviews, blockers, the way ahead
+   ├─ in background its voice is lost to a poll, and tokens are wasted
+   │
+   └─ instead, run it in the foreground
+      └─ remove run_in_background from your Bash call
+```
+
+**what this proves that layer (a) cannot**: the harness actually fires PreToolUse for a `run_in_background: true` Bash call, and honors exit 2 to block it. layer (a) proves the hook's decision logic; layer (b) proves the harness invokes the hook at all. both are required; both pass.
+
+## outcome
+
+done. the hook is active, tested at both layers — (a) 37-case isolated integration test, (b) documented live-harness smoke check above — and follows bhrain's extant driver-hook pattern. a background `route.stone.set` is now blocked with clear guidance to run in the foreground; foreground calls are untouched.
+
+## design notes
+
+- **unconditional**: unlike route.mutate.guard (route-bound), this blocks background route.stone.set always — no bound-route check. the wish is absolute.
+- **three invocation forms** matched: `rhx route.stone.set`, `npx rhachet run --skill route.stone.set`, `.bin/rhx route.stone.set`.
+- **block signal**: exit 2 + owl stderr message via companion `.output.sh`.

--- a/.behavior/v2026_07_05.fix-stone-set-foreground/5.3.verification.guard
+++ b/.behavior/v2026_07_05.fix-stone-set-foreground/5.3.verification.guard
@@ -1,0 +1,291 @@
+artifacts:
+  # track verification progress
+  - "$route/5.3.verification.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    - slug: has-behavior-coverage
+      say: |
+        double-check: does the verification checklist show every behavior from wish/vision has a test?
+
+        - is every behavior in 0.wish.md covered?
+        - is every behavior in 1.vision.md covered?
+        - can you point to each test file in the checklist?
+
+        **if any behavior lacks a test, write the test NOW.** do not pass this gate with gaps.
+
+    - slug: has-zero-test-skips
+      say: |
+        double-check: did you verify zero skips — and REMOVE any you found?
+
+        - no .skip() or .only() found?
+        - no silent credential bypasses?
+        - no prior failures carried forward?
+
+        **if you found skips, did you remove them and make those tests pass?**
+
+        this is buttonup. skips are gaps. gaps get fixed, not noted.
+
+    - slug: has-all-tests-passed
+      say: |
+        double-check: did all tests pass? prove it.
+
+        **zero unproven claims.** you must cite the exact command and output.
+
+        for each test suite:
+        - what command did you run?
+        - what was the exit code?
+        - how many tests passed?
+
+        example proof:
+        ```
+        $ npm run test:unit
+        > exit 0
+        > 47 tests passed
+        ```
+
+        if you cannot cite the command and output, you did not prove it.
+
+        zero tolerance for extant failures:
+        - "it was already broken" is not an excuse — fix it
+        - "it's unrelated to my changes" is not an excuse — fix it
+        - flaky tests must be stabilized, not tolerated
+        - every failure is your responsibility now
+
+        zero tolerance for fake tests:
+        - tests that always pass are fraud
+        - tests that mock the system under test prove nothingness
+        - tests must verify real behavior
+
+        zero tolerance for credential excuses:
+        - "i don't have creds" means get them or mock them
+        - silent bypasses are forbidden
+        - if creds block tests, that is a BLOCKER — not a deferral
+
+    - slug: has-preserved-test-intentions
+      say: |
+        double-check: did you preserve test intentions?
+
+        for every test you touched:
+        - what did this test verify before?
+        - does it still verify the same behavior after?
+        - did you change what the test asserts, or fix why it failed?
+
+        forbidden:
+        - weaken assertions to make tests pass
+        - remove test cases that "no longer apply"
+        - change expected values to match broken output
+        - delete tests that fail instead of fix code
+
+        the test knew a truth. if it failed, either:
+        - the code is wrong — fix the code
+        - the test has a bug — fix the bug, keep the intention
+        - requirements changed — document why, get approval
+
+        to "fix tests" via changed intent is not a fix — it is at worst
+        malicious deception, at best reckless negligence. unacceptable.
+
+    - slug: has-journey-tests-from-repros
+      say: |
+        double-check: did you implement each journey sketched in repros?
+
+        look back at the repros artifact:
+        - .behavior/v2026_07_05.fix-stone-set-foreground/3.2.distill.repros.experience.*.md
+
+        for each journey test sketch in repros:
+        - is there a test file for it?
+        - does the test follow the BDD given/when/then structure?
+        - does each `when([tN])` step exist?
+
+        **if any journey was planned but not implemented, go back and add it NOW.**
+
+        this is buttonup. absent journey tests = incomplete implementation.
+        test coverage proves prod coverage. no test = no proof = not done.
+
+    - slug: has-contract-output-variants-snapped
+      say: |
+        double-check: does each public contract have EXHAUSTIVE snapshots?
+
+        **zero gaps in caller experience.** every contract must snap every output variant.
+
+        for each new or modified public contract:
+
+        | contract type | what to snap | required variants |
+        |---------------|--------------|-------------------|
+        | cli command | stdout + stderr | success, error, --help, edge cases |
+        | api endpoint | response body | 2xx, 4xx, 5xx, edge cases |
+        | sdk method | return value | success, error, edge cases |
+
+        checklist per contract:
+        - [ ] positive path (success) is snapped
+        - [ ] negative path (error) is snapped
+        - [ ] help/usage is snapped (for cli)
+        - [ ] edge cases are snapped (empty, invalid, boundary)
+        - [ ] snapshot shows actual output, not placeholder
+
+        why this matters:
+        - snapshots enable vibecheck in prs — reviewers see actual output without execute
+        - snapshots detect drift over time — output changes surface in diffs
+        - absent variants mean blind spots in review
+        - exhaustive coverage proves the contract works for all callers
+
+        **zero leniency.** if a contract lacks any variant, add the test case NOW.
+
+        if you find yourself about to say "this variant isn't worth a snapshot" — stop.
+        that is the variant that will break in prod. snap it.
+
+        this is buttonup. absent snapshots = absent proof. add them or fail this gate.
+
+    - slug: has-snap-changes-rationalized
+      say: |
+        double-check: is every `.snap` file change intentional and justified?
+
+        for each `.snap` file in git diff:
+        1. what changed? (added, modified, deleted)
+        2. was this change intended or accidental?
+        3. if intended: what is the rationale?
+        4. if accidental: revert it or explain why the new output is an improvement
+
+        common regressions caught here:
+        - output format degraded (lost alignment, lost structure)
+        - error messages became less helpful
+        - timestamps or ids leaked into snapshots (flaky)
+        - extra output added unintentionally
+
+        forbidden:
+        - "updated snapshots" without per-file rationale
+        - bulk snapshot updates without review
+        - regressions accepted without justification
+
+        every snap change tells a story. make sure the story is intentional.
+
+    - slug: has-critical-paths-frictionless
+      say: |
+        double-check: are the critical paths frictionless in practice?
+
+        look back at the repros artifact for critical paths:
+        - .behavior/v2026_07_05.fix-stone-set-foreground/3.2.distill.repros.experience.*.md
+
+        for each critical path:
+        - run through it manually — is it smooth?
+        - are there unexpected errors?
+        - does it feel effortless to the user?
+
+        critical paths must "just work." if there's friction, fix it now.
+
+    - slug: has-ergonomics-validated
+      say: |
+        double-check: does the actual input/output match what felt right at repros?
+
+        compare the implemented input/output to what was sketched in repros:
+        - does the actual input match the planned input?
+        - does the actual output match the planned output?
+        - did the design change between repros and implementation?
+
+        if the ergonomics drifted, either:
+        - update repros to reflect the better design, or
+        - fix the implementation to match the planned ergonomics
+
+    - slug: has-play-test-convention
+      say: |
+        double-check: are journey test files named correctly?
+
+        journey tests should use `.play.test.ts` suffix:
+        - `feature.play.test.ts` — journey test
+        - `feature.play.integration.test.ts` — if repo requires integration runner
+        - `feature.play.acceptance.test.ts` — if repo requires acceptance runner
+
+        verify:
+        - are journey tests in the right location?
+        - do they have the `.play.` suffix?
+        - if not supported, is the fallback convention used?
+
+    - slug: has-fixed-all-gaps
+      say: |
+        final buttonup check: did you FIX every gap you found, or just detect it?
+
+        **this is the buttonup phase. detection is not enough — you must fix.**
+
+        look back at all the reviews above. for every gap you identified:
+        - absent test coverage → did you WRITE the test?
+        - absent prod coverage → did you IMPLEMENT the behavior?
+        - failed test → did you FIX the code or test?
+        - skipped test → did you REMOVE the skip and make it pass?
+
+        **zero omissions.** if any review above surfaced a gap, that gap must be fixed before you pass this gate.
+
+        ask yourself:
+        - did i just note the gap, or did i actually fix it?
+        - is there any item marked "todo" or "later"? (forbidden)
+        - is there any coverage marked incomplete? (forbidden)
+
+        **if you detected it, you fixed it.** prove it with citations.
+
+        this is the final self-review. you are about to hand off to peer review.
+        prove that all items above were addressed — not deferred.
+
+  peer:
+    # --- level 1: cheap reviewers (run first, in parallel) ---
+
+    - slug: repo-rules
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: ergo-contract-snapshots
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-external-contracts
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.external-contract-integration-tests.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.remote-boundaries.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: ergo-acceptance-journey-coverage
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.require.acceptance-journey-coverage.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: ergo-snapshot-visual-blemishes
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.forbid.snapshot-visual-blemishes.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-given-when-then
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/rule.require.given-when-then.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/criteria.given_when_then.[seed].v3.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/lessons.howto/*.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-test-intent
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.forbid.test-intent-violations.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/work.flow/refactor/rule.require.review-test-changes.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-test-scope-purity
+      run: $rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/rule.require.test-coverage-by-grain.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.unit.remote-boundaries.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.integration/rule.forbid.integration.mocks.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.acceptance/rule.forbid.acceptance.mocks.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.acceptance/rule.require.acceptance.blackbox.md' --diffs since-main --paths-with '{src,blackbox}/**/*.test.ts' --join intersect --output "$output" --mode hard
+      budget: 3
+      level: 1
+
+    # --- level 3: expensive reviewers (run after level 1 is terminal) ---
+
+    - slug: enroll-verif-snapshot-coverage
+      run: $rhx enroll claude --model sonnet --roles behaver,ergonomist,mechanic -p 'review the diff for snapshot coverage on contract endpoints and acceptance test user journey coverage'
+      budget: 3
+      level: 3
+
+    - slug: enroll-verif-snapshot-blemishes
+      run: $rhx enroll claude --model sonnet --roles behaver,ergonomist,mechanic -p 'review the diff for experiential and visual blemishes in snapshotted acceptance test journeys'
+      budget: 3
+      level: 3
+
+    - slug: enroll-verif-test-intent
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current implementation for test intent violation diffs. if any of the diffs related to tests loosened assertions or changed the criteria, this is a blocker. tests were added for a reason. we have to maintain the behavior they locked in'
+      budget: 3
+      level: 3
+
+judges:
+  # enforce peer reviews pass with zero blockers
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0

--- a/.behavior/v2026_07_05.fix-stone-set-foreground/5.3.verification.stamp
+++ b/.behavior/v2026_07_05.fix-stone-set-foreground/5.3.verification.stamp
@@ -1,0 +1,104 @@
+🦉 the way speaks for itself
+
+🗿 route.stone.set
+   ├─ stone = 5.3.verification
+   ├─ passage = blocked
+   ├─ reason = reviewer constraint
+   ├─ options
+   │  ├─ overrule the constraint
+   │  │  └─ rhx route.stone.set --stone 5.3.verification --as overruled
+   │  └─ or fix the reviewer, then retry
+   └─ guard
+      ├─ artifacts
+      │   ├─ $route/5.3.verification.yield.md
+      │   └─ src/**/*
+      ├─ reviews
+      │   ├─ r1: repo-rules (l1, 1/3)
+      │   │   ├─ approved 39.6s
+      │   │   ├─ 0 blockers ✓
+      │   │   ├─ 0 nitpicks ✓
+      │   │   └─ review: .behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/5.3.verification._.review.i1.75da87f3b99195ed40.r1._.given.by_peer.repo-rules.md
+      │   ├─ r2: ergo-contract-snapshots (l1, 1/3)
+      │   │   ├─ approved 32.7s
+      │   │   ├─ 0 blockers ✓
+      │   │   ├─ 0 nitpicks ✓
+      │   │   └─ review: .behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/5.3.verification._.review.i1.75da87f3b99195ed40.r2._.given.by_peer.ergo-contract-snapshots.md
+      │   ├─ r3: mech-external-contracts (l1, 1/3)
+      │   │   ├─ approved 23.2s
+      │   │   ├─ 0 blockers ✓
+      │   │   ├─ 0 nitpicks ✓
+      │   │   └─ review: .behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/5.3.verification._.review.i1.75da87f3b99195ed40.r3._.given.by_peer.mech-external-contracts.md
+      │   ├─ r4: ergo-acceptance-journey-coverage (l1, 1/3)
+      │   │   ├─ approved 28.4s
+      │   │   ├─ 0 blockers ✓
+      │   │   ├─ 0 nitpicks ✓
+      │   │   └─ review: .behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/5.3.verification._.review.i1.75da87f3b99195ed40.r4._.given.by_peer.ergo-acceptance-journey-coverage.md
+      │   ├─ r5: ergo-snapshot-visual-blemishes (l1, 1/3)
+      │   │   ├─ approved 23.2s
+      │   │   ├─ 0 blockers ✓
+      │   │   ├─ 0 nitpicks ✓
+      │   │   └─ review: .behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/5.3.verification._.review.i1.75da87f3b99195ed40.r5._.given.by_peer.ergo-snapshot-visual-blemishes.md
+      │   ├─ r6: mech-given-when-then (l1, 1/3)
+      │   │   ├─ approved 19.2s
+      │   │   ├─ 0 blockers ✓
+      │   │   ├─ 0 nitpicks ✓
+      │   │   └─ review: .behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/5.3.verification._.review.i1.75da87f3b99195ed40.r6._.given.by_peer.mech-given-when-then.md
+      │   ├─ r7: mech-test-intent (l1, 1/3)
+      │   │   ├─ approved 27.5s
+      │   │   ├─ 0 blockers ✓
+      │   │   ├─ 0 nitpicks ✓
+      │   │   └─ review: .behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/5.3.verification._.review.i1.75da87f3b99195ed40.r7._.given.by_peer.mech-test-intent.md
+      │   ├─ r8: mech-test-scope-purity (l1, 0/3)
+      │   │   ├─ constraint 10.5s
+      │   │   ├─ 0 blockers ✓
+      │   │   ├─ 0 nitpicks ✓
+      │   │   └─ review: .behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/5.3.verification._.review.i1.75da87f3b99195ed40.r8._.given.by_peer.mech-test-scope-purity.md
+      │   ├─ r9: enroll-verif-snapshot-coverage (l3, 1/3)
+      │   │   ├─ approved 130.4s
+      │   │   ├─ 0 blockers ✓
+      │   │   ├─ 0 nitpicks ✓
+      │   │   └─ review: .behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/5.3.verification._.review.i1.75da87f3b99195ed40.r9._.given.by_peer.enroll-verif-snapshot-coverage.md
+      │   ├─ r10: enroll-verif-snapshot-blemishes (l3, 1/3)
+      │   │   ├─ approved 154.4s
+      │   │   ├─ 0 blockers ✓
+      │   │   ├─ 0 nitpicks ✓
+      │   │   └─ review: .behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/5.3.verification._.review.i1.75da87f3b99195ed40.r10._.given.by_peer.enroll-verif-snapshot-blemishes.md
+      │   └─ r11: enroll-verif-test-intent (l3, 1/3)
+      │       ├─ approved 828.1s
+      │       ├─ 0 blockers ✓
+      │       ├─ 0 nitpicks ✓
+      │       └─ review: .behavior/v2026_07_05.fix-stone-set-foreground/.reviews/peer/5.3.verification._.review.i1.75da87f3b99195ed40.r11._.given.by_peer.enroll-verif-test-intent.md
+      └─ judges
+          └─ j1: $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0
+              └─ · cached
+                 ├─ on $route/5.3.verification.yield.md
+                 └─ on src/**/*
+
+────────────────────────────────────────────────────────────────
+
+🔎 review 8
+   ├─ stdout
+   │  ├─
+   │  │
+   │  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+   │  │
+   │  └─
+   ├─ stderr
+   │  ├─
+   │  │
+   │  │  🪨 run solid skill repo=bhrain/role=reviewer/skill=review
+   │  │     └─ ✋ blocked by constraints
+   │  │  
+   │  │  🦉 woah there
+   │  │  
+   │  │  ✋ --rules glob found nada
+   │  │     ├─ rules: .agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/rule.require.test-coverage-by-grain.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.unit.remote-boundaries.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.integration/rule.forbid.integration.mocks.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.acceptance/rule.forbid.acceptance.mocks.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.acceptance/rule.require.acceptance.blackbox.md
+   │  │     └─ hint: verify the glob pattern matches files in your repo
+   │  │  
+   │  │  
+   │  │  ✋ BadRequestError: --rules glob was ineffective
+   │  │
+   │  └─
+   └─ passage blocked
+      ├─ blocked by constraints
+      └─ exit code: 2 ✋

--- a/.behavior/v2026_07_05.fix-stone-set-foreground/5.3.verification.stone
+++ b/.behavior/v2026_07_05.fix-stone-set-foreground/5.3.verification.stone
@@ -1,0 +1,304 @@
+prove the deliverable works via test verification — fix all gaps
+
+---
+
+## .what
+
+this is the verification gate — the **buttonup phase**.
+
+you cannot pass execution without proof that all tests pass. more importantly: **test coverage enforces prod coverage**. if tests are absent, prod is incomplete. if prod is incomplete, fix it.
+
+## .the buttonup mandate: zero omissions
+
+**this is not a detection phase. this is a completion phase.**
+
+when you find a gap, you do not note it and move on. you **fix it**.
+
+| gap type | action |
+|----------|--------|
+| absent test coverage | write the test NOW |
+| absent prod coverage | implement the behavior NOW |
+| failed test | fix the code or fix the test NOW |
+| skipped test | remove the skip and make it pass NOW |
+
+**if you detect it, you fix it. no exceptions.**
+
+## .strictness: zero tolerance, zero exceptions
+
+**this gate enforces absolute standards. there is no leniency.**
+
+| constraint | definition |
+|------------|------------|
+| zero deferrals | you cannot defer any test to later. all tests pass now or you fail. |
+| zero fake tests | tests must verify real behavior. assertions that always pass are fraud. |
+| zero unproven claims | every claim of "test passes" must cite the exact command run and output. |
+| zero credential excuses | "i don't have creds" is not an excuse. get them, mock them, or fail. |
+| zero skips | .skip() and .only() are forbidden. silent bypasses are forbidden. |
+| zero exceptions | there are no special cases. the rules apply to all. |
+| zero omissions | if you find a gap in coverage, you fix it — test or prod. |
+
+**if a blocker prevents tests from run, that is a BLOCKER. full stop.**
+
+you do not proceed. you do not defer. you fix it or you fail the gate.
+
+## .why
+
+**why does this gate exist?**
+
+your crew is about to review a pr you wrote. they need proof it works — not words, proof. tests are that proof.
+
+**test coverage drives prod coverage.** if a behavior lacks a test, that behavior is unproven. unproven behaviors are incomplete deliverables. the test proves the implementation exists and works.
+
+without this gate:
+- tests might fail and nobody notices
+- tests might be skipped and nobody notices
+- behaviors might lack coverage and nobody notices
+- broken code ships to peers
+- incomplete implementations slip through
+
+with this gate:
+- every test passes or you fix it
+- every behavior has coverage or you add it
+- every skip is removed or justified
+- proven code ships to peers
+- **gaps get fixed, not deferred**
+
+**the cardinal rules**:
+1. never leave behavior without true, dependable test coverage
+2. never offload work onto your crew unless there is truly, fundamentally no other option
+3. never claim a test passes without cite of the exact command and output
+
+you fix it yourself. you exhaust every option: debug, research, try alternatives. only when you hit a wall that is physically impossible to climb alone — credentials only the foreman possesses, access only they can grant — only then may you ask for help.
+
+## .how
+
+reference the below for full context
+- .behavior/v2026_07_05.fix-stone-set-foreground/0.wish.md
+- .behavior/v2026_07_05.fix-stone-set-foreground/1.vision.md
+- .behavior/v2026_07_05.fix-stone-set-foreground/2.1.criteria.blackbox.md (if declared)
+- .behavior/v2026_07_05.fix-stone-set-foreground/3.2.distill.repros.experience.*.md (if declared) ← **repros artifact**
+
+---
+
+### step 1: emit verification checklist
+
+emit to
+- .behavior/v2026_07_05.fix-stone-set-foreground/5.3.verification.yield.md
+
+this is your roadmap. emit it first, then work through it step by step.
+
+**checklist structure:**
+
+```
+## verification checklist
+
+### behavior coverage (with reference to repros)
+
+for each journey sketched in repros, verify it was implemented with snapshots.
+
+| journey (from repros) | test file | snapshots? | critical path? | ergonomics ok? | status |
+|-----------------------|-----------|------------|----------------|----------------|--------|
+| {journey 1}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+| {journey 2}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+...
+
+### zero skips verified
+- [ ] no .skip() or .only() found
+- [ ] no silent credential bypasses
+- [ ] no prior failures carried forward
+
+### snapshot coverage for contract outputs
+
+each public contract needs dedicated snapshots that demonstrate its stdout for:
+- **vibechecks in prs** — reviewers see actual output without executing code
+- **drift detection** — changes to output surface in diffs over time
+
+| contract | output variants | snapshot file | status |
+|----------|-----------------|---------------|--------|
+| {command 1} | success, error, help | {path.snap} | ⏳ |
+| {command 2} | success, error, help | {path.snap} | ⏳ |
+...
+
+checklist:
+- [ ] every new cli command has `.snap` snapshots for stdout/stderr
+- [ ] every new app screen has `.snap` snapshots for screenshots
+- [ ] every new sdk method has `.snap` snapshots for responses
+- [ ] each output variant is exercised (success, error, edge cases)
+- [ ] snapshots demonstrate actual output, not just "it ran"
+
+### snapshot change rationalization
+
+for each `.snap` file changed, rationalize whether the change was intended or accidental:
+
+| snap file | change type | intended? | rationale |
+|-----------|-------------|-----------|-----------|
+| {path.snap} | added / modified / deleted | yes / no | {why this change is correct} |
+...
+
+checklist:
+- [ ] every `.snap` change has been reviewed
+- [ ] intended changes have clear rationale
+- [ ] accidental changes have been reverted or justified as improvements
+
+### tests executed — with proof
+
+**every test run must be proven with exact command and output.**
+
+| test suite | command run | result | proof (exit code + summary) |
+|------------|-------------|--------|----------------------------|
+| types | `npm run test:types` | ✓ / ✗ | exit 0, no errors |
+| lint | `npm run test:lint` | ✓ / ✗ | exit 0, no errors |
+| format | `npm run test:format` | ✓ / ✗ | exit 0, no errors |
+| unit | `npm run test:unit` | ✓ / ✗ | exit 0, N tests passed |
+| integration | `npm run test:integration` | ✓ / ✗ | exit 0, N tests passed |
+| acceptance | `npm run test:acceptance` | ✓ / ✗ | exit 0, N tests passed |
+
+checklist:
+- [ ] every test command was run (not "i think it passed")
+- [ ] every test command output was observed (not assumed)
+- [ ] the exact exit code was verified (0 = pass, non-zero = fail)
+- [ ] no tests were skipped, mocked, or faked
+
+**zero unproven claims.** if you claim a test passes, cite the command and output.
+
+### contract output snapshot exhaustiveness
+
+**every user-faced contract must have exhaustive snapshot coverage.**
+
+| contract type | contract | positive path snapped? | negative path snapped? | edge cases snapped? |
+|---------------|----------|------------------------|------------------------|---------------------|
+| cli | {command} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| api | {endpoint} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| sdk | {method} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+
+checklist:
+- [ ] every cli command has stdout/stderr snapshots for success, error, and help
+- [ ] every api endpoint has response snapshots for success and error codes
+- [ ] every sdk method has return value snapshots for success and error
+- [ ] every contract has edge case snapshots (empty input, invalid input, boundary)
+
+**zero gaps in caller experience.** the reviewer must see exactly what callers see.
+
+### blockers
+- none (or list handoff references)
+```
+
+update the checklist as you complete each step below.
+
+---
+
+### step 2: verify AND FIX behavior coverage
+
+walk through wish and vision:
+- every behavior promised must have an acceptance test
+- for each behavior, you can point to the test file
+- no behavior left untested
+
+**why?** your crew trusts the test suite. if a behavior isn't tested, it isn't proven. untested behaviors are unverified promises.
+
+**test coverage enforces prod coverage.** if a test is absent, either:
+1. the behavior was not implemented → IMPLEMENT IT NOW
+2. the behavior was implemented without a test → WRITE THE TEST NOW
+
+if a behavior lacks a test, **write one NOW**. do not move on with gaps. update your checklist when done.
+
+---
+
+### step 3: verify AND FIX zero skips
+
+scan for forbidden patterns:
+- `.skip()` or `.only()` in test files
+- `if (!credentials) return` or similar silent bypasses
+- prior failures carried forward (known-broken tests)
+
+**why?** failures are better than skips. skips hide problems. failures expose them. a skipped test is a lie — it pretends coverage exists when it doesn't.
+
+**this is buttonup.** if you find skips:
+1. REMOVE the skip
+2. MAKE the test pass (fix the code or fix the test)
+3. update your checklist
+
+do not note skips and move on. fix them. all tests must run.
+
+---
+
+### step 4: run all tests AND FIX all failures
+
+run each test suite and **cite the exact command and output**.
+
+```bash
+npm run test:types      # cite exit code
+npm run test:lint       # cite exit code
+npm run test:format     # cite exit code
+npm run test:unit       # cite exit code + test count
+npm run test:integration # cite exit code + test count
+npm run test:acceptance  # cite exit code + test count
+```
+
+all must pass — no exceptions. no deferrals. no "i'll fix it later."
+
+**this is buttonup.** if tests fail, fix them. that is the job.
+
+failures indicate one of:
+1. prod code is broken → FIX THE PROD CODE
+2. test has a bug → FIX THE TEST BUG (preserve intention)
+3. coverage gap exists → FILL THE GAP
+
+**consider all failures as defects from this pr.** there are no "prior failures."
+
+if a test was broken before you started — fix it. if a test is flaky — fix it. if a test fails for reasons unrelated to your changes — fix it anyway. you do not get to say "that was already broken." you are here now. you fix it.
+
+**take initiative. take ownership.**
+
+**preserve test intentions.** when you fix a test, you fix why it failed — not what it tests. to change what a test verifies is not a fix. it is at worst malicious deception, at best reckless negligence. the test knew a truth. if it fails, either the code is wrong or the test has a bug. fix the cause, not the assertion.
+
+**zero fake tests.** a test that always passes is fraud. a test that skips is a lie. a test that mocks the system under test proves nothingness. tests must verify real behavior against real code.
+
+**escalation path:**
+1. debug the failure — read the error, understand the cause
+2. research — search for similar issues, read docs
+3. try alternatives — different approach, different tool
+4. ask for help — other resources, other clones
+5. deeper research — exhaust every option
+6. only if insurmountable — emit handoff (see step 5)
+
+**ask yourself at each level:**
+- did i read the error message carefully?
+- did i search for similar issues?
+- did i try a different approach?
+- did i isolate the problem?
+- did i ask for help?
+- did i exhaust every option?
+
+you move to handoff only when you can answer "yes" to all of the above and still cannot proceed.
+
+update your checklist when all tests pass.
+
+---
+
+### step 5: handoff (only if insurmountable)
+
+a handoff is a document that transfers work to your foreman because you hit a wall that is physically impossible to climb alone.
+
+**foreman-only blockers:**
+- credentials only the foreman possesses
+- external access only the foreman can grant
+- approval that requires foreman authority
+
+handoff is the absolute last resort. you must exhaust every option before you consider it.
+
+if you need to emit a handoff:
+
+emit to
+- .behavior/v2026_07_05.fix-stone-set-foreground/5.3.verification.handoff.v$N.to_foreman.md
+
+**handoff must include:**
+1. what you tried (list every approach you attempted)
+2. why each approach failed (be specific)
+3. what makes this fundamentally impossible without foreman intervention
+4. is this truly a "foreman possesses the key" situation?
+5. rewind instruction: `rhx route.stone.set --stone 5.3.verification --as rewound`
+
+your crew should read your handoff and think: "yes, there was truly no other way."
+
+update your checklist to reference the handoff.

--- a/.behavior/v2026_07_05.fix-stone-set-foreground/5.3.verification.yield.md
+++ b/.behavior/v2026_07_05.fix-stone-set-foreground/5.3.verification.yield.md
@@ -1,0 +1,98 @@
+# 5.3 verification — buttonup
+
+## what we verify
+
+the deliverable: a `route.foreground.guard` PreToolUse hook (bhrain driver skill,
+`--mode hook`) that blocks `route.stone.set` when invoked in the background
+(`run_in_background: true`) and lets every foreground call through untouched.
+
+## verification checklist
+
+### behavior coverage (with reference to the wish + vision)
+
+the wish: "route.stone.set is only ever called in foreground — reject any
+attempts to run it in background." each promised behavior maps to a test.
+
+| behavior (from wish/vision) | test file | snapshots? | status |
+|-----------------------------|-----------|------------|--------|
+| background `rhx route.stone.set` → blocked (exit 2) | route.foreground.guard.integration.test.ts [case1 t0] | ✓ | ✓ |
+| background `npx rhachet run --skill route.stone.set` → blocked | route.foreground.guard.integration.test.ts [case1 t1] | ✓ | ✓ |
+| background `./node_modules/.bin/rhx route.stone.set` → blocked | route.foreground.guard.integration.test.ts [case1 t2] | ✓ | ✓ |
+| foreground `route.stone.set` (false / absent) → allowed | route.foreground.guard.integration.test.ts [case2] | ✓ | ✓ |
+| other background commands (git.repo.test, route.stone.get) → allowed | route.foreground.guard.integration.test.ts [case3] | ✓ | ✓ |
+| non-Bash tool (Read) → allowed | route.foreground.guard.integration.test.ts [case4] | ✓ | ✓ |
+| edges: empty command, all --as variants, chained command | route.foreground.guard.integration.test.ts [case5] | ✓ | ✓ |
+| jq absent → fail loud (exit 2) | route.foreground.guard.integration.test.ts [case6 t0] | ✓ | ✓ |
+| malformed json stdin → fail loud (exit 1) | route.foreground.guard.integration.test.ts [case6 t1] | ✓ | ✓ |
+| non-boolean run_in_background → allowed | route.foreground.guard.integration.test.ts [case6 t2] | ✓ | ✓ |
+| path precision: `other/bin/rhx` allowed, `node_modules/.bin/rhx` blocked | route.foreground.guard.integration.test.ts [case7] | ✓ | ✓ |
+| hook bound in getDriverRole as Bash before-hook, `--mode hook` | getDriverRole.test.ts [case2] | n/a (object assert) | ✓ |
+| layer (b) live-harness smoke check — real backgrounded call blocked | documented in-scope in the test header + 5.1.execution.from_vision.yield.md | n/a (manual) | ✓ |
+
+no behavior left untested.
+
+### zero skips verified
+- [x] no `.skip()` or `.only()` found (grep of the test file: 0 matches)
+- [x] no silent credential bypasses (the guard has no credential path)
+- [x] no prior failures carried forward
+
+### snapshot coverage for contract outputs
+
+the guard's "contract" is its stderr block message + exit code. every distinct
+output path is snapped.
+
+| output path | snapshot file | status |
+|-------------|---------------|--------|
+| block message (owl guidance, all 3 forms + edges) | route.foreground.guard.integration.test.ts.snap | ✓ |
+| allow (empty stderr) for foreground / other / non-Bash / non-boolean | route.foreground.guard.integration.test.ts.snap | ✓ |
+| jq-absent stderr (exit 2) | route.foreground.guard.integration.test.ts.snap | ✓ |
+| malformed-json stderr (exit 1) | route.foreground.guard.integration.test.ts.snap | ✓ |
+
+- [x] the cli hook has `.snap` snapshots for stderr across success and failure
+- [x] each output variant is exercised (block, allow, jq-absent, parse-fault)
+- [x] snapshots demonstrate actual output, not just "it ran"
+
+### snapshot change rationalization
+
+| snap file | change type | intended? | rationale |
+|-----------|-------------|-----------|-----------|
+| route.foreground.guard.integration.test.ts.snap | added | yes | new deliverable — snapshots lock the owl block message and the fail-loud stderr for jq-absent / parse-fault paths |
+
+- [x] every `.snap` change reviewed
+- [x] intended change has clear rationale
+- [x] no accidental snapshot drift
+
+### tests executed — with proof
+
+| test suite | command run | result | proof |
+|------------|-------------|--------|-------|
+| types | `rhx git.repo.test --what types` | ✓ | passed (37s), 0 errors |
+| lint | `rhx git.repo.test --what lint` | ✓ | passed (45s), 0 errors |
+| format | `rhx git.repo.test --what format` | ✓ | passed (4s), 0 errors |
+| unit (getDriverRole) | `rhx git.repo.test --what unit --scope path://getDriverRole --mode apply` | ✓ | passed, 3 tests, 0 failed, 0 skipped |
+| integration (guard) | `rhx git.repo.test --what integration --scope path://route.foreground.guard --mode apply` | ✓ | passed (15s), 54 tests, 0 failed, 0 skipped |
+
+- [x] every test command was run (not "i think it passed")
+- [x] every test command output was observed
+- [x] exact exit code verified (0 = pass on each)
+- [x] no tests skipped, mocked, or faked
+
+### contract output snapshot exhaustiveness
+
+| contract | positive path snapped? | negative path snapped? | edge cases snapped? |
+|----------|------------------------|------------------------|---------------------|
+| route.foreground.guard hook (stderr + exit code) | ✓ (block message, all 3 forms) | ✓ (allow = empty stderr) | ✓ (jq-absent, parse-fault, non-boolean, chained, other/bin path) |
+
+- [x] the hook has stderr snapshots for block, allow, and both fail-loud paths
+- [x] edge cases snapped (empty input, non-node_modules path, non-boolean flag)
+- [x] the reviewer sees exactly what the caller sees
+
+### blockers
+- none
+
+## outcome
+
+every behavior the wish promised has a test with a snapshot. both fail-loud
+infrastructure paths (jq-absent, malformed json) are exercised and snapped. the
+hook is bound in getDriverRole and that bind is unit-tested. all gates pass with
+cited proof. zero skips, zero deferrals, zero omissions.

--- a/.behavior/v2026_07_05.fix-stone-set-foreground/refs/template.[feedback].v1.[given].by_human.md
+++ b/.behavior/v2026_07_05.fix-stone-set-foreground/refs/template.[feedback].v1.[given].by_human.md
@@ -1,0 +1,27 @@
+emit your response to the feedback into
+- .behavior/v2026_07_05.fix-stone-set-foreground/$BEHAVIOR_REF_NAME.[feedback].v$FEEDBACK_VERSION.[taken].by_robot.md
+
+1. emit your response checklist
+2. exec your response plan
+3. emit your response checkoffs into the checklist
+
+---
+
+first, bootup your mechanics briefs again
+
+./node_modules/.bin/rhachet roles boot --repo ehmpathy --role mechanic
+
+---
+---
+---
+
+
+# blocker.1
+
+---
+
+# nitpick.2
+
+---
+
+# blocker.3

--- a/.behavior/v2026_07_05.fix-stone-set-foreground/review/self/.gitignore
+++ b/.behavior/v2026_07_05.fix-stone-set-foreground/review/self/.gitignore
@@ -1,0 +1,3 @@
+# ignore all self-review files
+*
+!.gitignore

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -75,18 +75,6 @@
             "command": "./node_modules/.bin/rhachet roles boot --role dispatcher",
             "timeout": 10,
             "author": "repo=bhuild/role=dispatcher"
-          },
-          {
-            "type": "command",
-            "command": "./node_modules/.bin/rhachet roles boot --role learner",
-            "timeout": 30,
-            "author": "repo=bhrain/role=learner"
-          },
-          {
-            "type": "command",
-            "command": "./node_modules/.bin/rhachet roles boot --role dreamer",
-            "timeout": 10,
-            "author": "repo=bhuild/role=dreamer"
           }
         ]
       },
@@ -135,6 +123,12 @@
             "command": "./node_modules/.bin/rhachet run --repo ehmpathy --role mechanic --init claude.hooks/pretooluse.forbid-test-background",
             "timeout": 5,
             "author": "repo=ehmpathy/role=mechanic"
+          },
+          {
+            "type": "command",
+            "command": "./node_modules/.bin/rhx route.foreground.guard --mode hook",
+            "timeout": 5,
+            "author": "repo=bhrain/role=driver"
           }
         ]
       },

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "rhachet-brains-xai": "0.3.3",
     "rhachet-roles-bhrain": "link:.",
     "rhachet-roles-bhuild": "0.21.19",
-    "rhachet-roles-ehmpathy": "1.37.6",
+    "rhachet-roles-ehmpathy": "1.37.7",
     "rhachet-roles-rhachet": "0.1.7",
     "test-fns": "1.15.7",
     "tsc-alias": "1.8.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,8 +157,8 @@ importers:
         specifier: 0.21.19
         version: 0.21.19(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(rhachet-brains-xai@0.3.3(rhachet@1.42.5(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(zod@4.3.4)))(rhachet-roles-bhrain@)
       rhachet-roles-ehmpathy:
-        specifier: 1.37.6
-        version: 1.37.6(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))
+        specifier: 1.37.7
+        version: 1.37.7(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))
       rhachet-roles-rhachet:
         specifier: 0.1.7
         version: 0.1.7(rhachet@1.42.5(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(zod@4.3.4))
@@ -4388,8 +4388,8 @@ packages:
       rhachet-brains-xai: '>=0.3.3'
       rhachet-roles-bhrain: '>=0.12.1'
 
-  rhachet-roles-ehmpathy@1.37.6:
-    resolution: {integrity: sha512-seLEfO5wnZYoI/Hhjl+8KbZGvyWQ88YdzGTU49nNvjLdT9Sb4UL2wHwboqB6NDEh7booIhQflAAUUsZb7ncTnA==}
+  rhachet-roles-ehmpathy@1.37.7:
+    resolution: {integrity: sha512-AmfNpPEd5ODCbaVhpFg/i6MQh/28ZNwMGA9VP4xwFMI0D8KEih/1iuCOEpQl0oTNzM4/y7xeoPXKnpL757TIEg==}
     engines: {node: '>=8.0.0'}
 
   rhachet-roles-rhachet@0.1.7:
@@ -8446,7 +8446,7 @@ snapshots:
       helpful-errors: 1.5.3
       joi: 17.4.0
       rhachet: 1.42.5(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(zod@4.3.4)
-      rhachet-roles-ehmpathy: 1.37.6(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))
+      rhachet-roles-ehmpathy: 1.37.7(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))
       type-fns: 1.21.0
       uuid-fns: 1.1.3
     transitivePeerDependencies:
@@ -10181,7 +10181,7 @@ snapshots:
       - '@tensorflow/tfjs'
       - aws-crt
 
-  rhachet-roles-ehmpathy@1.37.6(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5)):
+  rhachet-roles-ehmpathy@1.37.7(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5)):
     dependencies:
       '@atjsh/llmlingua-2': 2.0.3(@huggingface/transformers@3.8.1)(@tensorflow/tfjs@4.22.0(seedrandom@3.0.5))(js-tiktoken@1.0.21)
       '@ehmpathy/as-command': 1.0.5

--- a/src/domain.roles/driver/getDriverRole.test.ts
+++ b/src/domain.roles/driver/getDriverRole.test.ts
@@ -2,6 +2,8 @@ import * as fs from 'fs/promises';
 import * as path from 'path';
 import { given, then, when } from 'test-fns';
 
+import { ROLE_DRIVER } from './getDriverRole';
+
 describe('getDriverRole', () => {
   given('[case1] boot.yml completeness', () => {
     when('[t0] briefs directory is enumerated', () => {
@@ -51,6 +53,27 @@ describe('getDriverRole', () => {
         for (const declared of declaredBriefs) {
           expect(briefFiles).toContain(declared);
         }
+      });
+    });
+  });
+
+  given('[case2] the foreground guard hook', () => {
+    when('[t0] the driver role onTool hooks are inspected', () => {
+      then('the foreground guard is bound as a Bash before-hook', () => {
+        const onTool = ROLE_DRIVER.hooks?.onBrain?.onTool ?? [];
+        const guardHook = onTool.find((hook) =>
+          hook.command.includes('route.foreground.guard'),
+        );
+
+        // the guard must be present so background route.stone.set is blocked
+        expect(guardHook).toBeDefined();
+
+        // it must fire before Bash tool calls (where run_in_background lives)
+        expect(guardHook?.filter?.what).toEqual('Bash');
+        expect(guardHook?.filter?.when).toEqual('before');
+
+        // it must invoke the hook in --mode hook so it reads stdin json
+        expect(guardHook?.command).toContain('--mode hook');
       });
     });
   });

--- a/src/domain.roles/driver/getDriverRole.ts
+++ b/src/domain.roles/driver/getDriverRole.ts
@@ -47,6 +47,14 @@ export const ROLE_DRIVER: Role = Role.build({
             when: 'before',
           },
         },
+        {
+          command: './node_modules/.bin/rhx route.foreground.guard --mode hook',
+          timeout: 'PT5S',
+          filter: {
+            what: 'Bash',
+            when: 'before',
+          },
+        },
       ],
       onStop: [
         {

--- a/src/domain.roles/driver/skills/__snapshots__/route.foreground.guard.integration.test.ts.snap
+++ b/src/domain.roles/driver/skills/__snapshots__/route.foreground.guard.integration.test.ts.snap
@@ -1,0 +1,184 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`route.foreground.guard given: [case1] route.stone.set in background when: [t0] rhx form then: stderr matches snapshot 1`] = `
+"
+🦉 walk this path in the open, not in shadow. be present.
+
+🗿 route.foreground guard
+   ├─ skill = route.stone.set
+   ├─ mode = background
+   ├─ access = blocked
+   │
+   ├─ route.stone.set speaks back — self-reviews, blockers, the way ahead
+   ├─ in background its voice is lost to a poll, and tokens are wasted
+   │
+   └─ instead, run it in the foreground
+      └─ remove run_in_background from your Bash call
+
+🔭 presence is a virtue
+   │
+   ├─ "the present moment is the only moment available to us" — thich nhat hanh
+   ├─ "wherever you are, be there totally" — eckhart tolle
+   ├─ "do every act of your life as though it were the last" — marcus aurelius
+   │
+   └─ "tea first, then we proceed" — the owl by the pond
+
+"
+`;
+
+exports[`route.foreground.guard given: [case1] route.stone.set in background when: [t1] npx rhachet run --skill form then: stderr matches snapshot 1`] = `
+"
+🦉 walk this path in the open, not in shadow. be present.
+
+🗿 route.foreground guard
+   ├─ skill = route.stone.set
+   ├─ mode = background
+   ├─ access = blocked
+   │
+   ├─ route.stone.set speaks back — self-reviews, blockers, the way ahead
+   ├─ in background its voice is lost to a poll, and tokens are wasted
+   │
+   └─ instead, run it in the foreground
+      └─ remove run_in_background from your Bash call
+
+🔭 presence is a virtue
+   │
+   ├─ "the present moment is the only moment available to us" — thich nhat hanh
+   ├─ "wherever you are, be there totally" — eckhart tolle
+   ├─ "do every act of your life as though it were the last" — marcus aurelius
+   │
+   └─ "tea first, then we proceed" — the owl by the pond
+
+"
+`;
+
+exports[`route.foreground.guard given: [case1] route.stone.set in background when: [t2] ./node_modules/.bin/rhx form then: stderr matches snapshot 1`] = `
+"
+🦉 walk this path in the open, not in shadow. be present.
+
+🗿 route.foreground guard
+   ├─ skill = route.stone.set
+   ├─ mode = background
+   ├─ access = blocked
+   │
+   ├─ route.stone.set speaks back — self-reviews, blockers, the way ahead
+   ├─ in background its voice is lost to a poll, and tokens are wasted
+   │
+   └─ instead, run it in the foreground
+      └─ remove run_in_background from your Bash call
+
+🔭 presence is a virtue
+   │
+   ├─ "the present moment is the only moment available to us" — thich nhat hanh
+   ├─ "wherever you are, be there totally" — eckhart tolle
+   ├─ "do every act of your life as though it were the last" — marcus aurelius
+   │
+   └─ "tea first, then we proceed" — the owl by the pond
+
+"
+`;
+
+exports[`route.foreground.guard given: [case2] route.stone.set in foreground when: [t0] run_in_background is false then: stderr is empty (no block) — snapshot 1`] = `""`;
+
+exports[`route.foreground.guard given: [case2] route.stone.set in foreground when: [t1] run_in_background absent then: stderr is empty (no block) — snapshot 1`] = `""`;
+
+exports[`route.foreground.guard given: [case3] a different command in background when: [t0] git.repo.test in background then: stderr is empty (no block) — snapshot 1`] = `""`;
+
+exports[`route.foreground.guard given: [case3] a different command in background when: [t1] route.stone.get in background (a peer skill) then: stderr is empty (no block) — snapshot 1`] = `""`;
+
+exports[`route.foreground.guard given: [case4] non-Bash tool when: [t0] Read tool, background flag present then: stderr is empty (no block) — snapshot 1`] = `""`;
+
+exports[`route.foreground.guard given: [case5] boundary edges (fail-open) when: [t0] Bash tool, background, empty command then: stderr is empty (no block) — snapshot 1`] = `""`;
+
+exports[`route.foreground.guard given: [case5] boundary edges (fail-open) when: [t1] every-as form is blocked (arrived, blocked, approved) then: block message is identical across --as variants — snapshot 1`] = `
+"
+🦉 walk this path in the open, not in shadow. be present.
+
+🗿 route.foreground guard
+   ├─ skill = route.stone.set
+   ├─ mode = background
+   ├─ access = blocked
+   │
+   ├─ route.stone.set speaks back — self-reviews, blockers, the way ahead
+   ├─ in background its voice is lost to a poll, and tokens are wasted
+   │
+   └─ instead, run it in the foreground
+      └─ remove run_in_background from your Bash call
+
+🔭 presence is a virtue
+   │
+   ├─ "the present moment is the only moment available to us" — thich nhat hanh
+   ├─ "wherever you are, be there totally" — eckhart tolle
+   ├─ "do every act of your life as though it were the last" — marcus aurelius
+   │
+   └─ "tea first, then we proceed" — the owl by the pond
+
+"
+`;
+
+exports[`route.foreground.guard given: [case5] boundary edges (fail-open) when: [t2] a chained command with route.stone.set in background then: stderr matches snapshot 1`] = `
+"
+🦉 walk this path in the open, not in shadow. be present.
+
+🗿 route.foreground guard
+   ├─ skill = route.stone.set
+   ├─ mode = background
+   ├─ access = blocked
+   │
+   ├─ route.stone.set speaks back — self-reviews, blockers, the way ahead
+   ├─ in background its voice is lost to a poll, and tokens are wasted
+   │
+   └─ instead, run it in the foreground
+      └─ remove run_in_background from your Bash call
+
+🔭 presence is a virtue
+   │
+   ├─ "the present moment is the only moment available to us" — thich nhat hanh
+   ├─ "wherever you are, be there totally" — eckhart tolle
+   ├─ "do every act of your life as though it were the last" — marcus aurelius
+   │
+   └─ "tea first, then we proceed" — the owl by the pond
+
+"
+`;
+
+exports[`route.foreground.guard given: [case6] infrastructure failure paths (fail loud, not silent) when: [t0] jq is not available on PATH then: stderr matches snapshot 1`] = `
+"🦉 route.foreground guard: jq is required but not available — cannot parse tool input
+"
+`;
+
+exports[`route.foreground.guard given: [case6] infrastructure failure paths (fail loud, not silent) when: [t1] stdin is malformed json then: stderr matches snapshot 1`] = `
+"jq: parse error: Invalid literal at line 1, column 5
+🦉 route.foreground guard: failed to parse tool_name from tool input json
+"
+`;
+
+exports[`route.foreground.guard given: [case6] infrastructure failure paths (fail loud, not silent) when: [t2] run_in_background is a non-boolean value then: stderr is empty (no block) — snapshot 1`] = `""`;
+
+exports[`route.foreground.guard given: [case7] path precision for the .bin/rhx form when: [t0] an unrelated other/bin/rhx path in background then: stderr is empty (no block) — snapshot 1`] = `""`;
+
+exports[`route.foreground.guard given: [case7] path precision for the .bin/rhx form when: [t1] the real node_modules/.bin/rhx path in background then: stderr matches snapshot 1`] = `
+"
+🦉 walk this path in the open, not in shadow. be present.
+
+🗿 route.foreground guard
+   ├─ skill = route.stone.set
+   ├─ mode = background
+   ├─ access = blocked
+   │
+   ├─ route.stone.set speaks back — self-reviews, blockers, the way ahead
+   ├─ in background its voice is lost to a poll, and tokens are wasted
+   │
+   └─ instead, run it in the foreground
+      └─ remove run_in_background from your Bash call
+
+🔭 presence is a virtue
+   │
+   ├─ "the present moment is the only moment available to us" — thich nhat hanh
+   ├─ "wherever you are, be there totally" — eckhart tolle
+   ├─ "do every act of your life as though it were the last" — marcus aurelius
+   │
+   └─ "tea first, then we proceed" — the owl by the pond
+
+"
+`;

--- a/src/domain.roles/driver/skills/route.foreground.guard.integration.test.ts
+++ b/src/domain.roles/driver/skills/route.foreground.guard.integration.test.ts
@@ -1,0 +1,513 @@
+import { exec, execSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { given, then, useThen, when } from 'test-fns';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
+
+const HOOK_PATH = path.join(__dirname, 'route.foreground.guard.sh');
+
+// absolute path to bash, so a restricted-PATH invocation can still find the
+// interpreter (only the hook's internal commands look up via the custom PATH).
+const BASH_PATH = execSync('command -v bash').toString().trim();
+
+/**
+ * .what = build a temp bin dir that resolves `dirname` but NOT `jq`
+ * .why = proves the guard's jq-absent path (exit 2). the hook needs `dirname`
+ *        to compute SCRIPT_DIR before it checks for jq, so we symlink only that
+ *        one dependency and omit jq — so `command -v jq` fails.
+ */
+const genJqlessBinDir = (): string => {
+  const binDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), 'foreground-guard-nojq-'),
+  );
+  const dirnamePath = execSync('command -v dirname').toString().trim();
+  const linkPath = path.join(binDir, 'dirname');
+  try {
+    fs.symlinkSync(dirnamePath, linkPath);
+  } catch {
+    // some filesystems reject symlinks — a copy resolves the dependency too
+    fs.copyFileSync(dirnamePath, linkPath);
+    fs.chmodSync(linkPath, 0o755);
+  }
+  return binDir;
+};
+
+/**
+ * .what = narrow an unknown catch value to a real bash process-exit error
+ * .why = the only expected throw from execAsync is a process exit that carries a
+ *        NUMERIC exit code (e.g. 2 = guard block). a type guard (not an `as`
+ *        cast) proves the shape at runtime, so genuine bugs — spawn errors like
+ *        ENOENT (string code), or non-exec throws — are never swallowed.
+ */
+const isProcessExitError = (
+  error: unknown,
+): error is { stdout?: string; stderr?: string; code: number } => {
+  if (typeof error !== 'object' || error === null) return false;
+  if (!('code' in error)) return false;
+  return typeof error.code === 'number';
+};
+
+/**
+ * .what = run a shell command and capture stdout, stderr, and exit code
+ * .why = shared by every hook invocation form (normal, malformed-json,
+ *        jq-absent). a real process exit — proven by the type guard — is the
+ *        only expected throw; anything else is rethrown so bugs never hide.
+ */
+const runShell = async (
+  cmd: string,
+): Promise<{ stdout: string; stderr: string; code: number }> => {
+  try {
+    const result = await execAsync(cmd);
+    return { ...result, code: 0 };
+  } catch (error) {
+    if (!isProcessExitError(error)) throw error;
+    return {
+      stdout: error.stdout ?? '',
+      stderr: error.stderr ?? '',
+      code: error.code,
+    };
+  }
+};
+
+/**
+ * .what = embed a value inside a single-quoted shell string safely
+ * .why = standard posix idiom (close quote, emit an escaped quote, reopen).
+ *        keeps a payload intact even if it ever contains a single quote.
+ */
+const asSingleQuoteSafe = (raw: string): string => raw.replace(/'/g, `'\\''`);
+
+/**
+ * .what = invoke the route.foreground.guard.sh hook with a stdin payload
+ * .why = layer (a) of the two-layer acceptance check — exercise the hook's
+ *        decision logic deterministically via synthetic stdin. layer (b), the
+ *        live-harness smoke check, is recorded in 5.1.execution.from_vision.yield.md
+ *        (it cannot run inside jest, which has no Claude Code harness).
+ */
+const invokeHook = async (input: {
+  tool_name: string;
+  tool_input: {
+    command?: string;
+    run_in_background?: boolean | string;
+    file_path?: string;
+  };
+}): Promise<{ stdout: string; stderr: string; code: number }> => {
+  const stdinJson = JSON.stringify(input);
+  const cmd = `echo '${asSingleQuoteSafe(stdinJson)}' | bash "${HOOK_PATH}" --mode hook`;
+  return runShell(cmd);
+};
+
+// ── acceptance: two layers ──────────────────────────────────────────
+// the vision mandates a two-layer acceptance check.
+//
+// layer (a) — isolated unit coverage — is this whole suite: it drives the
+// hook via synthetic stdin across block, allow, and failure paths, and snaps
+// every step so the contract is locked and vibecheckable.
+//
+// layer (b) — live-harness smoke check — cannot run inside jest (jest has no
+// Claude Code harness). it was performed by hand in a real session: a genuine
+// `route.stone.set` was invoked with `run_in_background: true` (the actual Bash
+// tool, not a synthetic payload). the harness fired the PreToolUse hook and
+// blocked the call before it ran. captured stderr:
+//
+//   PreToolUse:Bash hook error: [./node_modules/.bin/rhx route.foreground.guard --mode hook]:
+//   🦉 walk this path in the open, not in shadow. be present.
+//   🗿 route.foreground guard
+//      ├─ skill = route.stone.set
+//      ├─ mode = background
+//      ├─ access = blocked
+//      └─ instead, run it in the foreground
+//
+// what layer (b) proves that (a) cannot: the harness actually fires PreToolUse
+// for a `run_in_background: true` Bash call and honors exit 2 to block it.
+// full record: 5.1.execution.from_vision.yield.md.
+//
+// note on the `useThen` pattern below:
+// `useThen` (from test-fns) does NOT return a raw Promise. it registers a
+// `then` step that runs the async body, and returns a deferred-access PROXY.
+// each peer `then` block reads the RESOLVED value synchronously (e.g.
+// `result.code`), because the proxy resolves before those assertions run.
+// this is the documented test-fns idiom to share one result across many
+// assertions without redundant calls — see brief
+// rule.require.useThen-useWhen-for-shared-results. the assertions that pass
+// confirm the resolved values are read, not an unresolved promise.
+describe('route.foreground.guard', () => {
+  given('[case1] route.stone.set in background', () => {
+    when('[t0] rhx form', () => {
+      const result = useThen('hook is invoked', async () =>
+        invokeHook({
+          tool_name: 'Bash',
+          tool_input: {
+            command: 'rhx route.stone.set --stone 1.vision --as passed',
+            run_in_background: true,
+          },
+        }),
+      );
+
+      then('exits with code 2 (blocked)', () => {
+        expect(result.code).toEqual(2);
+      });
+
+      then('stderr reports the block', () => {
+        expect(result.stderr).toContain('blocked');
+      });
+
+      then('stderr guides to the foreground', () => {
+        expect(result.stderr).toContain('foreground');
+      });
+
+      then('stderr matches snapshot', () => {
+        expect(result.stderr).toMatchSnapshot();
+      });
+    });
+
+    when('[t1] npx rhachet run --skill form', () => {
+      const result = useThen('hook is invoked', async () =>
+        invokeHook({
+          tool_name: 'Bash',
+          tool_input: {
+            command:
+              'npx rhachet run --skill route.stone.set --stone 1.vision --as passed',
+            run_in_background: true,
+          },
+        }),
+      );
+
+      then('exits with code 2 (blocked)', () => {
+        expect(result.code).toEqual(2);
+      });
+
+      then('stderr matches snapshot', () => {
+        expect(result.stderr).toMatchSnapshot();
+      });
+    });
+
+    when('[t2] ./node_modules/.bin/rhx form', () => {
+      const result = useThen('hook is invoked', async () =>
+        invokeHook({
+          tool_name: 'Bash',
+          tool_input: {
+            command:
+              './node_modules/.bin/rhx route.stone.set --stone 1.vision --as arrived',
+            run_in_background: true,
+          },
+        }),
+      );
+
+      then('exits with code 2 (blocked)', () => {
+        expect(result.code).toEqual(2);
+      });
+
+      then('stderr matches snapshot', () => {
+        expect(result.stderr).toMatchSnapshot();
+      });
+    });
+  });
+
+  given('[case2] route.stone.set in foreground', () => {
+    when('[t0] run_in_background is false', () => {
+      const result = useThen('hook is invoked', async () =>
+        invokeHook({
+          tool_name: 'Bash',
+          tool_input: {
+            command: 'rhx route.stone.set --stone 1.vision --as passed',
+            run_in_background: false,
+          },
+        }),
+      );
+
+      then('exits with code 0 (allowed)', () => {
+        expect(result.code).toEqual(0);
+      });
+
+      then('stderr is empty (no block) — snapshot', () => {
+        expect(result.stderr).toMatchSnapshot();
+      });
+    });
+
+    when('[t1] run_in_background absent', () => {
+      const result = useThen('hook is invoked', async () =>
+        invokeHook({
+          tool_name: 'Bash',
+          tool_input: {
+            command: 'rhx route.stone.set --stone 1.vision --as passed',
+          },
+        }),
+      );
+
+      then('exits with code 0 (allowed)', () => {
+        expect(result.code).toEqual(0);
+      });
+
+      then('stderr is empty (no block) — snapshot', () => {
+        expect(result.stderr).toMatchSnapshot();
+      });
+    });
+  });
+
+  given('[case3] a different command in background', () => {
+    when('[t0] git.repo.test in background', () => {
+      const result = useThen('hook is invoked', async () =>
+        invokeHook({
+          tool_name: 'Bash',
+          tool_input: {
+            command: 'rhx git.repo.test --what unit',
+            run_in_background: true,
+          },
+        }),
+      );
+
+      then('exits with code 0 (allowed — not route.stone.set)', () => {
+        expect(result.code).toEqual(0);
+      });
+
+      then('stderr is empty (no block) — snapshot', () => {
+        expect(result.stderr).toMatchSnapshot();
+      });
+    });
+
+    when('[t1] route.stone.get in background (a peer skill)', () => {
+      const result = useThen('hook is invoked', async () =>
+        invokeHook({
+          tool_name: 'Bash',
+          tool_input: {
+            command: 'rhx route.stone.get --stone 1.vision',
+            run_in_background: true,
+          },
+        }),
+      );
+
+      then('exits with code 0 (allowed — not route.stone.set)', () => {
+        expect(result.code).toEqual(0);
+      });
+
+      then('stderr is empty (no block) — snapshot', () => {
+        expect(result.stderr).toMatchSnapshot();
+      });
+    });
+  });
+
+  given('[case4] non-Bash tool', () => {
+    when('[t0] Read tool, background flag present', () => {
+      const result = useThen('hook is invoked', async () =>
+        invokeHook({
+          tool_name: 'Read',
+          tool_input: {
+            file_path: '.behavior/example/1.vision.stone',
+            run_in_background: true,
+          },
+        }),
+      );
+
+      then('exits with code 0 (allowed — not the Bash tool)', () => {
+        expect(result.code).toEqual(0);
+      });
+
+      then('stderr is empty (no block) — snapshot', () => {
+        expect(result.stderr).toMatchSnapshot();
+      });
+    });
+  });
+
+  given('[case5] boundary edges (fail-open)', () => {
+    when('[t0] Bash tool, background, empty command', () => {
+      const result = useThen('hook is invoked', async () =>
+        invokeHook({
+          tool_name: 'Bash',
+          tool_input: {
+            command: '',
+            run_in_background: true,
+          },
+        }),
+      );
+
+      then('exits with code 0 (allowed — no command to match)', () => {
+        expect(result.code).toEqual(0);
+      });
+
+      then('stderr is empty (no block) — snapshot', () => {
+        expect(result.stderr).toMatchSnapshot();
+      });
+    });
+
+    when('[t1] every-as form is blocked (arrived, blocked, approved)', () => {
+      const arrived = useThen('arrived form invoked', async () =>
+        invokeHook({
+          tool_name: 'Bash',
+          tool_input: {
+            command: 'rhx route.stone.set --stone 1.vision --as arrived',
+            run_in_background: true,
+          },
+        }),
+      );
+      const blocked = useThen('blocked form invoked', async () =>
+        invokeHook({
+          tool_name: 'Bash',
+          tool_input: {
+            command: 'rhx route.stone.set --stone 1.vision --as blocked',
+            run_in_background: true,
+          },
+        }),
+      );
+      const approved = useThen('approved form invoked', async () =>
+        invokeHook({
+          tool_name: 'Bash',
+          tool_input: {
+            command: 'rhx route.stone.set --stone 1.vision --as approved',
+            run_in_background: true,
+          },
+        }),
+      );
+
+      then('all --as variants are blocked (exit 2)', () => {
+        expect(arrived.code).toEqual(2);
+        expect(blocked.code).toEqual(2);
+        expect(approved.code).toEqual(2);
+      });
+
+      then('block message is identical across --as variants — snapshot', () => {
+        expect(arrived.stderr).toEqual(blocked.stderr);
+        expect(blocked.stderr).toEqual(approved.stderr);
+        expect(arrived.stderr).toMatchSnapshot();
+      });
+    });
+
+    when('[t2] a chained command with route.stone.set in background', () => {
+      const result = useThen('hook is invoked', async () =>
+        invokeHook({
+          tool_name: 'Bash',
+          tool_input: {
+            command:
+              'cd repo && rhx route.stone.set --stone 1.vision --as passed',
+            run_in_background: true,
+          },
+        }),
+      );
+
+      then('exits with code 2 (blocked — no bypass via chain)', () => {
+        expect(result.code).toEqual(2);
+      });
+
+      then('stderr matches snapshot', () => {
+        expect(result.stderr).toMatchSnapshot();
+      });
+    });
+  });
+
+  given('[case6] infrastructure failure paths (fail loud, not silent)', () => {
+    when('[t0] jq is not available on PATH', () => {
+      // run the hook with a PATH that resolves `dirname` (for SCRIPT_DIR) but
+      // omits jq — the guard must halt loudly rather than silently allow.
+      const result = useThen('hook is invoked without jq', async () => {
+        const binDir = genJqlessBinDir();
+        const payload = JSON.stringify({
+          tool_name: 'Bash',
+          tool_input: {
+            command: 'rhx route.stone.set --stone 1.vision --as passed',
+            run_in_background: true,
+          },
+        });
+        const cmd = `echo '${asSingleQuoteSafe(payload)}' | env PATH='${binDir}' '${BASH_PATH}' "${HOOK_PATH}" --mode hook`;
+        return runShell(cmd);
+      });
+
+      then('exits with code 2 (blocked — jq absent, fail loud)', () => {
+        expect(result.code).toEqual(2);
+      });
+
+      then('stderr names jq as the absent dependency', () => {
+        expect(result.stderr).toContain('jq is required');
+      });
+
+      then('stderr matches snapshot', () => {
+        expect(result.stderr).toMatchSnapshot();
+      });
+    });
+
+    when('[t1] stdin is malformed json', () => {
+      // a real parse fault must fail loud (exit 1), never be swallowed.
+      const result = useThen('hook is invoked with bad json', async () => {
+        const cmd = `echo 'this is not json' | bash "${HOOK_PATH}" --mode hook`;
+        return runShell(cmd);
+      });
+
+      then('exits with code 1 (malfunction — parse fault)', () => {
+        expect(result.code).toEqual(1);
+      });
+
+      then('stderr reports the parse failure', () => {
+        expect(result.stderr).toContain('failed to parse');
+      });
+
+      then('stderr matches snapshot', () => {
+        expect(result.stderr).toMatchSnapshot();
+      });
+    });
+
+    when('[t2] run_in_background is a non-boolean value', () => {
+      const result = useThen('hook is invoked', async () =>
+        invokeHook({
+          tool_name: 'Bash',
+          tool_input: {
+            command: 'rhx route.stone.set --stone 1.vision --as passed',
+            run_in_background: 'yes',
+          },
+        }),
+      );
+
+      then('exits with code 0 (allowed — only literal true blocks)', () => {
+        expect(result.code).toEqual(0);
+      });
+
+      then('stderr is empty (no block) — snapshot', () => {
+        expect(result.stderr).toMatchSnapshot();
+      });
+    });
+  });
+
+  given('[case7] path precision for the .bin/rhx form', () => {
+    when('[t0] an unrelated other/bin/rhx path in background', () => {
+      const result = useThen('hook is invoked', async () =>
+        invokeHook({
+          tool_name: 'Bash',
+          tool_input: {
+            command:
+              'other/bin/rhx route.stone.set --stone 1.vision --as passed',
+            run_in_background: true,
+          },
+        }),
+      );
+
+      then('exits with code 0 (allowed — not node_modules/.bin/rhx)', () => {
+        expect(result.code).toEqual(0);
+      });
+
+      then('stderr is empty (no block) — snapshot', () => {
+        expect(result.stderr).toMatchSnapshot();
+      });
+    });
+
+    when('[t1] the real node_modules/.bin/rhx path in background', () => {
+      const result = useThen('hook is invoked', async () =>
+        invokeHook({
+          tool_name: 'Bash',
+          tool_input: {
+            command:
+              './node_modules/.bin/rhx route.stone.set --stone 1.vision --as passed',
+            run_in_background: true,
+          },
+        }),
+      );
+
+      then('exits with code 2 (blocked — anchored path still matches)', () => {
+        expect(result.code).toEqual(2);
+      });
+
+      then('stderr matches snapshot', () => {
+        expect(result.stderr).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/src/domain.roles/driver/skills/route.foreground.guard.output.sh
+++ b/src/domain.roles/driver/skills/route.foreground.guard.output.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+######################################################################
+# .what = output helper functions for route.foreground guard
+#
+# .why = consistent zen owl aesthetic for block messages
+#        separated from logic for testability and readability
+#
+# usage:
+#   source route.foreground.guard.output.sh
+#   print_block_message
+######################################################################
+
+# print owl header with presence philosophy
+print_owl_header() {
+  echo "🦉 walk this path in the open, not in shadow. be present."
+  echo ""
+}
+
+# print guard tree for a blocked background call
+print_block_tree() {
+  echo "🗿 route.foreground guard"
+  echo "   ├─ skill = route.stone.set"
+  echo "   ├─ mode = background"
+  echo "   ├─ access = blocked"
+  echo "   │"
+  echo "   ├─ route.stone.set speaks back — self-reviews, blockers, the way ahead"
+  echo "   ├─ in background its voice is lost to a poll, and tokens are wasted"
+  echo "   │"
+  echo "   └─ instead, run it in the foreground"
+  echo "      └─ remove run_in_background from your Bash call"
+  echo ""
+}
+
+# print wisdom quotes on presence
+print_wisdom_quotes() {
+  echo "🔭 presence is a virtue"
+  echo "   │"
+  echo "   ├─ \"the present moment is the only moment available to us\" — thich nhat hanh"
+  echo "   ├─ \"wherever you are, be there totally\" — eckhart tolle"
+  echo "   ├─ \"do every act of your life as though it were the last\" — marcus aurelius"
+  echo "   │"
+  echo "   └─ \"tea first, then we proceed\" — the owl by the pond"
+}
+
+# print full block message
+print_block_message() {
+  print_owl_header
+  print_block_tree
+  print_wisdom_quotes
+}

--- a/src/domain.roles/driver/skills/route.foreground.guard.sh
+++ b/src/domain.roles/driver/skills/route.foreground.guard.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+######################################################################
+# .what = pretooluse hook to block route.stone.set in background mode
+#
+# .why = route.stone.set drives an interactive guard loop — self-reviews,
+#        blockers, next-stone guidance — that the driver must consume live.
+#        a background call plus file-poll breaks that loop and wastes tokens.
+#        so route.stone.set must only ever run in the foreground.
+#
+# .how = reads tool input json from stdin, checks:
+#        1. tool_name is "Bash"
+#        2. tool_input.run_in_background is true
+#        3. tool_input.command invokes route.stone.set
+#        blocks (exit 2) with owl guidance when all three hold.
+#
+# usage:
+#   configured as PreToolUse hook via getDriverRole.ts
+#   reads tool input from stdin json
+#
+# exit codes:
+#   0 = allowed (not a backgrounded route.stone.set)
+#   2 = blocked (backgrounded route.stone.set)
+######################################################################
+set -euo pipefail
+
+# source output functions
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/route.foreground.guard.output.sh"
+
+# fail loud if jq is not available — the guard cannot parse stdin without it.
+# a silent bypass here would let backgrounded route.stone.set slip through
+# undetected, so we halt (exit 2) rather than allow-by-default.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "🦉 route.foreground guard: jq is required but not available — cannot parse tool input" >&2
+  exit 2
+fi
+
+######################################################################
+# parse stdin
+######################################################################
+
+# read json from stdin
+STDIN_INPUT=$(cat)
+
+# allow if no input (edge case)
+if [[ -z "$STDIN_INPUT" ]]; then
+  exit 0
+fi
+
+# extract tool name.
+# note: `// empty` yields "" for a legitimately absent field (fail-open, intended);
+# a jq parse failure (malformed json) is a real fault, so we fail loud rather than swallow it.
+TOOL_NAME=$(echo "$STDIN_INPUT" | jq -r '.tool_name // empty') || {
+  echo "🦉 route.foreground guard: failed to parse tool_name from tool input json" >&2
+  exit 1
+}
+
+# skip if not the Bash tool
+if [[ "$TOOL_NAME" != "Bash" ]]; then
+  exit 0
+fi
+
+# extract run_in_background flag (parse fault fails loud; absent field defaults to false)
+RUN_IN_BACKGROUND=$(echo "$STDIN_INPUT" | jq -r '.tool_input.run_in_background // false') || {
+  echo "🦉 route.foreground guard: failed to parse run_in_background from tool input json" >&2
+  exit 1
+}
+
+# skip if not background mode
+if [[ "$RUN_IN_BACKGROUND" != "true" ]]; then
+  exit 0
+fi
+
+# extract command (parse fault fails loud; absent field defaults to empty)
+COMMAND=$(echo "$STDIN_INPUT" | jq -r '.tool_input.command // empty') || {
+  echo "🦉 route.foreground guard: failed to parse command from tool input json" >&2
+  exit 1
+}
+
+# skip if empty command
+if [[ -z "$COMMAND" ]]; then
+  exit 0
+fi
+
+######################################################################
+# match route.stone.set across the three invocation forms
+######################################################################
+
+IS_STONE_SET=false
+
+# form 1: rhx route.stone.set
+if [[ "$COMMAND" =~ (^|[[:space:]])rhx[[:space:]]+route\.stone\.set([[:space:]]|$) ]]; then
+  IS_STONE_SET=true
+fi
+
+# form 2: npx rhachet run --skill route.stone.set
+if [[ "$COMMAND" =~ npx[[:space:]]+rhachet[[:space:]]+run[[:space:]].*--skill[[:space:]]+route\.stone\.set([[:space:]]|$) ]]; then
+  IS_STONE_SET=true
+fi
+
+# form 3: ./node_modules/.bin/rhx route.stone.set
+# anchored to node_modules/.bin/rhx so an unrelated path like other/bin/rhx
+# does not falsely match — the vision names this exact bin path.
+if [[ "$COMMAND" =~ node_modules/\.bin/rhx[[:space:]]+route\.stone\.set([[:space:]]|$) ]]; then
+  IS_STONE_SET=true
+fi
+
+# allow if the command is not route.stone.set
+if [[ "$IS_STONE_SET" != "true" ]]; then
+  exit 0
+fi
+
+######################################################################
+# block: backgrounded route.stone.set
+######################################################################
+
+# print block message to stderr (claude shows this to the agent)
+{
+  echo ""
+  print_block_message
+  echo ""
+} >&2
+
+exit 2


### PR DESCRIPTION
fix(driver): block route.stone.set in background via foreground guard hook

- add route.foreground.guard PreToolUse hook (bhrain driver-skill, --mode hook)
  that blocks backgrounded route.stone.set and guides to the foreground
- mirror the extant route.mutate.guard pattern with a companion owl .output.sh
- fail loud when jq is absent (exit 2) or stdin json is malformed (exit 1)
- anchor the .bin/rhx form to node_modules/.bin/rhx for path precision
- wire the hook into getDriverRole onTool (Bash, before) + unit-test the bind
- 54-case integration suite covers block, allow, and infra-failure paths;
  every output variant is snapshotted

---
🐢🌊 surfed in by seaturtle[bot]