### PR TITLE
fix(route): failfast on unparseable reviewer output; add reviewer-output contract

### DIFF
--- a/.behavior/v2026_07_05.fix-reviewer-malfunction/.bind/vlad.fix-reviewer-malfunction.flag
+++ b/.behavior/v2026_07_05.fix-reviewer-malfunction/.bind/vlad.fix-reviewer-malfunction.flag
@@ -1,0 +1,2 @@
+branch: vlad/fix-reviewer-malfunction
+bound_by: init.behavior skill

--- a/.behavior/v2026_07_05.fix-reviewer-malfunction/.reviews/peer/.gitignore
+++ b/.behavior/v2026_07_05.fix-reviewer-malfunction/.reviews/peer/.gitignore
@@ -1,0 +1,3 @@
+# ignore all peer-review files
+*
+!.gitignore

--- a/.behavior/v2026_07_05.fix-reviewer-malfunction/.route/.bind.vlad.fix-reviewer-malfunction.flag
+++ b/.behavior/v2026_07_05.fix-reviewer-malfunction/.route/.bind.vlad.fix-reviewer-malfunction.flag
@@ -1,0 +1,2 @@
+branch: vlad/fix-reviewer-malfunction
+bound_by: route.bind skill

--- a/.behavior/v2026_07_05.fix-reviewer-malfunction/.route/.bouncer.cache.json
+++ b/.behavior/v2026_07_05.fix-reviewer-malfunction/.route/.bouncer.cache.json
@@ -1,0 +1,3 @@
+{
+  "protections": []
+}

--- a/.behavior/v2026_07_05.fix-reviewer-malfunction/.route/.gitignore
+++ b/.behavior/v2026_07_05.fix-reviewer-malfunction/.route/.gitignore
@@ -1,0 +1,5 @@
+# ignore all except passage.jsonl and .bind flags
+*
+!.gitignore
+!passage.jsonl
+!.bind.*

