### PR TITLE
fix(ci): pin npm@11 in publish workflow to keep node 22.21 compat

### DIFF
--- a/.github/workflows/.publish-npm.yml
+++ b/.github/workflows/.publish-npm.yml
@@ -49,7 +49,7 @@ jobs:
           MIN_VERSION="11.5.1"
           if [ "$(printf '%s\n' "$MIN_VERSION" "$NPM_VERSION" | sort -V | head -n1)" != "$MIN_VERSION" ]; then
             echo "npm $NPM_VERSION < $MIN_VERSION, will upgrade npm now to support oidc..."
-            npm install -g npm@latest
+            npm install -g npm@11
           else
             echo "npm $NPM_VERSION >= $MIN_VERSION, ready to use!"
           fi


### PR DESCRIPTION
fix(ci): pin npm@11 in publish workflow to keep node 22.21 compat

- npm@latest rolled to 12.0.1, which requires node >=22.22.2, but .nvmrc
  pins 22.21.0, so the oidc npm upgrade failed EBADENGINE and blocked publish
- npm@11 supports oidc (>=11.5.1) and stays compatible with node 22.21.0

---
🐢🌊 surfed in by seaturtle[bot]