--- a/.behavior/v2026_07_05.fix-reviewer-malfunction/.route/passage.jsonl
+++ b/.behavior/v2026_07_05.fix-reviewer-malfunction/.route/passage.jsonl
@@ -1,0 +1,22 @@
+{"stone":"1.vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-grounded-in-reality"}
+{"stone":"1.vision","status":"blocked","blocker":"approval","reason":"wait for human approval"}
+{"stone":"1.vision","status":"blocked","blocker":"approval","reason":"wait for human approval"}
+{"stone":"1.vision","status":"approved"}
+{"stone":"1.vision","status":"passed"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.self","reason":"review.self required: has-pruned-yagni"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.self","reason":"review.self required: behavior-declaration-adherance"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer","reason":"blockers exceed threshold (4 > 0)"}
+{"stone":"5.1.execution.from_vision","status":"malfunction"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer","reason":"blockers exceed threshold (4 > 0)"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer.exhausted","reason":"peer reviewer budget exhausted: repo-rules, arch-opport-decomposition"}
+{"stone":"5.1.execution.from_vision","status":"overruled","level":1}
+{"stone":"5.1.execution.from_vision","status":"overruled","level":3}
+{"stone":"5.1.execution.from_vision","status":"approved"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer","reason":"no review files found for hash aaae61cf"}
+{"stone":"5.1.execution.from_vision","status":"blocked"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer","reason":"no review files found for hash 752fe91c"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer","reason":"no review files found for hash b59f9182"}
+{"stone":"5.1.execution.from_vision","status":"blocked"}
+{"stone":"5.1.execution.from_vision","status":"blocked","blocker":"review.peer","reason":"no review files found for hash 70f8a1b6"}
+{"stone":"5.1.execution.from_vision","status":"blocked"}
+{"stone":"5.1.execution.from_vision","status":"passed"}

--- a/.behavior/v2026_07_05.fix-reviewer-malfunction/0.wish.md
+++ b/.behavior/v2026_07_05.fix-reviewer-malfunction/0.wish.md
@@ -1,0 +1,28 @@
+wish =
+
+if a peer reviewer invoked via route guard peer-reviews does not explicitly declare a `blocker.$n` or `nitpick.$n` format declaration
+
+or explicitly say `blockers = none` or `nitpicks = none`
+
+then we should failfast
+
+as its likely the reviewer did not emit their review in a parseable format 
+
+---
+
+how do the guards extract the number of blockers and nitpicks from a reviewer's stdout?
+
+we must failfast if we cant definitively detect blockers 0 and nitpicks 0
+or some other quant of blockers and nitpicks from the stdout
+
+---
+
+that way, folks dont think that their reviewers have approved when in reality we just didnt see how they labeled the blockers and nitpicks
+
+we need to failfast 
+
+---
+
+also, we need to create a brief on the exact contract that we expect from reviewers as an output
+
+so that if someone wants to `rhx enroll claude --roles x,y,z` to enroll a reviewer loosely. if they include `reviewer` as one of the roles, they'll get the briefs required to conform to the contract successfully

--- a/.behavior/v2026_07_05.fix-reviewer-malfunction/1.vision.guard
+++ b/.behavior/v2026_07_05.fix-reviewer-malfunction/1.vision.guard
@@ -1,0 +1,89 @@
+# guard for vision stone
+#
+# requires human approval before stone can be marked as passed
+# because the self-review prompts require human feedback,
+# the process needs to halt here for human review
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism approved? --stone $stone --route $route
+
+reviews:
+  self:
+    - slug: has-grounded-in-reality
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        did the junior ground the vision in reality, or make things up?
+
+        check the groundwork section:
+
+        for external references (APIs, services, docs):
+        - did they actually verify these exist?
+        - did they cite what they checked?
+        - or did they assume without sanity check?
+
+        for internal references (extant behavior, patterns, code):
+        - did they actually verify what that behavior is?
+        - did they verify extant contracts to conform to? (interfaces, types, signatures)
+        - did they verify extant vocab to reuse? (domain terms, name patterns)
+        - did they verify extant stdouts to match? (CLI output patterns, error formats)
+        - did they cite specific files/lines?
+        - or did they assume the code works a certain way without verification?
+
+        this is NOT about exhaustive research — just sanity checks.
+        the question is: is this vision coherent with reality, or built on assumptions?
+
+    - slug: has-questioned-requirements
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any requirements that should be questioned?
+
+        for each requirement, ask:
+        - who said this was needed? when? why?
+        - what evidence supports this requirement?
+        - what if we didn't do this — what would happen?
+        - is the scope too large, too small, or misdirected?
+        - could we achieve the goal in a simpler way?
+
+        challenge each requirement and justify why it belongs.
+
+    - slug: has-questioned-assumptions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any hidden assumptions the junior took as requirements?
+
+        for each assumption, ask:
+        - what do we assume here without evidence?
+        - what evidence supports this assumption?
+        - what if the opposite were true?
+        - did the wisher actually say this, or did we infer it?
+        - what exceptions or counterexamples exist?
+
+        surface all hidden assumptions and question each one.
+
+    - slug: has-questioned-questions
+      say: |
+        a junior recently modified files in this repo. we need to carefully
+        review the vision due to this.
+
+        are there any open questions? triage them:
+
+        for each question, ask:
+        - can this be answered via logic now? if so, answer it now.
+        - can this be answered via extant docs or code now? if so, answer it now.
+        - should this be answered via external research later? if so, mark it for research.
+        - does only the wisher know the answer? if so, ask the wisher.
+
+        for each question, ensure it is clearly marked as either:
+        - [answered] — resolved now
+        - [research] — to be answered in the research phase
+        - [wisher] — requires wisher input
+
+        ensure they're enumerated within the vision under "open questions & assumptions"
+
+  peer: []

--- a/.behavior/v2026_07_05.fix-reviewer-malfunction/1.vision.stone
+++ b/.behavior/v2026_07_05.fix-reviewer-malfunction/1.vision.stone
@@ -1,0 +1,70 @@
+illustrate the vision implied in the wish .behavior/v2026_07_05.fix-reviewer-malfunction/0.wish.md
+
+emit into .behavior/v2026_07_05.fix-reviewer-malfunction/1.vision.yield.md
+
+---
+
+paint a picture of what the world looks like when this wish is fulfilled
+
+testdrive the contract we propose via realworld examples
+
+specifically,
+
+## the outcome world
+
+- what does a day-in-the-life look like with this in place?
+- what's the before/after contrast?
+- what's the "aha" moment where the value clicks?
+
+## user experience
+
+- what usecases do folks fulfill? what goals?
+- what contract inputs & outputs do they leverage?
+- what would it look like to leverage them?
+- what timelines do they go through?
+
+## mental model
+
+- how would users describe this to a friend?
+- what analogies or metaphors fit?
+- what terms would they use vs what terms would we use?
+
+## evaluation
+
+- how well does it solve the goals?
+- what are the pros? the cons?
+- what edgecases exist and how do our contracts keep users in a pit of success?
+
+## open questions & assumptions
+
+- what assumptions have we made?
+- what questions remain unanswered?
+- what must we validate with the wisher before we proceed?
+- what must we research externally?
+
+## groundwork
+
+sanity check the vision against reality. NOT exhaustive research — just enough to know the vision isn't built on false assumptions.
+
+### external research
+
+if the wish references external APIs, services, or docs:
+- did you verify they exist and work the way you assume?
+- cite what you checked (links, key constraints noted)
+- if none referenced, say "none — no external dependencies"
+
+### internal research
+
+if the wish references extant behavior, patterns, or code:
+- did you verify what that behavior actually is?
+- contracts: interfaces, types, signatures to conform to
+- vocab: domain terms, name patterns to reuse
+- stdouts: CLI output patterns, error formats to match
+- cite what you checked (file paths, line numbers)
+- if none referenced, say "none — no extant behavior extended"
+
+## what is awkward?
+
+- what feels off or forced?
+- where does the design fight the user's mental model?
+- what tradeoffs feel uncomfortable?

--- a/.behavior/v2026_07_05.fix-reviewer-malfunction/1.vision.yield.md
+++ b/.behavior/v2026_07_05.fix-reviewer-malfunction/1.vision.yield.md
@@ -1,0 +1,323 @@
+# 1.vision — fix reviewer malfunction
+
+> failfast when a peer reviewer's stdout has no parseable blocker/nitpick declaration, so a silent parse-miss can never masquerade as an approval.
+
+---
+
+## the core defect
+
+today, `getReviewCountsFromContent` (`src/domain.operations/route/guard/getReviewCountsFromContent.ts:5`) does this:
+
+```ts
+return {
+  blockers: blockerMatch?.[1] ? parseInt(blockerMatch[1], 10) : 0,
+  nitpicks: nitpickMatch?.[1] ? parseInt(nitpickMatch[1], 10) : 0,
+};
+```
+
+the `: 0` fallback is the malfunction. it conflates two very different worlds:
+
+| world | reviewer said | parser returns | truth |
+|-------|---------------|----------------|-------|
+| A | `0 blockers` / `blockers: 0` | `0` | ✅ genuinely clean |
+| B | *(no parseable declaration — malformed, truncated, wrong format)* | `0` | ❌ we have **no idea** |
+
+world B is indistinguishable from world A. a reviewer that crashed, timed out mid-emit, or wrote its review in prose without the summary tree is silently counted as **"0 blockers, 0 nitpicks — approved"**. the driver proceeds believing peers blessed the work. they did not. no one looked.
+
+this is a `failhide` — the exact hazard our own briefs forbid (`rule.forbid.failhide`).
+
+---
+
+## the outcome world
+
+### day-in-the-life
+
+a driver on a guarded stone runs `rhx route.stone.set --stone 3.execution --as arrived`. the guard fans out to peer reviewers. one reviewer — say a loosely-enrolled `claude --roles reviewer` — returns a thoughtful review, but emits it as free prose ending in *"looks solid, ship it"*, with no numeric `N blockers` / `N nitpicks` counts and no summary tree.
+
+**before:** guard parses `0/0`, marks the peer as `approved`, driver sails through. the "review" was never actually counted. weeks later a defect ships that a real review would have caught.
+
+**after:** the guard cannot detect a numeric count, so it treats that reviewer as a
+**malfunction** — it renders in the very same reviewer tree the guard already emits (via
+`formatGuardReviewerTree`), using the extant `💥 malfunction` state:
+
+```
+🦉 the way speaks for itself
+   │
+   ├─ r1: mechanic/review (l1, 1/3)
+   │   ├─ approved 8.2s
+   │   ├─ 0 blockers ✓
+   │   ├─ 2 nitpicks 🟠
+   │   └─ review: .reviews/peer/1.execute._.review.i1.<hash>.r1._.given.by_peer.mechanic-review.md
+   │
+   ├─ r2: claude-loose (l1, 1/3)
+   │   ├─ 💥 malfunction
+   │   └─ review: .reviews/peer/1.execute._.review.i1.<hash>.r2._.given.by_peer.claude-loose.md
+   │
+   └─ ✗ judge.1 - blocked [TIME]
+```
+
+the *why* (numeric count absent + the contract to conform to) lives in that reviewer's review
+artifact file, under its `passage blocked` footer — not a new bespoke block. r1 is unaffected;
+only r2, the unreadable reviewer, blocks. the driver now *knows* r2's review didn't land,
+instead of a false `approved`.
+
+> **note — this is the key format decision:** we do *not* invent a new stdout block. the guard
+> already has a `💥 malfunction` state (exit-class `malfunction`, see `getExitCodeClass` →
+> exit 1) rendered by `formatGuardReviewerTree`. the fix makes an *undetectable count* map to
+> that extant malfunction state for that reviewer. no new rendering surface.
+
+### before/after contrast
+
+- **before:** unparseable review → silent `0/0` → false approval → trust erodes when the defect surfaces
+- **after:** unparseable review → loud failfast → reviewer fixed or re-run → trust preserved
+
+### the "aha" moment
+
+> "wait — a review with *zero* blockers and a review we *failed to read* are not the same thing. one is a verdict, the other is silence. we were treating silence as a verdict."
+
+---
+
+## user experience
+
+### usecases & goals
+
+| who | goal |
+|-----|------|
+| **route driver** | trust that "peers approved" means peers actually reviewed and declared counts |
+| **guard author** | know instantly when a wired-up reviewer emits garbage, not discover it downstream |
+| **reviewer author** | have an unambiguous, documented output contract to conform to |
+| **loose enroller** (`rhx enroll claude --roles reviewer`) | receive the briefs that teach the output contract, so a loosely-enrolled reviewer conforms by default |
+
+### contract inputs & outputs
+
+**the parse contract** — `getReviewCountsFromContent` gains a third possible outcome. instead of always returning counts, it distinguishes *declared* from *undeclared*:
+
+```ts
+// conceptual — exact shape decided at design stone
+type ReviewCountsParse =
+  | { detected: true;  blockers: number; nitpicks: number }
+  | { detected: false; reason: string }; // → guard failfasts
+```
+
+a count is **detected** when the stdout contains, for each dimension, an explicit **numeric**
+declaration — `blockers: 3`, `3 blockers`, `2 nitpicks`, and crucially `0 blockers` /
+`blockers: 0` to declare clean. **only a number counts.** word-forms like `blockers = none`
+are *not* supported — a reviewer must state `0 blockers`, not "none".
+
+if **either** dimension has no numeric declaration → `detected: false` → guard failfasts.
+
+> **why numbers only:** one form to parse, one form to teach. "none", "n/a", "no blockers"
+> and friends each invite ambiguity and incidental-mention false-positives. a single numeric
+> contract (`N blockers`) makes detection unambiguous and the brief trivial to state.
+
+**the reviewer output contract (the exact ask of every reviewer):**
+
+> to be counted, a reviewer's stdout MUST contain a **numeric** count for **both** dimensions:
+> - `N blockers` (or `blockers: N`) — where `N` is an integer ≥ 0
+> - `N nitpicks` (or `nitpicks: N`) — where `N` is an integer ≥ 0
+>
+> to declare clean, emit `0 blockers` and `0 nitpicks`. **do not** rely on prose, "none",
+> "n/a", or omission — those are treated as *undeclared* and the guard marks that reviewer a
+> `💥 malfunction`. the canonical form is the `└─ summary` tree from `genReviewOutputStdout`;
+> the minimal valid form is two numeric lines.
+
+**where this contract lives — a brief under the reviewer role:**
+- new brief: `src/domain.roles/reviewer/briefs/contract.reviewer-output.md` (loads to
+  `.agent/repo=bhrain/role=reviewer/briefs/contract.reviewer-output.md`)
+- listed in `src/domain.roles/reviewer/boot.yml` under `always.briefs.say`, so **any**
+  `rhx enroll claude --roles …,reviewer,…` bundles the contract into that clone's context by
+  default — a loose reviewer conforms because it was taught the contract at enroll time.
+
+### what leveraging it looks like
+
+a reviewer, to be counted, ends its stdout with a declaration the parser can see. the canonical form is the summary tree already emitted by `genReviewOutputStdout` (`src/domain.operations/review/genReviewOutputStdout.ts:54`):
+
+```
+   └─ summary
+      ├─ 0 blockers
+      ├─ 2 nitpicks 🟠
+      └─ ...
+```
+
+a loose reviewer that can't emit the full tree can satisfy the contract minimally:
+
+```
+0 blockers
+2 nitpicks
+```
+
+### timeline
+
+1. driver marks stone `arrived`
+2. guard runs each peer reviewer
+3. **new:** guard asserts each reviewer's stdout is parseable → failfast on any that aren't
+4. only parseable reviews contribute to the verdict
+5. driver sees honest pass/block
+
+---
+
+## mental model
+
+### how a user describes it to a friend
+
+> "our review guard used to assume that if it couldn't find any blockers in a reviewer's output, there were none. turns out that's the same as assuming a silent phone means good news. now if the reviewer doesn't clearly say how many blockers and nitpicks it found, we stop and shout instead of pretending it approved."
+
+### analogies
+
+- **the silent phone** — no news ≠ good news. absence of a "blocker" word ≠ absence of blockers.
+- **the unsigned form** — a blank signature line isn't a "no objections"; it's an unprocessed form. reject it, don't file it.
+- **the missing lab result** — a lab that never reported isn't a clean bill of health.
+
+### terms
+
+| we say | users might say |
+|--------|-----------------|
+| unparseable review / parse-miss | "the reviewer didn't answer" |
+| declared vs undeclared counts | "did it actually say, or did we guess?" |
+| failfast on undetected counts | "stop pretending it passed" |
+| reviewer output contract | "the format reviewers have to follow" |
+
+---
+
+## evaluation
+
+### how well it solves the goals
+
+- **directly kills the false-approval path** — the `: 0` failhide is replaced with an explicit `detected: false` → failfast. this is the whole wish.
+- **institutionalizes the contract** — a brief means the expectation is discoverable and bundled at enroll-time, not tribal knowledge.
+
+### pros
+
+- removes a silent-failure class entirely (aligns with `rule.forbid.failhide`, `rule.require.failfast`, `rule.require.failloud`)
+- single parse site owns the decision (aligns with `rule.require.review-standardization-at-parse`)
+- self-documenting failure — the error names the contract brief
+- backward compatible with reviewers that already emit the summary tree (they always declare counts)
+
+### cons / tradeoffs
+
+- **stricter contract may break extant loose reviewers** — any reviewer currently relying on the silent `0/0` will now failfast. this is intended (they were never really reviewing), but it's a behavior change that could surprise.
+- **incidental-match risk** — the parser must count only a *deliberate numeric declaration*, not an incidental mention. prose like "no major blockers here" must NOT read as detected. numbers-only narrows this risk sharply: `0 blockers` is a count; "no blockers" is prose and correctly fails.
+- **partial declaration** — a reviewer that declares blockers but not nitpicks (or vice versa) must failfast, not default the missing one to 0.
+
+### edgecases & pit-of-success
+
+| edgecase | desired behavior |
+|----------|------------------|
+| `0 blockers` / `0 nitpicks` (or `blockers: 0`) | detected, both 0 |
+| `blockers = none` / `no blockers` (word-forms) | **failfast** — not a numeric count |
+| only `3 blockers` present, no nitpick line | **failfast** — nitpicks undeclared |
+| prose review, no numeric counts at all | **failfast** — both undeclared |
+| empty stdout (reviewer crashed) | **failfast** — both undeclared |
+| reviewer exits non-zero already | extant exit-class handled separately; ensure parse-check composes with it, doesn't mask it |
+| the word "blocker" appears in prose but not as a count (e.g. "no major blockers here") | must NOT be counted — only a deliberate numeric count declares |
+
+---
+
+## open questions & assumptions
+
+### assumptions made
+
+1. **the `: 0` fallback is the single root cause.** verified: `getReviewCountsFromContent.ts:19-20` is the only place counts default silently, and it's the shared parse site used by `runStoneGuardReviews.ts:237`, `computeReviewTotalsFromFiles.ts`, and the artifact hydration paths.
+2. **failfast means `MalfunctionError` / exit 1**, since an unparseable reviewer is a tool/reviewer defect the human must fix — not a caller constraint. (to confirm at design stone; could be argued as constraint/exit 2.)
+3. **the clean signal is numeric-only, per wisher** (2026-07-05): the zero declaration must be
+   `0 blockers` / `blockers: 0`, *not* the word-form `blockers = none`. numbers-only keeps
+   detection unambiguous. (open: whether the `# blocker.1` / `# nitpick.2` enumeration headers
+   in the feedback template also count — i.e. tally the markers — is a design-stone question;
+   the *zero* case is settled as numeric.)
+
+### open questions (triaged)
+
+each question is tagged **[answered]** (resolved now via logic/code), **[research]** (verify
+at a later stone), or **[wisher]** (only the wisher can decide).
+
+1. **[answered — wisher, 2026-07-05] exit semantics = malfunction (exit 1).** an unparseable
+   reviewer is a **reviewer malfunction** — the reviewer tool emitted output the guard cannot
+   read. this is the very defect the behavior is named for. the guard raises a
+   `MalfunctionError` for *that reviewer*, surfaced as the owl `guard.review.peer` block. (i
+   had leaned constraint/exit 2; the wisher settled it as malfunction, which also reads truer
+   — the reviewer is broken, not the caller's request.)
+2. **[answered — wisher, 2026-07-05] per-reviewer grain, surfaced as that reviewer's blocker.**
+   the guard fans out and runs each peer reviewer independently. for *each* reviewer, if the
+   guard cannot detect a numeric blocker/nitpick count from its stdout, it raises a malfunction
+   for **that reviewer alone** — the reviewer's outcome becomes a blocker, never a silent
+   approval. r1/r3 passing is unaffected; only the unreadable reviewer blocks. each reviewer
+   yields its own artifact in `runStoneGuardReviews`, so this grain is natural. (design stone
+   confirms exact integration point.)
+3. **[wisher] retro-compat grace:** any extant reviewers in the wild we'd knowingly break?
+   hard cut vs transition window is a rollout-risk call only the wisher can weigh. my lean:
+   hard cut — the silent path is a bug, not a feature.
+4. **[answered] contract brief scope:** the brief documents the *canonical* summary tree as
+   preferred and the *minimal* `0 blockers` / `N nitpicks` numeric form as the floor. resolved
+   via logic — both must be accepted so loose reviewers have a low bar while the built-in
+   skill's richer output still conforms.
+5. **[answered] guard-vs-parse ownership of the throw** (surfaced in self-review r2/r3):
+   should the parse function throw on undetected, or should the guard? resolved toward
+   **parse-level detection + guard-level failfast** — the parse function returns a
+   detected/undetected result (honoring `rule.require.review-standardization-at-parse`:
+   decide once at parse), and the guard turns undetected into the failfast. this keeps the
+   4 callers' behavior explicit rather than a hidden throw.
+6. **[research] does `detected` need to be per-dimension?** (surfaced r3): the boolean sketch
+   may be too coarse for partial declarations. verify the right return shape against the
+   downstream callers at the design/execution stone.
+7. **[research] does enroll inject `always.briefs.say`?** (surfaced r2): confirm
+   `rhx enroll claude --roles reviewer` actually reads that boot key and injects the new
+   brief. verify via the external rhachet enroll logic or a test run at execution.
+
+### must-research-externally
+
+none — no external APIs, services, or docs. the two **[research]** items above are *internal*
+verification (return-shape fit; enroll injection mechanism), to be resolved at design/execution.
+
+---
+
+## groundwork
+
+### external research
+
+none — no external dependencies. the wish is entirely about internal parse logic, guard behavior, and role briefs.
+
+### internal research (verified)
+
+**contracts / signatures to conform to:**
+- `getReviewCountsFromContent(input: { content: string }): { blockers: number; nitpicks: number }` — `src/domain.operations/route/guard/getReviewCountsFromContent.ts:5`. this signature will change to express detected/undetected.
+- consumed at `src/domain.operations/route/guard/runStoneGuardReviews.ts:237` (`const counts = getReviewCountsFromContent({ content: stdout })`), which builds `RouteStoneGuardReviewArtifact` (`:245`).
+- also consumed by `computeReviewTotalsFromFiles.ts`, `getAllStoneGuardArtifactsByHash.ts`, `getLatestReviewArtifactForIndex.ts` (per exploration) — all downstream sites must be updated to handle the undetected case without re-parsing.
+
+**accepted formats (from `getReviewCountsFromContent.test.ts`, verified via source):**
+- tree: `├─ 8 blockers 🔴`, `└─ 1 nitpick 🟠`
+- yaml: `blockers: 3`, `nitpicks: 5`
+- prose: `found 12 blockers and 4 nitpicks`
+- singular: `1 blocker`, `0 nitpicks`
+
+**canonical output producer:**
+- `genReviewOutputStdout.ts:54-60` emits the `└─ summary / ├─ N blockers / └─ N nitpicks` tree. reviewers using the `rhx review` skill already conform. the contract brief should point here as the reference implementation.
+
+**reviewer role wiring:**
+- role defined: `src/domain.roles/reviewer/getReviewerRole.ts` (briefs dir + skills dir + `boot.yml`).
+- boot config: `src/domain.roles/reviewer/boot.yml` — `always.briefs.say` is where the new contract brief must be listed so `rhx enroll claude --roles reviewer` bundles it into context.
+- extant briefs live under `.agent/repo=bhrain/role=reviewer/briefs/` (e.g. `review.tactics.md`, `on.rules/rules101.*`).
+
+**standardization rule to honor:**
+- `.agent/repo=.this/role=any/briefs/rule.require.review-standardization-at-parse.md` — the detected/undetected decision must be made once, at parse, and never re-derived downstream.
+
+**ground-truth stdout format the guard actually emits (verified via snapshots):**
+- the per-reviewer tree is rendered by `formatGuardReviewerTree` (`src/domain.operations/route/guard/formatGuardReviewerTree.ts`). header form: `r${index}: ${slug} (l${level}, ${rounds}/${budget})`.
+- exit-class comes from `getExitCodeClass` (`.../getExitCodeClass.ts:12`): `0 → passed`, `2 → constraint`, else `malfunction`.
+- the extant states (from `formatGuardReviewerTree.test.ts.snap`) are: `approved`, `rejected`, `exhausted`, `⠋ inflight`, `💥 malfunction`, `✋ constraint`, `awaits …`. **the fix reuses `💥 malfunction`** — it does NOT add a new state or a bespoke block.
+- the per-reviewer *detail* (stdout/stderr buckets + `passage blocked` footer with `exit code: N 💥`) is built in `runStoneGuardReviews.ts:214-228` via `formatTreeBucket` and written to the review artifact file.
+
+**vocab to reuse:** `blocker`, `nitpick`, `peer`, `self`, `guard`, `stone`, `arrived`/`passed`, `MalfunctionError`/`ConstraintError`, `malfunction`/`constraint` (exit-class), `failfast`/`failloud`.
+
+**stdout/error format to match:** the extant `formatGuardReviewerTree` output under `🦉 the way speaks for itself` — reuse the `💥 malfunction` reviewer state; do not invent a new render surface.
+
+---
+
+## what is awkward?
+
+1. **`0 blockers` as a required signal.** the parser demands a reviewer emit an explicit `0 blockers` line, not merely omit the word. it feels slightly awkward to require a "zero" count rather than treat silence as clean — but that is precisely the point: silence was the bug. the discomfort is the fix at work.
+
+2. **two-sided detection.** a review can be half-parseable (blockers declared, nitpicks not). handling "partial detection → failfast" adds branching that's slightly fiddly, but skipping it would reopen the failhide on one dimension.
+
+3. **incidental word matches.** prose like "no blockers, just cleanup" contains "blockers" — the parser must count only a deliberate *numeric* declaration, never an incidental mention. the numbers-only contract makes this line easy to draw: `0 blockers` counts, "no blockers" does not. this is the subtlest part of the design and deserves care at the design/execution stones.
+
+4. **breaking loose reviewers is a feature that feels like a regression.** anyone who wired up a sloppy reviewer will suddenly see failfasts. that's correct — they were getting fake approvals — but the rollout will feel like "the fix broke my thing." the contract brief + a clear error message pointing to it is how we keep them in the pit of success.

--- a/.behavior/v2026_07_05.fix-reviewer-malfunction/5.1.execution.from_vision.guard
+++ b/.behavior/v2026_07_05.fix-reviewer-malfunction/5.1.execution.from_vision.guard
@@ -1,0 +1,218 @@
+# guard for execution stone (from vision - nano size)
+# includes standardized self-review frame
+
+artifacts:
+  # track execution progress
+  - "$route/5.1.execution.from_vision.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    # 1. minimalism - yagni
+    - slug: has-pruned-yagni
+      say: |
+        review for extras that were not prescribed.
+
+        YAGNI = "you ain't gonna need it"
+
+        for each component in the code, ask:
+        - was this explicitly requested in the vision or criteria?
+        - is this the minimum viable way to satisfy the requirement?
+        - did we add abstraction "for future flexibility"?
+        - did we add features "while we're here"?
+        - did we optimize before we knew it was needed?
+
+        if a component was not requested, delete it or flag it as an open question
+        for the wisher to decide.
+
+    # 2. minimalism - backwards compat
+    - slug: has-pruned-backcompat
+      say: |
+        review for backwards compatibility that was not explicitly requested.
+
+        for each backwards-compat concern in the code, ask:
+        - did the wisher explicitly say to maintain this compatibility?
+        - is there evidence this backwards compat is needed?
+        - or did we assume it "to be safe"?
+
+        if backwards compat was not explicitly requested:
+        1. flag it as an open question for the wisher
+        2. eliminate it if not confirmed as required
+        3. make the open question very clearly reported
+
+    # 3. consistency - mechanisms
+    - slug: has-consistent-mechanisms
+      say: |
+        review for new mechanisms that duplicate extant functionality.
+
+        unless the ask was to refactor, be consistent with extant mechanisms.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). look for extant utilities and patterns.
+
+        then for each new mechanism in the code, ask:
+        - does the codebase already have a mechanism that does this?
+        - do we duplicate extant utilities or patterns?
+        - could we reuse an extant component instead of a new one?
+
+        if a new mechanism duplicates extant functionality:
+        1. replace with the extant mechanism
+        2. or flag as an open question if unsure
+
+    # 4. consistency - conventions
+    - slug: has-consistent-conventions
+      say: |
+        review for divergence from extant names and patterns.
+
+        unless the ask was to refactor, be consistent with extant conventions.
+
+        first, search for related codepaths in the codebase (if not done in prior
+        research stone). identify extant name conventions and patterns.
+
+        then for each name choice in the code, ask:
+        - what name conventions does the codebase use?
+        - do we use a different namespace, prefix, or suffix pattern?
+        - do we introduce new terms when extant terms exist?
+        - does our structure match extant patterns?
+
+        if we diverge from extant conventions:
+        1. align with the extant convention
+        2. or flag as an open question if the extant convention seems wrong
+
+    # 5. review against behavior declaration - coverage
+    - slug: behavior-declaration-coverage
+      say: |
+        review for coverage of the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have omitted
+        requirements or left features unimplemented.
+
+        go through the behavior's vision and wish, then check
+        each requirement against the code line by line:
+        - is every requirement from the vision addressed?
+        - did the junior skip or forget any part of the spec?
+
+        fix all gaps before you continue.
+
+    # 6. review against behavior declaration - adherance
+    - slug: behavior-declaration-adherance
+      say: |
+        review for adherance to the behavior declaration.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have drifted
+        from the spec or implemented items incorrectly.
+
+        go through each file changed in this pr, line by line, and check
+        against the behavior's vision:
+        - does the implementation match what the vision describes?
+        - did the junior misinterpret or deviate from the spec?
+
+        fix all gaps before you continue.
+
+    # 7. review against role standards - adherance
+    - slug: role-standards-adherance
+      say: |
+        review for adherance to mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have introduced
+        bad practices or violated patterns that we require.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - does the code follow mechanic standards correctly?
+        - are there violations of required patterns?
+        - did the junior introduce anti-patterns, bad practices, or deviations from our conventions?
+
+        fix all gaps before you continue.
+
+    # 8. review against role standards - coverage
+    - slug: role-standards-coverage
+      say: |
+        review for coverage of mechanic role standards.
+
+        our systems have detected that a junior touched this pr since your
+        last changes. we need you to be diligent - they may have forgotten
+        best practices or omitted patterns that should be present.
+
+        first, enumerate the rule directories you will check:
+        - list each briefs/ subdirectory relevant to this code
+        - confirm you have not missed any rule categories
+
+        then go through each file changed in this pr, line by line, and check:
+        - are all relevant mechanic standards applied?
+        - are there patterns that should be present but are absent?
+        - did the junior forget to add error handle, validation, tests, types, or other required practices?
+
+        fix all gaps before you continue.
+
+  peer:
+    # --- level 1: cheap reviewers (run first, in parallel) ---
+
+    - slug: repo-rules
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-failhides
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.{prod,test}/pitofsuccess.errors/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-decode-friction
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.{forbid.decode-friction-in-orchestrators,require.orchestrators-as-narrative}.md' --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/rule.{forbid.inline-decode-friction,require.named-transforms}.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/{define.domain-operation-grains,philosophy.transform-orchestrator-separation.[philosophy]}.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-without '**/*.test.ts' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    # --- architect reviews (level 1) ---
+
+    - slug: arch-opport-decomposition
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.prefer.decomposable-architecture.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: arch-smell-scopeleaks
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.scope-leaks.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.architecture/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.domain.operations/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: arch-hazards-maintenance
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.maintenance-hazards.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/practices/rule.require.solve-at-cause.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.errors/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.typedefs/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.narrative/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/readable.comments/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: arch-hazards-behavior
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.behavior-hazards.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/pitofsuccess.procedures/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.prod/evolvable.procedures/*.md.min' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: behavior-intent-coverage
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.require.behavior-intent-coverage.md' --refs '$route/0.wish.md' --refs '$route/1.vision.yield.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.criteria/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: ergo-friction-hazards
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/architect/rule.forbid.friction-hazards.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    # --- level 3: expensive reviewers (run after level 1 is terminal) ---
+
+    - slug: enroll-impl-behavior-intent
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current implementation for omissions or divergences from the wished and envisioned behavioral intent. in particular flag any ergonomic friction that is unaddressed or friction hazards that are not clearly covered with acceptance tests and snaps'
+      budget: 3
+      level: 3
+
+    - slug: enroll-impl-arch-defects
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current implementation for architectural defects and omissions; opports to decompose for recompose, prevent scope leaks, and eliminate maintenance and behavior hazards structurally'
+      budget: 3
+      level: 3
+
+judges:
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3

--- a/.behavior/v2026_07_05.fix-reviewer-malfunction/5.1.execution.from_vision.stamp
+++ b/.behavior/v2026_07_05.fix-reviewer-malfunction/5.1.execution.from_vision.stamp
@@ -1,0 +1,69 @@
+🦉 the way speaks for itself
+
+🗿 route.stone.set
+   ├─ stone = 5.1.execution.from_vision
+   ├─ passage = overruled
+   ├─ guard
+   │  ├─ artifacts
+   │  │   ├─ $route/5.1.execution.from_vision.yield.md
+   │  │   └─ src/**/*
+   │  ├─ reviews
+   │  │   ├─ r1: repo-rules (l1, 3/3)
+   │  │   │   ├─ exhausted, cached
+   │  │   │   ├─ 1 blocker 🔴
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   └─ review: .behavior/v2026_07_05.fix-reviewer-malfunction/.reviews/peer/5.1.execution.from_vision._.review.i3.c50b11c1ebd7f180c2.r1._.given.by_peer.repo-rules.md
+   │  │   ├─ r2: mech-failhides (l1, 3/3)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   └─ review: .behavior/v2026_07_05.fix-reviewer-malfunction/.reviews/peer/5.1.execution.from_vision._.review.i3.c50b11c1ebd7f180c2.r2._.given.by_peer.mech-failhides.md
+   │  │   ├─ r3: mech-decode-friction (l1, 3/3)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   └─ review: .behavior/v2026_07_05.fix-reviewer-malfunction/.reviews/peer/5.1.execution.from_vision._.review.i3.c50b11c1ebd7f180c2.r3._.given.by_peer.mech-decode-friction.md
+   │  │   ├─ r4: arch-opport-decomposition (l1, 3/3)
+   │  │   │   ├─ exhausted, cached
+   │  │   │   ├─ 2 blockers 🔴
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   └─ review: .behavior/v2026_07_05.fix-reviewer-malfunction/.reviews/peer/5.1.execution.from_vision._.review.i3.c50b11c1ebd7f180c2.r4._.given.by_peer.arch-opport-decomposition.md
+   │  │   ├─ r5: arch-smell-scopeleaks (l1, 3/3)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   └─ review: .behavior/v2026_07_05.fix-reviewer-malfunction/.reviews/peer/5.1.execution.from_vision._.review.i3.c50b11c1ebd7f180c2.r5._.given.by_peer.arch-smell-scopeleaks.md
+   │  │   ├─ r6: arch-hazards-maintenance (l1, 3/3)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   └─ review: .behavior/v2026_07_05.fix-reviewer-malfunction/.reviews/peer/5.1.execution.from_vision._.review.i3.c50b11c1ebd7f180c2.r6._.given.by_peer.arch-hazards-maintenance.md
+   │  │   ├─ r7: arch-hazards-behavior (l1, 3/3)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   └─ review: .behavior/v2026_07_05.fix-reviewer-malfunction/.reviews/peer/5.1.execution.from_vision._.review.i3.c50b11c1ebd7f180c2.r7._.given.by_peer.arch-hazards-behavior.md
+   │  │   ├─ r8: behavior-intent-coverage (l1, 3/3)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   └─ review: .behavior/v2026_07_05.fix-reviewer-malfunction/.reviews/peer/5.1.execution.from_vision._.review.i3.c50b11c1ebd7f180c2.r8._.given.by_peer.behavior-intent-coverage.md
+   │  │   ├─ r9: ergo-friction-hazards (l1, 3/3)
+   │  │   │   ├─ approved, cached
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   └─ review: .behavior/v2026_07_05.fix-reviewer-malfunction/.reviews/peer/5.1.execution.from_vision._.review.i4.24f3222e7223044aed.r9._.given.by_peer.ergo-friction-hazards.md
+   │  │   ├─ r10: enroll-impl-behavior-intent (l3, 2/3)
+   │  │   │   ├─ approved 369.5s
+   │  │   │   ├─ 0 blockers ✓
+   │  │   │   ├─ 0 nitpicks ✓
+   │  │   │   └─ review: .behavior/v2026_07_05.fix-reviewer-malfunction/.reviews/peer/5.1.execution.from_vision._.review.i9.70f8a1b6b6101504c1.r10._.given.by_peer.enroll-impl-behavior-intent.md
+   │  │   └─ r11: enroll-impl-arch-defects (l3, 0/3)
+   │  │       ├─ 💥 malfunction
+   │  │       └─ review: .behavior/v2026_07_05.fix-reviewer-malfunction/.reviews/peer/5.1.execution.from_vision._.review.i9.70f8a1b6b6101504c1.r11._.given.by_peer.enroll-impl-arch-defects.md
+   │  └─ judges
+   │      └─ j1: $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 3
+   │          └─ finished 1.3s ✓
+   │
+   └─ the way continues, run
+      └─ rhx route.drive

--- a/.behavior/v2026_07_05.fix-reviewer-malfunction/5.1.execution.from_vision.stone
+++ b/.behavior/v2026_07_05.fix-reviewer-malfunction/5.1.execution.from_vision.stone
@@ -1,0 +1,15 @@
+bootup your mechanic's role via `./node_modules/.bin/rhachet roles boot --repo ehmpathy --role mechanic`
+
+then, execute the vision directly
+- .behavior/v2026_07_05.fix-reviewer-malfunction/1.vision.md
+
+ref:
+- .behavior/v2026_07_05.fix-reviewer-malfunction/0.wish.md
+
+
+---
+
+track your progress
+
+emit todos and check them off into
+- .behavior/v2026_07_05.fix-reviewer-malfunction/5.1.execution.from_vision.yield.md

--- a/.behavior/v2026_07_05.fix-reviewer-malfunction/5.1.execution.from_vision.yield.md
+++ b/.behavior/v2026_07_05.fix-reviewer-malfunction/5.1.execution.from_vision.yield.md
@@ -1,0 +1,167 @@
+# 5.1.execution.from_vision — todos
+
+execute the vision: failfast (per-reviewer `💥 malfunction`) when a reviewer's stdout has no
+numeric blocker/nitpick count, plus a reviewer-output contract brief.
+
+## plan (traced against real code)
+
+the pipeline that makes this work end-to-end:
+1. `getReviewCountsFromContent` parses counts → gains `detected`
+2. `runOneStoneGuardReview` promotes exit 0 + undetected → `exitCode = 1` (malfunction)
+3. artifact footer writes `exit code: 1 💥`
+4. `getAllStoneGuardArtifactsByHash` re-reads footer → `exitClass = 'malfunction'`
+5. `computeReviewPeerVerdict` → verdict `malfunction` (precedence)
+6. `formatGuardReviewerTree` renders `💥 malfunction`
+7. `setStoneAsPassed` blocks passage on any `exitClass === 'malfunction'`
+
+## todos
+
+- [x] **parse**: `getReviewCountsFromContent` returns `{ detected, blockers, nitpicks }`;
+      `detected` = numeric count present for BOTH dimensions (numbers-only)
+- [x] **guard**: `runOneStoneGuardReview` — parse counts before artifact build; if
+      `exitCode === 0 && !detected` → promote to malfunction (exit 1) with a stderr reason
+      that names the contract brief
+- [x] **consumers**: `computeReviewTotalsFromFiles` + `getAllStoneGuardArtifactsByHash` read
+      `.blockers`/`.nitpicks` — still present on the richer return; exit-code footer drives
+      exitClass on re-hydration. no change needed. (types pass.)
+- [x] **brief**: added `src/domain.roles/reviewer/briefs/contract.reviewer-output.md`
+- [x] **boot**: listed the brief in `src/domain.roles/reviewer/boot.yml` `always.briefs.say`
+- [x] **tests (unit)**: `getReviewCountsFromContent.test.ts` — 9 cases incl. undetected,
+      detected-zero, partial-declaration, word-form, empty. 9/9 pass.
+- [x] **tests (integration)**: updated clean-reviewer fixtures to emit BOTH dimensions
+      (old shorthand `blockers: 0` now correctly malfunctions); added case22 (no count →
+      malfunction) + case23 (one dimension → malfunction); resnapped. 90/90 in file.
+- [x] **verify (partial)**: types ✓, format ✓, lint ✓, unit 976/976 ✓, integration 184/184 ✓
+- [ ] **verify (acceptance)**: `--what acceptance --against local --env test` — in progress
+
+## peer-review round i1 (addressed)
+
+- [x] **blocker (mech-decode-friction)**: inline duration regex in the orchestrator — extracted
+      to a named transformer `getDurationMsFromContent` (+ 4 unit cases). orchestrator now reads
+      as narrative. (note: the line was prior code shifted by this change; the extract preserves
+      behavior — 90/90 integration still green.)
+- [x] **blocker (repo-rules / judge-derived-counts)**: FALSE POSITIVE, verified with evidence.
+      `getAllStoneGuardArtifactsByHash` (the re-hydration path the judge reads) uses the SAME
+      `getReviewCountsFromContent` at line 140 — artifact counts and judge counts funnel through
+      ONE shared op, so single-source-of-truth holds and there is no separate regex that can drift.
+      no `runReviewedJudge` exists. approved in i2; flaky-flagged again in i1/i3.
+
+## peer-review round i3 (addressed)
+
+reviewers are highly non-deterministic (arch-opport-decomposition approved in i1+i2, flagged 2 in
+i3; repo-rules flip-flops each round). the three real fixes from i1/i2 all cleared in i3
+(mech-decode-friction ✓, arch-hazards-behavior/immutable-vars ✓, behavior-intent-coverage ✓).
+
+- [x] **blocker (ergo-friction-hazards / friction not snapped)**: LEGITIMATE. case22 asserted
+      exitClass/stderr but did not snapshot the user-visible malfunction output. added a
+      `toMatchSnapshot` on `{ exitCode, exitClass, stdout, stderr }` (91/91 in file).
+- [x] **opportunistic**: absorbed the duplicate duration regex at
+      `getAllStoneGuardArtifactsByHash:146` into the new `getDurationMsFromContent` transformer —
+      proves reuse (most-common-denominator) and removes decode-friction from a 2nd caller.
+- [x] **blocker (arch-opport-decomposition / get One/All cardinality)**: FALSE POSITIVE vs local
+      convention. the guard dir reserves One/All for entity lookups
+      (`getOneRouteStoneGuardReviewPeerMeter`, `getAllStoneGuardArtifactsByHash`); scalar-compute
+      transformers omit it (`getReviewCountsFromContent`, `getExitCodeClass`,
+      `getMaxStoneGuardIteration`, `getGitBlobHashes`, `getReviewedJudgeThresholds`). a rename to
+      `getOneDurationMsFromContent` would break consistency with 8 siblings. held per
+      has-consistent-conventions.
+
+## peer-review round i5 (L3 enroll reviewers — addressed)
+
+both L3 reviewers (enroll-impl-*) emitted PROSE counts (`### blocker`), so the feature under
+test promoted them to `💥 malfunction` — a live dogfood of the wish. their prose still carried
+substantive findings, weighed below.
+
+- [x] **blocker (r11 #1 / dead code)**: LEGITIMATE. `isFilePresent` (+ its `isENOENT` import) had
+      no caller in the 733-line file. removed both.
+- [x] **blocker (r11 #2 / duplicated git-root lookup)**: LEGITIMATE. the try/catch
+      getGitRepoRoot+cwd fallback appeared twice. extracted `getRepoRootWithFallback` transformer
+      (+2 integration cases); both call sites now share it.
+- [x] **blocker (r11 #3 / mutable let)**: RESOLVED by #2 — both `let repoRoot`/`let gitRoot`
+      became `const`; removed the earlier `.note` deliberate-mutation band-aids.
+- [x] **nitpick (r10 / no nitpicks-only mirror)**: LEGITIMATE. added case7b (nitpicks-only →
+      undetected), mirror of case7.
+- [x] **blocker (r11 #2 sub-claim / `'Not Inside'` vs `'Not inside'` case mismatch)**: FALSE —
+      hallucination. both sites read `'Not inside a Git'` identically. no latent bug.
+- [x] **blocker (r10 / cases 1-10 redundant ops) + r11 #4-8**: HELD. prior structural debt in
+      code this 26-line change did not author or touch. per rule.require.review-test-changes +
+      wet-over-dry, a broad refactor of untouched code is out of scope for this bugfix.
+
+verify after L3 round: types ✓, format ✓, lint ✓, guard integration 252/252 ✓.
+
+## L3 report re-audit (full item-by-item — no item dropped)
+
+on re-read, two items i had wrongly held as "prior code" are actually MY code. addressed both.
+
+- [x] **r11 nitpick #6 (hardcoded contract-brief path)**: IN-SCOPE (my malfunction reason).
+      extracted `REVIEWER_OUTPUT_CONTRACT_BRIEF` module const; reason string + comment now
+      reference it so they cannot drift if the brief moves.
+- [x] **bonus (3rd duplicate duration regex)**: found the same inline regex in
+      `getLatestReviewArtifactForIndex.ts` (a 3rd site) — absorbed into `getDurationMsFromContent`
+      too. now all 3 call sites share the transformer.
+- [x] **r10 nitpick #1 (flat return type, no `reason` field)**: HELD WITH REASON. the vision
+      sketched a discriminated union `{detected:true;...} | {detected:false;reason}`. i keep the
+      flat `{detected;blockers;nitpicks}` because: (a) the parser returns *data*; the user-facing
+      *why* is guard policy and is already emitted with a contract-pointing reason; (b) the 3 other
+      callers (`computeReviewTotalsFromFiles`, `getAllStoneGuardArtifactsByHash`,
+      `getLatestReviewArtifactForIndex`) read only `.blockers`/`.nitpicks` and never inspect
+      `detected` — a union would force needless narrowing on them for zero gain. a nitpick,
+      declined with rationale per the "articulate why it holds" norm.
+
+remaining held (genuinely prior, untouched code — out of scope for a 26-line bugfix per
+wet-over-dry + review-test-changes): r10 blocker (cases 1-10 redundant ops), r11 #4
+(reviewOutcome IIFE), #5 (computeVerdicts closure), #7 (formatTimeoutForHuman placement),
+#8 (cachedReview precondition comment).
+
+re-verify: types ✓, format ✓, lint ✓, guard integration 252/252 ✓.
+
+## L3 round i7 (r10 re-review of the improved code — addressed)
+
+r10 re-reviewed after the fixes and CONFIRMED them ("REVIEWER_OUTPUT_CONTRACT_BRIEF constant
+prevents path drift ✓", "case22 ... with snapshot ✓"). new in-scope items, all addressed:
+
+- [x] **N1 (case23 no snapshot)**: LEGITIMATE (my case). added a `toMatchSnapshot` on the
+      one-dimension malfunction output, a mirror of case22. snapshot captures `blockers: 0`-alone →
+      malfunction with the contract-link reason.
+- [x] **N2 (duplicate case7 label)**: LEGITIMATE (my case7b). renumbered the parse cases to a
+      clean sequence: case8 (nitpicks-only), case9 (word-form), case10 (empty). 10/10 pass.
+- [x] **N3 (symlink path unverified)**: VERIFIED LIVE. `.agent/repo=bhrain/role=reviewer/briefs/
+      contract.reviewer-output.md` resolves (tree confirms). the malfunction message path is not
+      dead. no change needed.
+- [x] **B1 (discriminated-union return type)**: HELD WITH REASON (same as r10 nitpick #1 prior).
+      3 callers read only counts, never `detected`; a union forces needless narrow-casts for zero
+      gain. the parser returns data; the why is guard policy, already emitted with a contract link.
+- [x] **B2 (cases 1-3 redundant ops)**: HELD — prior untouched test code, out of scope per
+      wet-over-dry + review-test-changes.
+
+re-verify (i7): types ✓, format ✓, lint ✓, unit 10/10 ✓, integration 92/92 (in-file) ✓,
+guard suite 252/252 ✓.
+
+## L3 round i7 r11 (direct read — surfaced a REAL defect)
+
+on a direct read of the i7 r11 report (not just r10), r11's verdict was "No merge blockers"
+but it raised r11 #2, which turned out to be a genuine latent defect — not a false positive.
+
+- [x] **r11 #2 (first-match count regex)**: LEGITIMATE, a real bug. the prior parser took the
+      FIRST numeric match per dimension, so incidental prose ahead of the summary would deceive
+      it — e.g. `i reviewed the 3 blockers from last round. ... 0 blockers` read 3, not 0. fix:
+      extracted `getLastCountForDimension` that takes the LAST match per dimension (the reviewer's
+      authoritative final declaration). added case11 to lock the behavior. my first patch used
+      `\s+`, which spanned newlines and made `blockers: 3\nnitpicks: 5` read "3 nitpicks" (broke
+      case2). corrected to same-line `[ \t]+` so a number on a prior line cannot bind to a word
+      on the next. 11/11 unit pass.
+- [x] **r11 #1 (promotion-layer scope), #3 (union type), #4 (brief examples), #5 (filename
+      dedup)**: HELD WITH REASON. #3 is the same discriminated-union ask held above (3 callers
+      read only counts). the rest are prior untouched code or duplicate asks already weighed;
+      out of scope for this bugfix per wet-over-dry + review-test-changes.
+
+lesson: the earlier rounds' malfunction verdict masked the fact that r11 still carried one true
+finding. reading BOTH L3 reports directly — not just the confirming one — surfaced the defect.
+
+re-verify (i7 r11): types ✓, format ✓, lint ✓, unit 11/11 ✓, guard integration 253/253 ✓.
+
+## how it renders (ground truth)
+
+an unreadable reviewer promotes to `exitClass = 'malfunction'` → renders in the extant
+`formatGuardReviewerTree` as `💥 malfunction` and blocks passage via `setStoneAsPassed`
+(`r.exitClass === 'malfunction'`). no new render surface, per the vision.

--- a/.behavior/v2026_07_05.fix-reviewer-malfunction/5.3.verification.guard
+++ b/.behavior/v2026_07_05.fix-reviewer-malfunction/5.3.verification.guard
@@ -1,0 +1,291 @@
+artifacts:
+  # track verification progress
+  - "$route/5.3.verification.yield.md"
+  # track actual implementation in src/
+  - "src/**/*"
+
+reviews:
+  self:
+    - slug: has-behavior-coverage
+      say: |
+        double-check: does the verification checklist show every behavior from wish/vision has a test?
+
+        - is every behavior in 0.wish.md covered?
+        - is every behavior in 1.vision.md covered?
+        - can you point to each test file in the checklist?
+
+        **if any behavior lacks a test, write the test NOW.** do not pass this gate with gaps.
+
+    - slug: has-zero-test-skips
+      say: |
+        double-check: did you verify zero skips — and REMOVE any you found?
+
+        - no .skip() or .only() found?
+        - no silent credential bypasses?
+        - no prior failures carried forward?
+
+        **if you found skips, did you remove them and make those tests pass?**
+
+        this is buttonup. skips are gaps. gaps get fixed, not noted.
+
+    - slug: has-all-tests-passed
+      say: |
+        double-check: did all tests pass? prove it.
+
+        **zero unproven claims.** you must cite the exact command and output.
+
+        for each test suite:
+        - what command did you run?
+        - what was the exit code?
+        - how many tests passed?
+
+        example proof:
+        ```
+        $ npm run test:unit
+        > exit 0
+        > 47 tests passed
+        ```
+
+        if you cannot cite the command and output, you did not prove it.
+
+        zero tolerance for extant failures:
+        - "it was already broken" is not an excuse — fix it
+        - "it's unrelated to my changes" is not an excuse — fix it
+        - flaky tests must be stabilized, not tolerated
+        - every failure is your responsibility now
+
+        zero tolerance for fake tests:
+        - tests that always pass are fraud
+        - tests that mock the system under test prove nothingness
+        - tests must verify real behavior
+
+        zero tolerance for credential excuses:
+        - "i don't have creds" means get them or mock them
+        - silent bypasses are forbidden
+        - if creds block tests, that is a BLOCKER — not a deferral
+
+    - slug: has-preserved-test-intentions
+      say: |
+        double-check: did you preserve test intentions?
+
+        for every test you touched:
+        - what did this test verify before?
+        - does it still verify the same behavior after?
+        - did you change what the test asserts, or fix why it failed?
+
+        forbidden:
+        - weaken assertions to make tests pass
+        - remove test cases that "no longer apply"
+        - change expected values to match broken output
+        - delete tests that fail instead of fix code
+
+        the test knew a truth. if it failed, either:
+        - the code is wrong — fix the code
+        - the test has a bug — fix the bug, keep the intention
+        - requirements changed — document why, get approval
+
+        to "fix tests" via changed intent is not a fix — it is at worst
+        malicious deception, at best reckless negligence. unacceptable.
+
+    - slug: has-journey-tests-from-repros
+      say: |
+        double-check: did you implement each journey sketched in repros?
+
+        look back at the repros artifact:
+        - .behavior/v2026_07_05.fix-reviewer-malfunction/3.2.distill.repros.experience.*.md
+
+        for each journey test sketch in repros:
+        - is there a test file for it?
+        - does the test follow the BDD given/when/then structure?
+        - does each `when([tN])` step exist?
+
+        **if any journey was planned but not implemented, go back and add it NOW.**
+
+        this is buttonup. absent journey tests = incomplete implementation.
+        test coverage proves prod coverage. no test = no proof = not done.
+
+    - slug: has-contract-output-variants-snapped
+      say: |
+        double-check: does each public contract have EXHAUSTIVE snapshots?
+
+        **zero gaps in caller experience.** every contract must snap every output variant.
+
+        for each new or modified public contract:
+
+        | contract type | what to snap | required variants |
+        |---------------|--------------|-------------------|
+        | cli command | stdout + stderr | success, error, --help, edge cases |
+        | api endpoint | response body | 2xx, 4xx, 5xx, edge cases |
+        | sdk method | return value | success, error, edge cases |
+
+        checklist per contract:
+        - [ ] positive path (success) is snapped
+        - [ ] negative path (error) is snapped
+        - [ ] help/usage is snapped (for cli)
+        - [ ] edge cases are snapped (empty, invalid, boundary)
+        - [ ] snapshot shows actual output, not placeholder
+
+        why this matters:
+        - snapshots enable vibecheck in prs — reviewers see actual output without execute
+        - snapshots detect drift over time — output changes surface in diffs
+        - absent variants mean blind spots in review
+        - exhaustive coverage proves the contract works for all callers
+
+        **zero leniency.** if a contract lacks any variant, add the test case NOW.
+
+        if you find yourself about to say "this variant isn't worth a snapshot" — stop.
+        that is the variant that will break in prod. snap it.
+
+        this is buttonup. absent snapshots = absent proof. add them or fail this gate.
+
+    - slug: has-snap-changes-rationalized
+      say: |
+        double-check: is every `.snap` file change intentional and justified?
+
+        for each `.snap` file in git diff:
+        1. what changed? (added, modified, deleted)
+        2. was this change intended or accidental?
+        3. if intended: what is the rationale?
+        4. if accidental: revert it or explain why the new output is an improvement
+
+        common regressions caught here:
+        - output format degraded (lost alignment, lost structure)
+        - error messages became less helpful
+        - timestamps or ids leaked into snapshots (flaky)
+        - extra output added unintentionally
+
+        forbidden:
+        - "updated snapshots" without per-file rationale
+        - bulk snapshot updates without review
+        - regressions accepted without justification
+
+        every snap change tells a story. make sure the story is intentional.
+
+    - slug: has-critical-paths-frictionless
+      say: |
+        double-check: are the critical paths frictionless in practice?
+
+        look back at the repros artifact for critical paths:
+        - .behavior/v2026_07_05.fix-reviewer-malfunction/3.2.distill.repros.experience.*.md
+
+        for each critical path:
+        - run through it manually — is it smooth?
+        - are there unexpected errors?
+        - does it feel effortless to the user?
+
+        critical paths must "just work." if there's friction, fix it now.
+
+    - slug: has-ergonomics-validated
+      say: |
+        double-check: does the actual input/output match what felt right at repros?
+
+        compare the implemented input/output to what was sketched in repros:
+        - does the actual input match the planned input?
+        - does the actual output match the planned output?
+        - did the design change between repros and implementation?
+
+        if the ergonomics drifted, either:
+        - update repros to reflect the better design, or
+        - fix the implementation to match the planned ergonomics
+
+    - slug: has-play-test-convention
+      say: |
+        double-check: are journey test files named correctly?
+
+        journey tests should use `.play.test.ts` suffix:
+        - `feature.play.test.ts` — journey test
+        - `feature.play.integration.test.ts` — if repo requires integration runner
+        - `feature.play.acceptance.test.ts` — if repo requires acceptance runner
+
+        verify:
+        - are journey tests in the right location?
+        - do they have the `.play.` suffix?
+        - if not supported, is the fallback convention used?
+
+    - slug: has-fixed-all-gaps
+      say: |
+        final buttonup check: did you FIX every gap you found, or just detect it?
+
+        **this is the buttonup phase. detection is not enough — you must fix.**
+
+        look back at all the reviews above. for every gap you identified:
+        - absent test coverage → did you WRITE the test?
+        - absent prod coverage → did you IMPLEMENT the behavior?
+        - failed test → did you FIX the code or test?
+        - skipped test → did you REMOVE the skip and make it pass?
+
+        **zero omissions.** if any review above surfaced a gap, that gap must be fixed before you pass this gate.
+
+        ask yourself:
+        - did i just note the gap, or did i actually fix it?
+        - is there any item marked "todo" or "later"? (forbidden)
+        - is there any coverage marked incomplete? (forbidden)
+
+        **if you detected it, you fixed it.** prove it with citations.
+
+        this is the final self-review. you are about to hand off to peer review.
+        prove that all items above were addressed — not deferred.
+
+  peer:
+    # --- level 1: cheap reviewers (run first, in parallel) ---
+
+    - slug: repo-rules
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=.this/**/rule.*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: ergo-contract-snapshots
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-external-contracts
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.external-contract-integration-tests.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.remote-boundaries.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: ergo-acceptance-journey-coverage
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.require.acceptance-journey-coverage.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/*.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: ergo-snapshot-visual-blemishes
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.execution/ergonomist/rule.forbid.snapshot-visual-blemishes.md' --refs '.agent/repo=ehmpathy/role=ergonomist/briefs/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/lang.tones/*.md.min' --refs '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.require.contract-snapshot-exhaustiveness.md' --diffs since-main --paths-with '**/*.{ts,sh}' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-given-when-then
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/rule.require.given-when-then.md' --refs '.agent/repo=ehmpathy/role=architect/briefs/criteria.given_when_then.[seed].v3.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/frames.behavior/*.md.min' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/lessons.howto/*.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-test-intent
+      run: $rhx review --repo bhrain --mode hard --rules '.agent/repo=bhuild/role=behaver/briefs/practices/behavior.verification/rule.forbid.test-intent-violations.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/*.md' --refs '.agent/repo=ehmpathy/role=mechanic/briefs/practices/work.flow/refactor/rule.require.review-test-changes.md.min' --diffs since-main --paths-with '**/*.test.ts' --paths-with '**/*.snap' --join intersect --output "$output"
+      budget: 3
+      level: 1
+
+    - slug: mech-test-scope-purity
+      run: $rhachet run --repo bhrain --skill review --rules '.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.coverage/rule.require.test-coverage-by-grain.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.unit/rule.forbid.unit.remote-boundaries.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.integration/rule.forbid.integration.mocks.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.acceptance/rule.forbid.acceptance.mocks.md,.agent/repo=ehmpathy/role=mechanic/briefs/practices/code.test/scope.acceptance/rule.require.acceptance.blackbox.md' --diffs since-main --paths-with '{src,blackbox}/**/*.test.ts' --join intersect --output "$output" --mode hard
+      budget: 3
+      level: 1
+
+    # --- level 3: expensive reviewers (run after level 1 is terminal) ---
+
+    - slug: enroll-verif-snapshot-coverage
+      run: $rhx enroll claude --model sonnet --roles behaver,ergonomist,mechanic -p 'review the diff for snapshot coverage on contract endpoints and acceptance test user journey coverage'
+      budget: 3
+      level: 3
+
+    - slug: enroll-verif-snapshot-blemishes
+      run: $rhx enroll claude --model sonnet --roles behaver,ergonomist,mechanic -p 'review the diff for experiential and visual blemishes in snapshotted acceptance test journeys'
+      budget: 3
+      level: 3
+
+    - slug: enroll-verif-test-intent
+      run: $rhx enroll claude --model sonnet --roles behaver,architect,mechanic -p 'review the current implementation for test intent violation diffs. if any of the diffs related to tests loosened assertions or changed the criteria, this is a blocker. tests were added for a reason. we have to maintain the behavior they locked in'
+      budget: 3
+      level: 3
+
+judges:
+  # enforce peer reviews pass with zero blockers
+  - $rhachet run --repo bhrain --skill route.stone.judge --mechanism reviewed? --stone $stone --route $route --allow-blockers 0 --allow-nitpicks 0

--- a/.behavior/v2026_07_05.fix-reviewer-malfunction/5.3.verification.stone
+++ b/.behavior/v2026_07_05.fix-reviewer-malfunction/5.3.verification.stone
@@ -1,0 +1,304 @@
+prove the deliverable works via test verification — fix all gaps
+
+---
+
+## .what
+
+this is the verification gate — the **buttonup phase**.
+
+you cannot pass execution without proof that all tests pass. more importantly: **test coverage enforces prod coverage**. if tests are absent, prod is incomplete. if prod is incomplete, fix it.
+
+## .the buttonup mandate: zero omissions
+
+**this is not a detection phase. this is a completion phase.**
+
+when you find a gap, you do not note it and move on. you **fix it**.
+
+| gap type | action |
+|----------|--------|
+| absent test coverage | write the test NOW |
+| absent prod coverage | implement the behavior NOW |
+| failed test | fix the code or fix the test NOW |
+| skipped test | remove the skip and make it pass NOW |
+
+**if you detect it, you fix it. no exceptions.**
+
+## .strictness: zero tolerance, zero exceptions
+
+**this gate enforces absolute standards. there is no leniency.**
+
+| constraint | definition |
+|------------|------------|
+| zero deferrals | you cannot defer any test to later. all tests pass now or you fail. |
+| zero fake tests | tests must verify real behavior. assertions that always pass are fraud. |
+| zero unproven claims | every claim of "test passes" must cite the exact command run and output. |
+| zero credential excuses | "i don't have creds" is not an excuse. get them, mock them, or fail. |
+| zero skips | .skip() and .only() are forbidden. silent bypasses are forbidden. |
+| zero exceptions | there are no special cases. the rules apply to all. |
+| zero omissions | if you find a gap in coverage, you fix it — test or prod. |
+
+**if a blocker prevents tests from run, that is a BLOCKER. full stop.**
+
+you do not proceed. you do not defer. you fix it or you fail the gate.
+
+## .why
+
+**why does this gate exist?**
+
+your crew is about to review a pr you wrote. they need proof it works — not words, proof. tests are that proof.
+
+**test coverage drives prod coverage.** if a behavior lacks a test, that behavior is unproven. unproven behaviors are incomplete deliverables. the test proves the implementation exists and works.
+
+without this gate:
+- tests might fail and nobody notices
+- tests might be skipped and nobody notices
+- behaviors might lack coverage and nobody notices
+- broken code ships to peers
+- incomplete implementations slip through
+
+with this gate:
+- every test passes or you fix it
+- every behavior has coverage or you add it
+- every skip is removed or justified
+- proven code ships to peers
+- **gaps get fixed, not deferred**
+
+**the cardinal rules**:
+1. never leave behavior without true, dependable test coverage
+2. never offload work onto your crew unless there is truly, fundamentally no other option
+3. never claim a test passes without cite of the exact command and output
+
+you fix it yourself. you exhaust every option: debug, research, try alternatives. only when you hit a wall that is physically impossible to climb alone — credentials only the foreman possesses, access only they can grant — only then may you ask for help.
+
+## .how
+
+reference the below for full context
+- .behavior/v2026_07_05.fix-reviewer-malfunction/0.wish.md
+- .behavior/v2026_07_05.fix-reviewer-malfunction/1.vision.md
+- .behavior/v2026_07_05.fix-reviewer-malfunction/2.1.criteria.blackbox.md (if declared)
+- .behavior/v2026_07_05.fix-reviewer-malfunction/3.2.distill.repros.experience.*.md (if declared) ← **repros artifact**
+
+---
+
+### step 1: emit verification checklist
+
+emit to
+- .behavior/v2026_07_05.fix-reviewer-malfunction/5.3.verification.yield.md
+
+this is your roadmap. emit it first, then work through it step by step.
+
+**checklist structure:**
+
+```
+## verification checklist
+
+### behavior coverage (with reference to repros)
+
+for each journey sketched in repros, verify it was implemented with snapshots.
+
+| journey (from repros) | test file | snapshots? | critical path? | ergonomics ok? | status |
+|-----------------------|-----------|------------|----------------|----------------|--------|
+| {journey 1}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+| {journey 2}           | {path}    | ✓ / ✗      | ✓ frictionless / needs work | ✓ natural / needs work | ⏳ |
+...
+
+### zero skips verified
+- [ ] no .skip() or .only() found
+- [ ] no silent credential bypasses
+- [ ] no prior failures carried forward
+
+### snapshot coverage for contract outputs
+
+each public contract needs dedicated snapshots that demonstrate its stdout for:
+- **vibechecks in prs** — reviewers see actual output without executing code
+- **drift detection** — changes to output surface in diffs over time
+
+| contract | output variants | snapshot file | status |
+|----------|-----------------|---------------|--------|
+| {command 1} | success, error, help | {path.snap} | ⏳ |
+| {command 2} | success, error, help | {path.snap} | ⏳ |
+...
+
+checklist:
+- [ ] every new cli command has `.snap` snapshots for stdout/stderr
+- [ ] every new app screen has `.snap` snapshots for screenshots
+- [ ] every new sdk method has `.snap` snapshots for responses
+- [ ] each output variant is exercised (success, error, edge cases)
+- [ ] snapshots demonstrate actual output, not just "it ran"
+
+### snapshot change rationalization
+
+for each `.snap` file changed, rationalize whether the change was intended or accidental:
+
+| snap file | change type | intended? | rationale |
+|-----------|-------------|-----------|-----------|
+| {path.snap} | added / modified / deleted | yes / no | {why this change is correct} |
+...
+
+checklist:
+- [ ] every `.snap` change has been reviewed
+- [ ] intended changes have clear rationale
+- [ ] accidental changes have been reverted or justified as improvements
+
+### tests executed — with proof
+
+**every test run must be proven with exact command and output.**
+
+| test suite | command run | result | proof (exit code + summary) |
+|------------|-------------|--------|----------------------------|
+| types | `npm run test:types` | ✓ / ✗ | exit 0, no errors |
+| lint | `npm run test:lint` | ✓ / ✗ | exit 0, no errors |
+| format | `npm run test:format` | ✓ / ✗ | exit 0, no errors |
+| unit | `npm run test:unit` | ✓ / ✗ | exit 0, N tests passed |
+| integration | `npm run test:integration` | ✓ / ✗ | exit 0, N tests passed |
+| acceptance | `npm run test:acceptance` | ✓ / ✗ | exit 0, N tests passed |
+
+checklist:
+- [ ] every test command was run (not "i think it passed")
+- [ ] every test command output was observed (not assumed)
+- [ ] the exact exit code was verified (0 = pass, non-zero = fail)
+- [ ] no tests were skipped, mocked, or faked
+
+**zero unproven claims.** if you claim a test passes, cite the command and output.
+
+### contract output snapshot exhaustiveness
+
+**every user-faced contract must have exhaustive snapshot coverage.**
+
+| contract type | contract | positive path snapped? | negative path snapped? | edge cases snapped? |
+|---------------|----------|------------------------|------------------------|---------------------|
+| cli | {command} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| api | {endpoint} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+| sdk | {method} | ✓ / ✗ | ✓ / ✗ | ✓ / ✗ |
+
+checklist:
+- [ ] every cli command has stdout/stderr snapshots for success, error, and help
+- [ ] every api endpoint has response snapshots for success and error codes
+- [ ] every sdk method has return value snapshots for success and error
+- [ ] every contract has edge case snapshots (empty input, invalid input, boundary)
+
+**zero gaps in caller experience.** the reviewer must see exactly what callers see.
+
+### blockers
+- none (or list handoff references)
+```
+
+update the checklist as you complete each step below.
+
+---
+
+### step 2: verify AND FIX behavior coverage
+
+walk through wish and vision:
+- every behavior promised must have an acceptance test
+- for each behavior, you can point to the test file
+- no behavior left untested
+
+**why?** your crew trusts the test suite. if a behavior isn't tested, it isn't proven. untested behaviors are unverified promises.
+
+**test coverage enforces prod coverage.** if a test is absent, either:
+1. the behavior was not implemented → IMPLEMENT IT NOW
+2. the behavior was implemented without a test → WRITE THE TEST NOW
+
+if a behavior lacks a test, **write one NOW**. do not move on with gaps. update your checklist when done.
+
+---
+
+### step 3: verify AND FIX zero skips
+
+scan for forbidden patterns:
+- `.skip()` or `.only()` in test files
+- `if (!credentials) return` or similar silent bypasses
+- prior failures carried forward (known-broken tests)
+
+**why?** failures are better than skips. skips hide problems. failures expose them. a skipped test is a lie — it pretends coverage exists when it doesn't.
+
+**this is buttonup.** if you find skips:
+1. REMOVE the skip
+2. MAKE the test pass (fix the code or fix the test)
+3. update your checklist
+
+do not note skips and move on. fix them. all tests must run.
+
+---
+
+### step 4: run all tests AND FIX all failures
+
+run each test suite and **cite the exact command and output**.
+
+```bash
+npm run test:types      # cite exit code
+npm run test:lint       # cite exit code
+npm run test:format     # cite exit code
+npm run test:unit       # cite exit code + test count
+npm run test:integration # cite exit code + test count
+npm run test:acceptance  # cite exit code + test count
+```
+
+all must pass — no exceptions. no deferrals. no "i'll fix it later."
+
+**this is buttonup.** if tests fail, fix them. that is the job.
+
+failures indicate one of:
+1. prod code is broken → FIX THE PROD CODE
+2. test has a bug → FIX THE TEST BUG (preserve intention)
+3. coverage gap exists → FILL THE GAP
+
+**consider all failures as defects from this pr.** there are no "prior failures."
+
+if a test was broken before you started — fix it. if a test is flaky — fix it. if a test fails for reasons unrelated to your changes — fix it anyway. you do not get to say "that was already broken." you are here now. you fix it.
+
+**take initiative. take ownership.**
+
+**preserve test intentions.** when you fix a test, you fix why it failed — not what it tests. to change what a test verifies is not a fix. it is at worst malicious deception, at best reckless negligence. the test knew a truth. if it fails, either the code is wrong or the test has a bug. fix the cause, not the assertion.
+
+**zero fake tests.** a test that always passes is fraud. a test that skips is a lie. a test that mocks the system under test proves nothingness. tests must verify real behavior against real code.
+
+**escalation path:**
+1. debug the failure — read the error, understand the cause
+2. research — search for similar issues, read docs
+3. try alternatives — different approach, different tool
+4. ask for help — other resources, other clones
+5. deeper research — exhaust every option
+6. only if insurmountable — emit handoff (see step 5)
+
+**ask yourself at each level:**
+- did i read the error message carefully?
+- did i search for similar issues?
+- did i try a different approach?
+- did i isolate the problem?
+- did i ask for help?
+- did i exhaust every option?
+
+you move to handoff only when you can answer "yes" to all of the above and still cannot proceed.
+
+update your checklist when all tests pass.
+
+---
+
+### step 5: handoff (only if insurmountable)
+
+a handoff is a document that transfers work to your foreman because you hit a wall that is physically impossible to climb alone.
+
+**foreman-only blockers:**
+- credentials only the foreman possesses
+- external access only the foreman can grant
+- approval that requires foreman authority
+
+handoff is the absolute last resort. you must exhaust every option before you consider it.
+
+if you need to emit a handoff:
+
+emit to
+- .behavior/v2026_07_05.fix-reviewer-malfunction/5.3.verification.handoff.v$N.to_foreman.md
+
+**handoff must include:**
+1. what you tried (list every approach you attempted)
+2. why each approach failed (be specific)
+3. what makes this fundamentally impossible without foreman intervention
+4. is this truly a "foreman possesses the key" situation?
+5. rewind instruction: `rhx route.stone.set --stone 5.3.verification --as rewound`
+
+your crew should read your handoff and think: "yes, there was truly no other way."
+
+update your checklist to reference the handoff.

--- a/.behavior/v2026_07_05.fix-reviewer-malfunction/blocker/5.1.execution.from_vision.md
+++ b/.behavior/v2026_07_05.fix-reviewer-malfunction/blocker/5.1.execution.from_vision.md
@@ -1,0 +1,97 @@
+# blocker: 5.1.execution.from_vision
+
+## what blocks me
+
+the stone is gated only by the two L3 `enroll-impl-*` peer reviewers (r10
+`enroll-impl-behavior-intent`, r11 `enroll-impl-arch-defects`). all 9 L1 reviewers have
+approved and are cached.
+
+those two L3 reviewers emit their blocker/nitpick counts as **prose** (`### blocker 🔴`,
+`| blocker | severity |` tables), NOT the numeric `N blockers` / `N nitpicks` format. that
+numeric format is the exact contract this very PR introduces
+(`contract.reviewer-output.md`). because their output carries no numeric count, the
+feature-under-test **correctly** promotes each to `💥 malfunction`, which blocks passage.
+
+this is a genuine contradiction i cannot settle from inside this codebase: the repo's own
+L3 reviewer brains do not yet conform to the numeric-count contract this PR adds, and i
+cannot change how an external `rhx enroll claude` reviewer brain formats its stdout. every
+future round will reproduce the same malfunction.
+
+additionally, the most recent background arrival stalled on r10 (output frozen across many
+stop-hook cycles; claude-code is on the known-good `2.1.87` pin, so this is slowness/stall,
+not the old version bug).
+
+## what i tried
+
+- **drove the peer rounds i1–i5.** each round the L1 reviewers converged to approve; the
+  reviewers are non-deterministic (arch-opport-decomposition and repo-rules each flip-flopped
+  approve/reject across rounds on byte-identical code).
+- **addressed every substantive finding raised**, real or not:
+  - decode-friction: extracted `getDurationMsFromContent` transformer (+ absorbed a duplicate
+    duration regex in `getAllStoneGuardArtifactsByHash`).
+  - immutable-vars: extracted `getRepoRootWithFallback`, turning two `let` git-root lookups
+    into `const` and deduping them.
+  - dead code: removed unused `isFilePresent` + `isENOENT` import.
+  - friction-not-snapped: added a snapshot to case22 (malfunction output).
+  - test coverage: added case7b (nitpicks-only → undetected mirror of case7).
+- **verified the false positives with evidence**: judge-derived-counts (judge's re-hydration
+  path uses the same shared op), get One/All cardinality (8 sibling transformers omit it),
+  and the `'Not Inside'`/`'Not inside'` case-mismatch claim (both sites identical — a
+  hallucination).
+- **confirmed green**: types ✓, format ✓, lint ✓, guard integration 252/252 ✓, plus the 2
+  previously-regressed acceptance files (guard-cwd, artifact-expansion) 35/35 ✓.
+- the human already approved the L1 reviewers; passage still blocks on the L3 malfunctions.
+
+## update (after 2 more L3 rounds)
+
+i kept the route moving. addressed every in-scope L3 item across rounds i5→i7:
+- r11 #6 (hardcoded brief path) → `REVIEWER_OUTPUT_CONTRACT_BRIEF` const
+- found + absorbed a 3rd duplicate duration regex (`getLatestReviewArtifactForIndex`)
+- i7 N1 (case23 snapshot) → added; N2 (case label) → renumbered; N3 (symlink) → verified live
+- r10's i7 re-review CONFIRMED the fixes ("constant prevents path drift ✓", "case22 snapshot ✓")
+
+held-with-reason: discriminated-union return type (3 callers read only counts) and the
+cases-1–3 redundant-ops (prior untouched test code). still green: types/format/lint,
+guard suite 252/252.
+
+the L3 reviewers STILL malfunction — because they emit prose counts, which my feature
+correctly rejects. this will not change no matter how many items i clear. it is inherent.
+
+## update (i7 r11 direct read — a REAL defect surfaced + fixed)
+
+on a direct read of BOTH L3 reports (not just the r10 that agreed), r11 — despite its "No
+merge blockers" verdict — carried one true item i had not yet cleared:
+
+- **r11 #2 (first-match count regex)**: LEGITIMATE. the parser took the FIRST numeric match
+  per dimension, so incidental prose ahead of the summary would deceive it (e.g. "i reviewed
+  the 3 blockers from last round. ... 0 blockers" read 3, not 0). fixed: `getLastCountForDimension`
+  now takes the LAST match (the authoritative final declaration), anchored to same-line
+  whitespace so a count on a prior line cannot bind to a word on the next. added case11 to lock it.
+
+this is the value of the wish itself: even a reviewer that malfunctions still carries
+substantive findings that matter. a direct read of both reports caught a genuine correctness
+bug. now green: types, format, lint, unit 11/11, guard integration 253/253.
+
+## the L1 rejects that remain are exhausted false-positives
+
+two L1 reviewers are frozen at "exhausted, 3/3" with reject verdicts:
+- r1 repo-rules (1 blocker) — the judge-derived-counts claim, verified FALSE (one shared op)
+- r4 arch-opport-decomposition (2 blockers) — the get-One/All cardinality claim, verified FALSE
+  (8 peer scalar-compute transformers omit One/All by local convention)
+
+both flip-flopped approve/reject across rounds on byte-identical code; their budgets are spent,
+so they cannot re-review to their prior approvals. these too need human overrule.
+
+## what i need
+
+a human decision, since only a human can `--as approved` or `--as overruled`:
+
+1. **overrule the L3 malfunctions and approve the stone** — if you agree the code is complete
+   and the L3 reviewers' prose-format output (not the code) is what fails the contract; or
+2. **update the L3 `enroll-impl-*` reviewers to emit numeric counts** so they can conform to
+   the new contract and re-run cleanly; or
+3. **investigate the r10 stall** if you believe the L3 round should have completed by now.
+
+my recommendation: option 1 (overrule + approve). the feature works exactly as designed — it
+caught two reviewers that violate the output contract. that is the wish succeeding, not the
+code failing.

--- a/.behavior/v2026_07_05.fix-reviewer-malfunction/refs/template.[feedback].v1.[given].by_human.md
+++ b/.behavior/v2026_07_05.fix-reviewer-malfunction/refs/template.[feedback].v1.[given].by_human.md
@@ -1,0 +1,27 @@
+emit your response to the feedback into
+- .behavior/v2026_07_05.fix-reviewer-malfunction/$BEHAVIOR_REF_NAME.[feedback].v$FEEDBACK_VERSION.[taken].by_robot.md
+
+1. emit your response checklist
+2. exec your response plan
+3. emit your response checkoffs into the checklist
+
+---
+
+first, bootup your mechanics briefs again
+
+./node_modules/.bin/rhachet roles boot --repo ehmpathy --role mechanic
+
+---
+---
+---
+
+
+# blocker.1
+
+---
+
+# nitpick.2
+
+---
+
+# blocker.3

--- a/.behavior/v2026_07_05.fix-reviewer-malfunction/review/self/.gitignore
+++ b/.behavior/v2026_07_05.fix-reviewer-malfunction/review/self/.gitignore
@@ -1,0 +1,3 @@
+# ignore all self-review files
+*
+!.gitignore

--- a/blackbox/.test/assets/route-artifact-expansion/1.vision.guard
+++ b/blackbox/.test/assets/route-artifact-expansion/1.vision.guard
@@ -2,7 +2,7 @@ artifacts:
   - $route/1.vision*.md
 
 reviews:
-  - bash -c 'if [ -f "$route/1.vision.md" ]; then echo "blockers: 0"; echo "artifact present at $route"; else echo "blockers: 1"; echo "artifact absent at $route"; fi'
+  - bash -c 'if [ -f "$route/1.vision.md" ]; then echo "blockers: 0"; echo "nitpicks: 0"; echo "artifact present at $route"; else echo "blockers: 1"; echo "nitpicks: 0"; echo "artifact absent at $route"; fi'
 
 judges:
   - rhx route.stone.judge --mechanism approved? --stone $stone --route $route

--- a/blackbox/.test/assets/route-guard-cwd/1.vision.guard
+++ b/blackbox/.test/assets/route-guard-cwd/1.vision.guard
@@ -2,7 +2,7 @@ artifacts:
   - $route/1.vision*.md
 
 reviews:
-  - bash -c 'if [ -f "$route/1.vision.md" ]; then echo "blockers: 0"; echo "artifact present at $route"; else echo "blockers: 1"; echo "artifact absent at $route"; fi'
+  - bash -c 'if [ -f "$route/1.vision.md" ]; then echo "blockers: 0"; echo "nitpicks: 0"; echo "artifact present at $route"; else echo "blockers: 1"; echo "nitpicks: 0"; echo "artifact absent at $route"; fi'
 
 judges:
   - rhx route.stone.judge --mechanism approved? --stone $stone --route $route

--- a/src/domain.operations/route/guard/__snapshots__/runStoneGuardReviews.integration.test.ts.snap
+++ b/src/domain.operations/route/guard/__snapshots__/runStoneGuardReviews.integration.test.ts.snap
@@ -113,6 +113,7 @@ exports[`runStoneGuardReviews given: [case3] review exits with code 0 (passed) w
 │  ├─
 │  │
 │  │  blockers: 0
+│  │  nitpicks: 0
 │  │  review passed
 │  │
 │  └─
@@ -136,6 +137,7 @@ exports[`runStoneGuardReviews given: [case3] review exits with code 0 (passed) w
     "path": "<route>/.reviews/peer/1.test._.review.i1.case3ret.r1._.given.by_peer.echo.md",
     "stderr": "",
     "stdout": "blockers: 0
+nitpicks: 0
 review passed
 ",
     "stone": {
@@ -374,6 +376,7 @@ exports[`runStoneGuardReviews given: [case15] l1 malfunction does not block l3 e
     "path": "<route>/.reviews/peer/1.test._.review.i1.tierescalate.r2._.given.by_peer.l3-checker.md",
     "stderr": "",
     "stdout": "blockers: 0
+nitpicks: 0
 ",
     "stone": {
       "path": "<route>/1.test.stone",
@@ -413,6 +416,7 @@ exports[`runStoneGuardReviews given: [case16] l1 constraint does not block l3 ex
     "path": "<route>/.reviews/peer/1.test._.review.i1.tierconstraint.r2._.given.by_peer.l3-checker.md",
     "stderr": "",
     "stdout": "blockers: 0
+nitpicks: 0
 ",
     "stone": {
       "path": "<route>/1.test.stone",
@@ -469,6 +473,7 @@ exports[`runStoneGuardReviews given: [case17] multiple l1 malfunctions do not bl
     "path": "<route>/.reviews/peer/1.test._.review.i1.multil1mal.r3._.given.by_peer.l3-checker.md",
     "stderr": "",
     "stdout": "blockers: 0
+nitpicks: 0
 ",
     "stone": {
       "path": "<route>/1.test.stone",
@@ -525,6 +530,7 @@ exports[`runStoneGuardReviews given: [case18] mixed l1 terminal states (malfunct
     "path": "<route>/.reviews/peer/1.test._.review.i1.mixedl1.r3._.given.by_peer.l3-checker.md",
     "stderr": "",
     "stdout": "blockers: 0
+nitpicks: 0
 ",
     "stone": {
       "path": "<route>/1.test.stone",
@@ -547,6 +553,7 @@ exports[`runStoneGuardReviews given: [case19] l1 passed + l1 malfunction still a
     "path": "<route>/.reviews/peer/1.test._.review.i1.partiall1.r1._.given.by_peer.l1-good.md",
     "stderr": "",
     "stdout": "blockers: 0
+nitpicks: 0
 ",
     "stone": {
       "path": "<route>/1.test.stone",
@@ -581,6 +588,7 @@ exports[`runStoneGuardReviews given: [case19] l1 passed + l1 malfunction still a
     "path": "<route>/.reviews/peer/1.test._.review.i1.partiall1.r3._.given.by_peer.l3-checker.md",
     "stderr": "",
     "stdout": "blockers: 0
+nitpicks: 0
 ",
     "stone": {
       "path": "<route>/1.test.stone",
@@ -637,6 +645,7 @@ exports[`runStoneGuardReviews given: [case20] three-level cascade: l1 malfunctio
     "path": "<route>/.reviews/peer/1.test._.review.i1.3levelcascade.r3._.given.by_peer.l3-checker.md",
     "stderr": "",
     "stdout": "blockers: 0
+nitpicks: 0
 ",
     "stone": {
       "path": "<route>/1.test.stone",
@@ -707,10 +716,31 @@ exports[`runStoneGuardReviews given: [case21] all l1 terminal (malfunction+const
     "path": "<route>/.reviews/peer/1.test._.review.i1.alll1term.r4._.given.by_peer.l3-checker.md",
     "stderr": "",
     "stdout": "blockers: 0
+nitpicks: 0
 ",
     "stone": {
       "path": "<route>/1.test.stone",
     },
   },
 ]
+`;
+
+exports[`runStoneGuardReviews given: [case22] reviewer exits 0 but emits no numeric count (unparseable) when: [t0] reviews are executed then: the malfunction output matches snapshot 1`] = `
+{
+  "exitClass": "malfunction",
+  "exitCode": 1,
+  "stderr": "💥 malfunction: reviewer output lacks a numeric blocker/nitpick count (expected \`N blockers\` and \`N nitpicks\`; use \`0 blockers\` / \`0 nitpicks\` to declare clean). see .agent/repo=bhrain/role=reviewer/briefs/contract.reviewer-output.md",
+  "stdout": "looks solid, ship it
+",
+}
+`;
+
+exports[`runStoneGuardReviews given: [case23] reviewer exits 0 but declares only one dimension when: [t0] reviews are executed then: the malfunction output matches snapshot 1`] = `
+{
+  "exitClass": "malfunction",
+  "exitCode": 1,
+  "stderr": "💥 malfunction: reviewer output lacks a numeric blocker/nitpick count (expected \`N blockers\` and \`N nitpicks\`; use \`0 blockers\` / \`0 nitpicks\` to declare clean). see .agent/repo=bhrain/role=reviewer/briefs/contract.reviewer-output.md",
+  "stdout": "blockers: 0
+",
+}
 `;

--- a/src/domain.operations/route/guard/getAllStoneGuardArtifactsByHash.ts
+++ b/src/domain.operations/route/guard/getAllStoneGuardArtifactsByHash.ts
@@ -8,6 +8,7 @@ import { RouteStoneGuardReviewArtifact } from '@src/domain.objects/Driver/RouteS
 
 import { enumRouteGuardJudgeFiles } from './enumRouteGuardJudgeFiles';
 import { enumRouteGuardReviewPeerFiles } from './enumRouteGuardReviewPeerFiles';
+import { getDurationMsFromContent } from './getDurationMsFromContent';
 import { getExitCodeClass } from './getExitCodeClass';
 import { getReviewCountsFromContent } from './getReviewCountsFromContent';
 
@@ -141,10 +142,8 @@ const parseReviewMetadata = (
   const blockers = counts.blockers;
   const nitpicks = counts.nitpicks;
 
-  // parse duration from content
-  // format: "└─ total: 51455ms" under metrics.realized > time
-  const durationMatch = content.match(/total:\s*(\d+)ms/i);
-  const durationMs = durationMatch?.[1] ? parseInt(durationMatch[1], 10) : null;
+  // parse duration from content via shared operation
+  const durationMs = getDurationMsFromContent({ content });
 
   // parse exit code from tree bucket format
   const exitCodeMatch = content.match(/exit code:\s*(\d+)/);

--- a/src/domain.operations/route/guard/getDurationMsFromContent.test.ts
+++ b/src/domain.operations/route/guard/getDurationMsFromContent.test.ts
@@ -1,0 +1,53 @@
+import { given, then, when } from 'test-fns';
+
+import { getDurationMsFromContent } from './getDurationMsFromContent';
+
+describe('getDurationMsFromContent', () => {
+  given('[case1] content with a total duration line', () => {
+    const content = '└─ total: 51455ms';
+
+    when('[t0] parsed', () => {
+      then('it returns the numeric milliseconds', () => {
+        const durationMs = getDurationMsFromContent({ content });
+        expect(durationMs).toEqual(51455);
+      });
+    });
+  });
+
+  given('[case2] content with the duration embedded in a larger tree', () => {
+    const content = [
+      '   ✨ metrics.realized',
+      '      └─ time',
+      '         └─ total: 24238ms',
+    ].join('\n');
+
+    when('[t0] parsed', () => {
+      then('it extracts the milliseconds', () => {
+        const durationMs = getDurationMsFromContent({ content });
+        expect(durationMs).toEqual(24238);
+      });
+    });
+  });
+
+  given('[case3] content with no duration line', () => {
+    const content = 'looks solid, ship it';
+
+    when('[t0] parsed', () => {
+      then('it returns null', () => {
+        const durationMs = getDurationMsFromContent({ content });
+        expect(durationMs).toBeNull();
+      });
+    });
+  });
+
+  given('[case4] empty content', () => {
+    const content = '';
+
+    when('[t0] parsed', () => {
+      then('it returns null', () => {
+        const durationMs = getDurationMsFromContent({ content });
+        expect(durationMs).toBeNull();
+      });
+    });
+  });
+});

--- a/src/domain.operations/route/guard/getDurationMsFromContent.ts
+++ b/src/domain.operations/route/guard/getDurationMsFromContent.ts
@@ -1,0 +1,13 @@
+/**
+ * .what = extracts the review duration in milliseconds from review content
+ * .why = encapsulates regex extraction so the orchestrator reads as narrative
+ *
+ * format: "└─ total: 51455ms" under metrics.realized > time.
+ * returns null when no duration line is present.
+ */
+export const getDurationMsFromContent = (input: {
+  content: string;
+}): number | null => {
+  const durationMatch = input.content.match(/total:\s*(\d+)ms/i);
+  return durationMatch?.[1] ? parseInt(durationMatch[1], 10) : null;
+};

--- a/src/domain.operations/route/guard/getLatestReviewArtifactForIndex.ts
+++ b/src/domain.operations/route/guard/getLatestReviewArtifactForIndex.ts
@@ -6,6 +6,7 @@ import type { RouteStone } from '@src/domain.objects/Driver/RouteStone';
 import { RouteStoneGuardReviewArtifact } from '@src/domain.objects/Driver/RouteStoneGuardReviewArtifact';
 
 import { enumRouteGuardReviewPeerFiles } from './enumRouteGuardReviewPeerFiles';
+import { getDurationMsFromContent } from './getDurationMsFromContent';
 import { getExitCodeClass } from './getExitCodeClass';
 import { getReviewCountsFromContent } from './getReviewCountsFromContent';
 
@@ -81,9 +82,8 @@ export const getLatestReviewArtifactForIndex = async (input: {
   // parse blockers and nitpicks from stdout
   const counts = getReviewCountsFromContent({ content });
 
-  // parse duration from content
-  const durationMatch = content.match(/total:\s*(\d+)ms/i);
-  const durationMs = durationMatch?.[1] ? parseInt(durationMatch[1], 10) : null;
+  // parse duration from content via shared operation
+  const durationMs = getDurationMsFromContent({ content });
 
   // parse exit code from tree bucket format
   const exitCodeMatch = content.match(/exit code:\s*(\d+)/);

--- a/src/domain.operations/route/guard/getRepoRootWithFallback.integration.test.ts
+++ b/src/domain.operations/route/guard/getRepoRootWithFallback.integration.test.ts
@@ -1,0 +1,43 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { given, then, useThen, when } from 'test-fns';
+
+import { getRepoRootWithFallback } from './getRepoRootWithFallback';
+
+describe('getRepoRootWithFallback', () => {
+  given('[case1] a path inside this git repo', () => {
+    when('[t0] looked up', () => {
+      const found = useThen('resolves a root', async () => ({
+        root: await getRepoRootWithFallback({ from: __dirname }),
+      }));
+
+      then('returns the git repo root (contains package.json)', async () => {
+        const hasPackageJson = await fs
+          .access(path.join(found.root, 'package.json'))
+          .then(() => true)
+          .catch(() => false);
+        expect(hasPackageJson).toBe(true);
+      });
+    });
+  });
+
+  given('[case2] a temp dir that is not a git repo', () => {
+    const tempDir = path.join(os.tmpdir(), `test-reporoot-${Date.now()}`);
+
+    beforeEach(async () => {
+      await fs.mkdir(tempDir, { recursive: true });
+    });
+
+    afterEach(async () => {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    });
+
+    when('[t0] looked up', () => {
+      then('falls back to process.cwd()', async () => {
+        const root = await getRepoRootWithFallback({ from: tempDir });
+        expect(root).toEqual(process.cwd());
+      });
+    });
+  });
+});

--- a/src/domain.operations/route/guard/getRepoRootWithFallback.ts
+++ b/src/domain.operations/route/guard/getRepoRootWithFallback.ts
@@ -1,0 +1,23 @@
+import { getGitRepoRoot } from 'rhachet-artifact-git';
+
+/**
+ * .what = looks up the git repo root, with a cwd fallback when not in a git repo
+ * .why = guard paths relativize against the repo root; integration tests run in temp
+ *        dirs that are not git repos, so a cwd fallback keeps them functional.
+ *        shared so the two guard call sites cannot drift apart.
+ */
+export const getRepoRootWithFallback = async (input: {
+  from: string;
+}): Promise<string> => {
+  try {
+    return await getGitRepoRoot({ from: input.from });
+  } catch (error) {
+    // only catch "not in git repo" error; rethrow any other errors
+    // .note = check error message instead of instanceof due to cross-module class instances
+    const isNotInGitRepoError =
+      error instanceof Error && error.message.includes('Not inside a Git');
+    if (!isNotInGitRepoError) throw error;
+
+    return process.cwd();
+  }
+};

--- a/src/domain.operations/route/guard/getReviewCountsFromContent.test.ts
+++ b/src/domain.operations/route/guard/getReviewCountsFromContent.test.ts
@@ -31,8 +31,9 @@ describe('getReviewCountsFromContent', () => {
 │  └─`;
 
     when('[t0] parsed', () => {
-      then('extracts correct counts', () => {
+      then('extracts correct counts and detects both', () => {
         const counts = getReviewCountsFromContent({ content });
+        expect(counts.detected).toBe(true);
         expect(counts.blockers).toBe(8);
         expect(counts.nitpicks).toBe(1);
       });
@@ -44,8 +45,9 @@ describe('getReviewCountsFromContent', () => {
 nitpicks: 5`;
 
     when('[t0] parsed', () => {
-      then('extracts correct counts', () => {
+      then('extracts correct counts and detects both', () => {
         const counts = getReviewCountsFromContent({ content });
+        expect(counts.detected).toBe(true);
         expect(counts.blockers).toBe(3);
         expect(counts.nitpicks).toBe(5);
       });
@@ -56,36 +58,119 @@ nitpicks: 5`;
     const content = `found 12 blockers and 4 nitpicks in the review`;
 
     when('[t0] parsed', () => {
-      then('extracts correct counts', () => {
+      then('extracts correct counts and detects both', () => {
         const counts = getReviewCountsFromContent({ content });
+        expect(counts.detected).toBe(true);
         expect(counts.blockers).toBe(12);
         expect(counts.nitpicks).toBe(4);
       });
     });
   });
 
-  given('[case4] no blockers or nitpicks', () => {
+  given('[case4] prose with no numeric counts', () => {
     const content = `all good, no issues found`;
 
     when('[t0] parsed', () => {
-      then('returns zeros', () => {
+      then('is undetected (must not silently read as zero)', () => {
         const counts = getReviewCountsFromContent({ content });
+        expect(counts.detected).toBe(false);
+      });
+    });
+  });
+
+  given('[case5] singular blocker/nitpick with explicit zero', () => {
+    const content = `├─ 1 blocker 🔴
+└─ 0 nitpicks`;
+
+    when('[t0] parsed', () => {
+      then('extracts correct counts and detects both', () => {
+        const counts = getReviewCountsFromContent({ content });
+        expect(counts.detected).toBe(true);
+        expect(counts.blockers).toBe(1);
+        expect(counts.nitpicks).toBe(0);
+      });
+    });
+  });
+
+  given('[case6] explicit zeros for both dimensions', () => {
+    const content = `0 blockers
+0 nitpicks`;
+
+    when('[t0] parsed', () => {
+      then('detects both as a clean review', () => {
+        const counts = getReviewCountsFromContent({ content });
+        expect(counts.detected).toBe(true);
         expect(counts.blockers).toBe(0);
         expect(counts.nitpicks).toBe(0);
       });
     });
   });
 
-  given('[case5] singular blocker/nitpick', () => {
-    const content = `├─ 1 blocker 🔴
-└─ 0 nitpicks`;
+  given('[case7] only blockers declared, nitpicks absent', () => {
+    const content = `3 blockers`;
 
     when('[t0] parsed', () => {
-      then('extracts correct counts', () => {
+      then('is undetected (nitpicks dimension absent)', () => {
         const counts = getReviewCountsFromContent({ content });
-        expect(counts.blockers).toBe(1);
-        expect(counts.nitpicks).toBe(0);
+        expect(counts.detected).toBe(false);
       });
     });
   });
+
+  given('[case8] only nitpicks declared, blockers absent', () => {
+    const content = `2 nitpicks`;
+
+    when('[t0] parsed', () => {
+      then('is undetected (blockers dimension absent)', () => {
+        const counts = getReviewCountsFromContent({ content });
+        expect(counts.detected).toBe(false);
+      });
+    });
+  });
+
+  given('[case9] word-form "none" is not a numeric count', () => {
+    const content = `blockers = none
+nitpicks = none`;
+
+    when('[t0] parsed', () => {
+      then('is undetected (numbers-only contract)', () => {
+        const counts = getReviewCountsFromContent({ content });
+        expect(counts.detected).toBe(false);
+      });
+    });
+  });
+
+  given('[case10] empty stdout (reviewer crashed)', () => {
+    const content = ``;
+
+    when('[t0] parsed', () => {
+      then('is undetected', () => {
+        const counts = getReviewCountsFromContent({ content });
+        expect(counts.detected).toBe(false);
+      });
+    });
+  });
+
+  given(
+    '[case11] incidental prose count precedes the authoritative summary',
+    () => {
+      // a reviewer that mentions an earlier count in prose then declares the real
+      // count last — the authoritative declaration is the LAST one, not the first
+      const content = `i reviewed the 3 blockers from last round. all fixed.
+0 blockers
+0 nitpicks`;
+
+      when('[t0] parsed', () => {
+        then(
+          'takes the last declaration, not the incidental first mention',
+          () => {
+            const counts = getReviewCountsFromContent({ content });
+            expect(counts.detected).toBe(true);
+            expect(counts.blockers).toBe(0);
+            expect(counts.nitpicks).toBe(0);
+          },
+        );
+      });
+    },
+  );
 });

--- a/src/domain.operations/route/guard/getReviewCountsFromContent.ts
+++ b/src/domain.operations/route/guard/getReviewCountsFromContent.ts
@@ -1,22 +1,59 @@
 /**
+ * .what = extracts the last numeric count for a single dimension from review content
+ * .why = the authoritative count is the reviewer's final declaration (typically the summary),
+ *        so we take the LAST occurrence — a first-match would be fooled by incidental prose
+ *        like "i reviewed the 3 blockers from last round. 0 blockers remain." (grabs 3, not 0).
+ *
+ * matches both numeric forms in one pass, in document order:
+ *   1. "blockers: N" (yaml/key-value form from review tools)
+ *   2. "N blockers"  (tree/prose form from skill output)
+ * returns undefined when the dimension carries no numeric declaration.
+ */
+const getLastCountForDimension = (input: {
+  content: string;
+  stem: 'blocker' | 'nitpick';
+}): number | undefined => {
+  // .note = the "N word" form uses same-line whitespace ([ \t]+, not \s+) so a number on a
+  //         prior line cannot bind to a word on the next (e.g. "blockers: 3\nnitpicks: 5"
+  //         must not read "3 nitpicks"). count declarations are always single-line.
+  const pattern = new RegExp(
+    `${input.stem}s?:\\s*(\\d+)|(\\d+)[ \\t]+${input.stem}s?`,
+    'gi',
+  );
+  const matches = [...input.content.matchAll(pattern)];
+  const lastMatch = matches.at(-1);
+  const value = lastMatch ? (lastMatch[1] ?? lastMatch[2]) : undefined;
+  return value !== undefined ? parseInt(value, 10) : undefined;
+};
+
+/**
  * .what = extracts blocker and nitpick counts from review content
  * .why = encapsulates regex extraction for readability
+ *
+ * .detected = whether BOTH dimensions carry an explicit numeric count.
+ *   a reviewer must state a number for each (e.g. `0 blockers`, `2 nitpicks`).
+ *   when a dimension has no numeric count, detected = false — the caller must NOT
+ *   treat an absent count as zero. see rule.forbid.failhide + contract.reviewer-output.
+ *   numbers-only by design: word-forms like "none"/"no blockers" do NOT count.
  */
 export const getReviewCountsFromContent = (input: {
   content: string;
-}): { blockers: number; nitpicks: number } => {
-  // match both formats:
-  // 1. "blockers: N" (yaml/key-value format from review tools)
-  // 2. "N blockers" (tree/prose format from skill output)
-  const blockerMatch =
-    input.content.match(/blockers?:\s*(\d+)/i) ||
-    input.content.match(/(\d+)\s+blockers?/i);
-  const nitpickMatch =
-    input.content.match(/nitpicks?:\s*(\d+)/i) ||
-    input.content.match(/(\d+)\s+nitpicks?/i);
+}): { detected: boolean; blockers: number; nitpicks: number } => {
+  const blockerCount = getLastCountForDimension({
+    content: input.content,
+    stem: 'blocker',
+  });
+  const nitpickCount = getLastCountForDimension({
+    content: input.content,
+    stem: 'nitpick',
+  });
+
+  // detected only when both dimensions declared a number
+  const detected = blockerCount !== undefined && nitpickCount !== undefined;
 
   return {
-    blockers: blockerMatch?.[1] ? parseInt(blockerMatch[1], 10) : 0,
-    nitpicks: nitpickMatch?.[1] ? parseInt(nitpickMatch[1], 10) : 0,
+    detected,
+    blockers: blockerCount ?? 0,
+    nitpicks: nitpickCount ?? 0,
   };
 };

--- a/src/domain.operations/route/guard/runStoneGuardReviews.integration.test.ts
+++ b/src/domain.operations/route/guard/runStoneGuardReviews.integration.test.ts
@@ -240,7 +240,12 @@ describe('runStoneGuardReviews', () => {
       artifacts: ['1.test*.md'],
       reviews: {
         self: [],
-        peer: [asPeerReview('echo "blockers: 0\\nreview passed"', 0)],
+        peer: [
+          asPeerReview(
+            'echo "blockers: 0"; echo "nitpicks: 0"; echo "review passed"',
+            0,
+          ),
+        ],
       },
       judges: [],
       protect: [],
@@ -996,7 +1001,7 @@ describe('runStoneGuardReviews', () => {
           {
             slug: 'success-reviewer',
             budget: 3,
-            run: 'echo "blockers: 0"',
+            run: 'echo "blockers: 0"; echo "nitpicks: 0"',
             level: 1,
           },
         ],
@@ -1055,7 +1060,7 @@ describe('runStoneGuardReviews', () => {
           {
             slug: 'cache-reviewer',
             budget: 3,
-            run: 'echo "blockers: 0"',
+            run: 'echo "blockers: 0"; echo "nitpicks: 0"',
             level: 1,
           },
         ],
@@ -1117,7 +1122,7 @@ describe('runStoneGuardReviews', () => {
           {
             slug: 'blocker-reviewer',
             budget: 3,
-            run: 'echo "blockers: 1"',
+            run: 'echo "blockers: 1"; echo "nitpicks: 0"',
             level: 1,
           },
         ],
@@ -1185,7 +1190,7 @@ describe('runStoneGuardReviews', () => {
           {
             slug: 'l3-checker',
             budget: 1,
-            run: 'echo "blockers: 0"',
+            run: 'echo "blockers: 0"; echo "nitpicks: 0"',
             level: 3,
           },
         ],
@@ -1269,7 +1274,7 @@ describe('runStoneGuardReviews', () => {
           {
             slug: 'l3-checker',
             budget: 1,
-            run: 'echo "blockers: 0"',
+            run: 'echo "blockers: 0"; echo "nitpicks: 0"',
             level: 3,
           },
         ],
@@ -1369,7 +1374,7 @@ describe('runStoneGuardReviews', () => {
           {
             slug: 'l3-checker',
             budget: 1,
-            run: 'echo "blockers: 0"',
+            run: 'echo "blockers: 0"; echo "nitpicks: 0"',
             level: 3,
           },
         ],
@@ -1464,7 +1469,7 @@ describe('runStoneGuardReviews', () => {
             {
               slug: 'l3-checker',
               budget: 1,
-              run: 'echo "blockers: 0"',
+              run: 'echo "blockers: 0"; echo "nitpicks: 0"',
               level: 3,
             },
           ],
@@ -1545,7 +1550,7 @@ describe('runStoneGuardReviews', () => {
           {
             slug: 'l1-good',
             budget: 1,
-            run: 'echo "blockers: 0"',
+            run: 'echo "blockers: 0"; echo "nitpicks: 0"',
             level: 1,
           },
           {
@@ -1557,7 +1562,7 @@ describe('runStoneGuardReviews', () => {
           {
             slug: 'l3-checker',
             budget: 1,
-            run: 'echo "blockers: 0"',
+            run: 'echo "blockers: 0"; echo "nitpicks: 0"',
             level: 3,
           },
         ],
@@ -1647,7 +1652,7 @@ describe('runStoneGuardReviews', () => {
             {
               slug: 'l3-checker',
               budget: 1,
-              run: 'echo "blockers: 0"',
+              run: 'echo "blockers: 0"; echo "nitpicks: 0"',
               level: 3,
             },
           ],
@@ -1756,7 +1761,7 @@ describe('runStoneGuardReviews', () => {
           {
             slug: 'l3-checker',
             budget: 1,
-            run: 'echo "blockers: 0"',
+            run: 'echo "blockers: 0"; echo "nitpicks: 0"',
             level: 3,
           },
         ],
@@ -1818,6 +1823,129 @@ describe('runStoneGuardReviews', () => {
           },
         }));
         expect(sanitized).toMatchSnapshot();
+      });
+    });
+  });
+
+  given(
+    '[case22] reviewer exits 0 but emits no numeric count (unparseable)',
+    () => {
+      // .why = a reviewer that succeeds but declares no numeric blocker/nitpick count
+      //        must NOT read as a silent 0/0 approval. it is promoted to malfunction so
+      //        the guard blocks. see rule.forbid.failhide + contract.reviewer-output.
+      const tempDir = path.join(
+        os.tmpdir(),
+        `test-reviews-nocount-${Date.now()}`,
+      );
+      const stone = new RouteStone({
+        name: '1.test',
+        path: path.join(tempDir, '1.test.stone'),
+        guard: null,
+      });
+      const guard = new RouteStoneGuard({
+        path: path.join(tempDir, '1.test.guard'),
+        artifacts: ['1.test*.md'],
+        reviews: {
+          self: [],
+          peer: [asPeerReview('echo "looks solid, ship it"', 0)],
+        },
+        judges: [],
+        protect: [],
+      });
+
+      beforeEach(async () => {
+        await fs.mkdir(tempDir, { recursive: true });
+      });
+
+      afterEach(async () => {
+        await fs.rm(tempDir, { recursive: true, force: true });
+      });
+
+      when('[t0] reviews are executed', () => {
+        const reviews = useThen('runs the reviewer', async () =>
+          runStoneGuardReviews(
+            { stone, guard, hash: 'nocount', iteration: 1, route: tempDir },
+            noopContext,
+          ),
+        );
+
+        then('the reviewer is promoted to malfunction', () => {
+          const artifact = reviews.artifacts[0];
+          expect(artifact?.exitClass).toEqual('malfunction');
+          expect(artifact?.exitCode).toEqual(1);
+        });
+
+        then('the malfunction reason names the contract brief', () => {
+          expect(reviews.artifacts[0]?.stderr).toContain(
+            'contract.reviewer-output.md',
+          );
+        });
+
+        then('the malfunction output matches snapshot', () => {
+          // .why = the reviewer-visible malfunction message is user friction;
+          //        snap it so message regressions surface in prs (rule.require.snapshots)
+          const artifact = reviews.artifacts[0];
+          expect({
+            exitCode: artifact?.exitCode,
+            exitClass: artifact?.exitClass,
+            stdout: artifact?.stdout,
+            stderr: artifact?.stderr,
+          }).toMatchSnapshot();
+        });
+      });
+    },
+  );
+
+  given('[case23] reviewer exits 0 but declares only one dimension', () => {
+    // .why = both dimensions must carry a numeric count; a half-declared review is
+    //        undetectable and must fail as a malfunction, not a partial approval.
+    const tempDir = path.join(os.tmpdir(), `test-reviews-onedim-${Date.now()}`);
+    const stone = new RouteStone({
+      name: '1.test',
+      path: path.join(tempDir, '1.test.stone'),
+      guard: null,
+    });
+    const guard = new RouteStoneGuard({
+      path: path.join(tempDir, '1.test.guard'),
+      artifacts: ['1.test*.md'],
+      reviews: {
+        self: [],
+        peer: [asPeerReview('echo "blockers: 0"', 0)],
+      },
+      judges: [],
+      protect: [],
+    });
+
+    beforeEach(async () => {
+      await fs.mkdir(tempDir, { recursive: true });
+    });
+
+    afterEach(async () => {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    });
+
+    when('[t0] reviews are executed', () => {
+      const reviews = useThen('runs the reviewer', async () =>
+        runStoneGuardReviews(
+          { stone, guard, hash: 'onedim', iteration: 1, route: tempDir },
+          noopContext,
+        ),
+      );
+
+      then('the reviewer is promoted to malfunction', () => {
+        expect(reviews.artifacts[0]?.exitClass).toEqual('malfunction');
+      });
+
+      then('the malfunction output matches snapshot', () => {
+        // .why = one-dimension output is a distinct user-visible friction path; snap it so
+        //        message regressions surface in prs (rule.require.snapshots)
+        const artifact = reviews.artifacts[0];
+        expect({
+          exitCode: artifact?.exitCode,
+          exitClass: artifact?.exitClass,
+          stdout: artifact?.stdout,
+          stderr: artifact?.stderr,
+        }).toMatchSnapshot();
       });
     });
   });

--- a/src/domain.operations/route/guard/runStoneGuardReviews.ts
+++ b/src/domain.operations/route/guard/runStoneGuardReviews.ts
@@ -3,7 +3,6 @@ import * as fs from 'fs/promises';
 import { BadRequestError } from 'helpful-errors';
 import { type IsoDuration, toMilliseconds } from 'iso-time';
 import * as path from 'path';
-import { getGitRepoRoot } from 'rhachet-artifact-git';
 import { promisify } from 'util';
 
 import type { ContextCliEmit } from '@src/domain.objects/Driver/ContextCliEmit';
@@ -21,10 +20,11 @@ import { findsertReviewPeerGitignore } from '../gitignore/findsertReviewPeerGiti
 import { getStoneGuardOverruledLevels } from '../judges/getStoneGuardOverruledLevels';
 import { formatTreeBucket } from './formatTreeBucket';
 import { getAllStoneGuardArtifactsByHash } from './getAllStoneGuardArtifactsByHash';
+import { getDurationMsFromContent } from './getDurationMsFromContent';
 import { getExitCodeClass } from './getExitCodeClass';
 import { getLatestReviewArtifactForIndex } from './getLatestReviewArtifactForIndex';
+import { getRepoRootWithFallback } from './getRepoRootWithFallback';
 import { getReviewCountsFromContent } from './getReviewCountsFromContent';
-import { isENOENT } from './isENOENT';
 import { computeReviewPeerVerdict } from './reviewPeerMeter/computeReviewPeerVerdict';
 import { getAllRouteStoneGuardReviewPeerMeters } from './reviewPeerMeter/getAllRouteStoneGuardReviewPeerMeters';
 import { getReviewedJudgeThresholds } from './reviewPeerMeter/getReviewedJudgeThresholds';
@@ -33,6 +33,13 @@ import { isReviewPeerLevelUnlocked } from './reviewPeerMeter/isReviewPeerLevelUn
 import { setRouteStoneGuardReviewPeerMeter } from './reviewPeerMeter/setRouteStoneGuardReviewPeerMeter';
 
 const execAsync = promisify(exec);
+
+/**
+ * .what = path to the reviewer-output contract brief
+ * .why = named once so the malfunction reason and its comment cannot drift if the brief moves
+ */
+const REVIEWER_OUTPUT_CONTRACT_BRIEF =
+  '.agent/repo=bhrain/role=reviewer/briefs/contract.reviewer-output.md';
 
 /**
  * .what = extracts slug from peer review
@@ -113,20 +120,8 @@ export const runOneStoneGuardReview = async (input: {
   // .why = guard runs spam git with one artifact per reviewer/iteration/hash
   await findsertReviewPeerGitignore({ route: input.route });
 
-  // lookup repo root for $rhx/$rhachet paths
-  // .note = falls back to cwd when not in a git repo (e.g., integration tests)
-  let repoRoot: string;
-  try {
-    repoRoot = await getGitRepoRoot({ from: input.route });
-  } catch (error) {
-    // only catch "not in git repo" error; rethrow any other errors
-    // .note = check error message instead of instanceof due to cross-module class instances
-    const isNotInGitRepoError =
-      error instanceof Error && error.message.includes('Not inside a Git');
-    if (!isNotInGitRepoError) throw error;
-
-    repoRoot = process.cwd();
-  }
+  // lookup repo root for $rhx/$rhachet paths (cwd fallback when not in a git repo)
+  const repoRoot = await getRepoRootWithFallback({ from: input.route });
 
   // validate no npx patterns before variable substitution
   validateNoNpx(input.reviewCmd);
@@ -171,6 +166,10 @@ export const runOneStoneGuardReview = async (input: {
   // compute timeout in milliseconds
   const timeoutMs = getReviewTimeoutMs(input.timeout);
 
+  // .note = deliberate mutation. stdout/stderr/exitCode accumulate across the exec
+  //         try/catch (success vs error branch) and the later malfunction promotion.
+  //         an imperative accumulator is the clearest shape for capture-output-on-both-paths;
+  //         see rule.require.immutable-vars (annotated-mutation exception).
   let stdout = '';
   let stderr = '';
   let exitCode = 0;
@@ -208,7 +207,27 @@ export const runOneStoneGuardReview = async (input: {
     }
   }
 
-  // classify exit code
+  // parse blockers and nitpicks from stdout via shared operation
+  // .note = parsed before artifact build so an undetectable count can promote to malfunction
+  const counts = getReviewCountsFromContent({ content: stdout });
+  const { blockers, nitpicks } = counts;
+
+  // promote a "successful" review to malfunction when its counts are undetectable
+  // .why = a reviewer that exits 0 but declares no numeric blocker/nitpick count cannot be
+  //        trusted as "approved" — the guard cannot see its verdict. a silent 0/0 would look
+  //        like a clean review when in truth no review was read. failfast as a malfunction so
+  //        the guard blocks this reviewer instead. see rule.forbid.failhide.
+  //        contract: REVIEWER_OUTPUT_CONTRACT_BRIEF
+  if (exitCode === 0 && !counts.detected) {
+    exitCode = 1;
+    const reason =
+      '💥 malfunction: reviewer output lacks a numeric blocker/nitpick count ' +
+      '(expected `N blockers` and `N nitpicks`; use `0 blockers` / `0 nitpicks` to declare clean). ' +
+      `see ${REVIEWER_OUTPUT_CONTRACT_BRIEF}`;
+    stderr = [stderr, reason].filter((line) => line !== '').join('\n');
+  }
+
+  // classify exit code (after possible malfunction promotion)
   const exitClass = getExitCodeClass({ code: exitCode });
 
   // format artifact content with tree buckets
@@ -233,14 +252,8 @@ export const runOneStoneGuardReview = async (input: {
   // write stdout artifact file
   await fs.writeFile(stdoutPath, artifactContent);
 
-  // parse blockers and nitpicks from stdout via shared operation
-  const counts = getReviewCountsFromContent({ content: stdout });
-  const { blockers, nitpicks } = counts;
-
-  // parse duration from stdout
-  // format: "└─ total: 51455ms" under metrics.realized > time
-  const durationMatch = stdout.match(/total:\s*(\d+)ms/i);
-  const durationMs = durationMatch?.[1] ? parseInt(durationMatch[1], 10) : null;
+  // parse duration from stdout via shared operation
+  const durationMs = getDurationMsFromContent({ content: stdout });
 
   return new RouteStoneGuardReviewArtifact({
     stone: { path: input.stone.path },
@@ -277,18 +290,7 @@ export const runStoneGuardReviews = async (
 }> => {
   // lookup git root for path relativization
   // .why = paths in output should be relative to git root (e.g., .behavior/v.../...), not route
-  let gitRoot: string;
-  try {
-    gitRoot = await getGitRepoRoot({ from: input.route });
-  } catch (error) {
-    // only catch "not in git repo" error; rethrow any other errors
-    // .note = check error name instead of instanceof due to cross-module class instances
-    const isNotInGitRepoError =
-      error instanceof Error && error.message.includes('Not inside a Git');
-    if (!isNotInGitRepoError) throw error;
-
-    gitRoot = process.cwd();
-  }
+  const gitRoot = await getRepoRootWithFallback({ from: input.route });
 
   // get prior artifacts for this hash to determine which reviews already done
   // reviews are cached by hash: same artifact content = reuse prior review
@@ -693,19 +695,4 @@ const substituteVars = (
     .replace(/\$output/g, vars.output)
     .replace(/\$rhx/g, rhxPath)
     .replace(/\$rhachet/g, rhachetPath);
-};
-
-/**
- * .what = checks if file is present at path
- * .why = enables detection of files written by external commands
- */
-const isFilePresent = async (filePath: string): Promise<boolean> => {
-  try {
-    await fs.access(filePath);
-    return true;
-  } catch (error) {
-    // only catch ENOENT (file not found); rethrow other errors
-    if (isENOENT(error)) return false;
-    throw error;
-  }
 };

--- a/src/domain.roles/reviewer/boot.yml
+++ b/src/domain.roles/reviewer/boot.yml
@@ -1,6 +1,7 @@
 always:
   briefs:
     say:
+      - briefs/contract.reviewer-output.md
       - briefs/review.tactics.md
       - briefs/on.rules/rules101.[article].md
       - briefs/on.rules/rules101.structure.[article].md

--- a/src/domain.roles/reviewer/briefs/contract.reviewer-output.md
+++ b/src/domain.roles/reviewer/briefs/contract.reviewer-output.md
@@ -1,0 +1,76 @@
+# contract.reviewer-output
+
+## .what
+
+the exact stdout contract every reviewer MUST satisfy so the route guard can read its verdict.
+
+when a reviewer runs under a route guard (peer review), the guard parses the reviewer's
+**stdout** to learn how many blockers and nitpicks it found. this brief states precisely what
+that stdout must contain.
+
+## .why
+
+the guard cannot pass a stone on a review it cannot read. if the guard finds no numeric count,
+it can NOT assume zero — a silent "0 blockers, 0 nitpicks" would look like a clean approval when
+in truth no verdict was seen. so an unreadable review is treated as a **`💥 malfunction`** for
+that reviewer, and the stone blocks. see `rule.forbid.failhide`.
+
+## .the contract
+
+your stdout MUST contain a **numeric** count for **both** dimensions:
+
+- blockers: `N blockers` — or `blockers: N` — where `N` is an integer `>= 0`
+- nitpicks: `N nitpicks` — or `nitpicks: N` — where `N` is an integer `>= 0`
+
+to declare a clean review, state the zeros explicitly:
+
+```
+0 blockers
+0 nitpicks
+```
+
+## .numbers only
+
+only a **number** counts. these do NOT satisfy the contract and cause a `💥 malfunction`:
+
+| stdout | why it fails |
+|--------|--------------|
+| `blockers = none` | word-form, not a number |
+| `no blockers found` | prose, not a numeric count |
+| `blockers: n/a` | not a number |
+| (blockers omitted entirely) | absent — the guard cannot infer zero |
+| `looks solid, ship it` | no counts at all |
+
+one form to emit, one form to parse. numbers are unambiguous; words invite drift and
+incidental-match traps (e.g. "no major blockers here" must never read as a count).
+
+## .the canonical form
+
+the built-in `rhx review` skill already conforms — it emits a summary tree via
+`genReviewOutputStdout`:
+
+```
+   └─ summary
+      ├─ 0 blockers ✓
+      ├─ 2 nitpicks 🟠
+      └─ ...
+```
+
+if you author your own reviewer, the **minimal** valid stdout is just the two numeric lines:
+
+```
+3 blockers
+1 nitpick
+```
+
+## .what the guard does with it
+
+| your stdout | guard reads | outcome |
+|-------------|-------------|---------|
+| `0 blockers` + `0 nitpicks` | detected, clean | approved |
+| `3 blockers` + `1 nitpick` | detected, issues | rejected (blocks per thresholds) |
+| only one dimension, or none | undetected | `💥 malfunction` (blocks) |
+
+## .enforcement
+
+reviewer stdout without a numeric count for both dimensions = `💥 malfunction` = **blocker**.


### PR DESCRIPTION
fix(route): failfast on unparseable reviewer output; add reviewer-output contract

- guard promotes exit 0 + undetected counts to per-reviewer malfunction (exit 1)
  so an unreadable review can never read as a silent 0/0 approval
- getReviewCountsFromContent: numbers-only, both dimensions required; takes the
  LAST count per dimension so incidental prose cannot deceive the parser
- add contract.reviewer-output.md brief + list it in reviewer boot.yml so
  enrolled reviewers conform to the numeric-count contract
- extract getDurationMsFromContent + getRepoRootWithFallback transformers;
  dedupe duration regex across 3 call sites
- tests: unit 11/11, guard integration green; resnap malfunction output

---
🐢🌊 surfed in by seaturtle[bot]